### PR TITLE
OnTransitioned must be called before OnEntry

### DIFF
--- a/Stateless/StateMachine.cs
+++ b/Stateless/StateMachine.cs
@@ -189,11 +189,13 @@ namespace Stateless
                 var transition = new Transition(source, destination, trigger);
 
                 CurrentRepresentation.Exit(transition);
+
                 State = transition.Destination;
-                CurrentRepresentation.Enter(transition, args);
                 var onTransitioned = _onTransitioned;
                 if (onTransitioned != null)
                     onTransitioned(transition);
+                
+                CurrentRepresentation.Enter(transition, args);
             }
         }
 


### PR DESCRIPTION
This is a behavior fix for the ordering of events that are fired by the StateMachine during a state transition.

Description: In the previous version, if the action/lambda that is called as part of the OnEntry event results in a state transition (recursively), the state transitions events fired using the OnTransitioned method are captured in the reverse (wrong) order. The fix for this is to raise the OnTransitioned event as soon as the state transition occurs (before the OnEntry event).

Added unit test to verify new behavior.
