### PR TITLE
Make it safer not to configure a running statemachine by separating the configuration/operation into two interfaces

### DIFF
--- a/BugTrackerExample/Bug.cs
+++ b/BugTrackerExample/Bug.cs
@@ -12,7 +12,7 @@ namespace BugTrackerExample
         enum Trigger { Assign, Defer, Resolve, Close }
 
         State _state = State.Open;
-        StateMachine<State, Trigger> _machine;
+        IConfiguredStatemachine<State, Trigger> _machine;
         StateMachine<State, Trigger>.TriggerWithParameters<string> _assignTrigger;
 
         string _title;
@@ -22,7 +22,7 @@ namespace BugTrackerExample
         {
             _title = title;
 
-            _machine = new StateMachine<State, Trigger>(() => _state, s => _state = s);
+            var _machine = StateMachine<State, Trigger>.Create(() => _state, s => _state = s);
 
             _assignTrigger = _machine.SetTriggerParameters<string>(Trigger.Assign);
 
@@ -40,6 +40,8 @@ namespace BugTrackerExample
             _machine.Configure(State.Deferred)
                 .OnEntry(() => _assignee = null)
                 .Permit(Trigger.Assign, State.Assigned);
+
+            this._machine = _machine.FinishConfiguration();
         }
 
         public void Close()

--- a/OnOffExample/Program.cs
+++ b/OnOffExample/Program.cs
@@ -15,18 +15,20 @@ namespace OnOffExample
                 string on = "On", off = "Off";
                 var space = ' ';
 
-                var onOffSwitch = new StateMachine<string, char>(off);
+                var onOffSwitch = StateMachine<string, char>.Create(off);
 
                 onOffSwitch.Configure(off).Permit(space, on);
                 onOffSwitch.Configure(on).Permit(space, off);
+
+                var conOffSwitch = onOffSwitch.FinishConfiguration();
 
                 Console.WriteLine("Press <space> to toggle the switch. Any other key will raise an error.");
 
                 while (true)
                 {
-                    Console.WriteLine("Switch is in state: " + onOffSwitch.State);
+                    Console.WriteLine("Switch is in state: " + conOffSwitch.State);
                     var pressed = Console.ReadKey(true).KeyChar;
-                    onOffSwitch.Fire(pressed);
+                    conOffSwitch.Fire(pressed);
                 }
             }
             catch (Exception ex)

--- a/Stateless.Tests/DynamicTriggerBehaviourFixture.cs
+++ b/Stateless.Tests/DynamicTriggerBehaviourFixture.cs
@@ -12,26 +12,30 @@ namespace Stateless.Tests
         [Test]
         public void DestinationStateIsDynamic()
         {
-            var sm = new StateMachine<State, Trigger>(State.A);
+            var sm = StateMachine<State, Trigger>.Create(State.A);
             sm.Configure(State.A)
                 .PermitDynamic(Trigger.X, () => State.B);
 
-            sm.Fire(Trigger.X);
+            var csm = sm.FinishConfiguration();
 
-            Assert.AreEqual(State.B, sm.State);
+            csm.Fire(Trigger.X);
+
+            Assert.AreEqual(State.B, csm.State);
         }
 
         [Test]
         public void DestinationStateIsCalculatedBasedOnTriggerParameters()
         {
-            var sm = new StateMachine<State, Trigger>(State.A);
+            var sm = StateMachine<State, Trigger>.Create(State.A);
             var trigger = sm.SetTriggerParameters<int>(Trigger.X);
             sm.Configure(State.A)
                 .PermitDynamic(trigger, i => i == 1 ? State.B : State.C);
 
-            sm.Fire(trigger, 1);
+            var csm = sm.FinishConfiguration();
 
-            Assert.AreEqual(State.B, sm.State);
+            csm.Fire(trigger, 1);
+
+            Assert.AreEqual(State.B, csm.State);
         }
     }
 }

--- a/Stateless/StateMachine.cs
+++ b/Stateless/StateMachine.cs
@@ -4,12 +4,185 @@ using System.Linq;
 
 namespace Stateless
 {
+
+    /// <summary>
+    /// Represents a yet unconfigured/partly configured statemachine
+    /// </summary>
+    /// <typeparam name="TState"></typeparam>
+    /// <typeparam name="TTrigger"></typeparam>
+    public interface IUnconfiguredStatemachine<TState, TTrigger>
+    {
+
+        /// <summary>
+        /// Begin configuration of the entry/exit actions and allowed transitions
+        /// when the state machine is in a particular state.
+        /// </summary>
+        /// <param name="state">The state to configure.</param>
+        /// <returns>A configuration object through which the state can be configured.</returns>
+        StateMachine<TState, TTrigger>.StateConfiguration Configure(TState state);
+
+        /// <summary>
+        /// Specify the arguments that must be supplied when a specific trigger is fired.
+        /// </summary>
+        /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
+        /// <param name="trigger">The underlying trigger value.</param>
+        /// <returns>An object that can be passed to the Fire() method in order to 
+        /// fire the parameterised trigger.</returns>
+        StateMachine<TState, TTrigger>.TriggerWithParameters<TArg0> SetTriggerParameters<TArg0>(TTrigger trigger);
+
+
+        /// <summary>
+        /// finished configuration and returns a configured statemachine
+        /// </summary>
+        /// <returns></returns>
+        IConfiguredStatemachine<TState, TTrigger> FinishConfiguration();
+
+        /// <summary>
+        /// Specify the arguments that must be supplied when a specific trigger is fired.
+        /// </summary>
+        /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
+        /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
+        /// <param name="trigger">The underlying trigger value.</param>
+        /// <returns>An object that can be passed to the Fire() method in order to 
+        /// fire the parameterised trigger.</returns>
+        StateMachine<TState, TTrigger>.TriggerWithParameters<TArg0, TArg1> SetTriggerParameters<TArg0, TArg1>(
+            TTrigger trigger);
+
+        /// <summary>
+        /// Specify the arguments that must be supplied when a specific trigger is fired.
+        /// </summary>
+        /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
+        /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
+        /// <typeparam name="TArg2">Type of the third trigger argument.</typeparam>
+        /// <param name="trigger">The underlying trigger value.</param>
+        /// <returns>An object that can be passed to the Fire() method in order to 
+        /// fire the parameterised trigger.</returns>
+        StateMachine<TState, TTrigger>.TriggerWithParameters<TArg0, TArg1, TArg2> SetTriggerParameters
+            <TArg0, TArg1, TArg2>(TTrigger trigger);
+
+
+
+        /// <summary>
+        /// Registers a callback that will be invoked every time the statemachine
+        /// transitions from one state into another.
+        /// </summary>
+        /// <param name="onTransitionAction">The action to execute, accepting the details
+        /// of the transition.</param>
+        void OnTransitioned(Action<StateMachine<TState, TTrigger>.Transition> onTransitionAction);
+
+
+        /// <summary>
+        /// Override the default behaviour of throwing an exception when an unhandled trigger
+        /// is fired.
+        /// </summary>
+        /// <param name="unhandledTriggerAction">An action to call when an unhandled trigger is fired.</param>
+        void OnUnhandledTrigger(Action<TState, TTrigger> unhandledTriggerAction);
+
+    }
+
+    /// <summary>
+    /// represents a configures statemachine
+    /// </summary>
+    /// <typeparam name="TState"></typeparam>
+    /// <typeparam name="TTrigger"></typeparam>
+    public interface IConfiguredStatemachine<TState, TTrigger>
+    {
+        /// <summary>
+        /// Transition from the current state via the specified trigger.
+        /// The target state is determined by the configuration of the current state.
+        /// Actions associated with leaving the current state and entering the new one
+        /// will be invoked.
+        /// </summary>
+        /// <param name="trigger">The trigger to fire.</param>
+        /// <exception cref="System.InvalidOperationException">The current state does
+        /// not allow the trigger to be fired.</exception>
+        void Fire(TTrigger trigger);
+
+        /// <summary>
+        /// Transition from the current state via the specified trigger.
+        /// The target state is determined by the configuration of the current state.
+        /// Actions associated with leaving the current state and entering the new one
+        /// will be invoked.
+        /// </summary>
+        /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
+        /// <param name="trigger">The trigger to fire.</param>
+        /// <param name="arg0">The first argument.</param>
+        /// <exception cref="System.InvalidOperationException">The current state does
+        /// not allow the trigger to be fired.</exception>
+        void Fire<TArg0>(StateMachine<TState,TTrigger>.TriggerWithParameters<TArg0> trigger, TArg0 arg0);
+
+
+        /// <summary>
+        /// Transition from the current state via the specified trigger.
+        /// The target state is determined by the configuration of the current state.
+        /// Actions associated with leaving the current state and entering the new one
+        /// will be invoked.
+        /// </summary>
+        /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
+        /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
+        /// <param name="arg0">The first argument.</param>
+        /// <param name="arg1">The second argument.</param>
+        /// <param name="trigger">The trigger to fire.</param>
+        /// <exception cref="System.InvalidOperationException">The current state does
+        /// not allow the trigger to be fired.</exception>
+        void Fire<TArg0, TArg1>(StateMachine<TState, TTrigger>.TriggerWithParameters<TArg0, TArg1> trigger, TArg0 arg0, TArg1 arg1);
+
+        /// <summary>
+        /// Transition from the current state via the specified trigger.
+        /// The target state is determined by the configuration of the current state.
+        /// Actions associated with leaving the current state and entering the new one
+        /// will be invoked.
+        /// </summary>
+        /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
+        /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
+        /// <typeparam name="TArg2">Type of the third trigger argument.</typeparam>
+        /// <param name="arg0">The first argument.</param>
+        /// <param name="arg1">The second argument.</param>
+        /// <param name="arg2">The third argument.</param>
+        /// <param name="trigger">The trigger to fire.</param>
+        /// <exception cref="System.InvalidOperationException">The current state does
+        /// not allow the trigger to be fired.</exception>
+        void Fire<TArg0, TArg1, TArg2>(StateMachine<TState, TTrigger>.TriggerWithParameters<TArg0, TArg1, TArg2> trigger, TArg0 arg0, TArg1 arg1,
+            TArg2 arg2);
+
+
+        /// <summary>
+        /// The current state.
+        /// </summary>
+        TState State { get; }
+
+        /// <summary>
+        /// Determine if the state machine is in the supplied state.
+        /// </summary>
+        /// <param name="state">The state to test for.</param>
+        /// <returns>True if the current state is equal to, or a substate of,
+        /// the supplied state.</returns>
+        bool IsInState(TState state);
+
+        /// <summary>
+        /// Returns true if <paramref name="trigger"/> can be fired
+        /// in the current state.
+        /// </summary>
+        /// <param name="trigger">Trigger to test.</param>
+        /// <returns>True if the trigger can be fired, false otherwise.</returns>
+        bool CanFire(TTrigger trigger);
+
+
+
+        /// <summary>
+        /// The currently-permissible trigger values.
+        /// </summary>
+        IEnumerable<TTrigger> PermittedTriggers { get; }
+        
+    }
+
+
     /// <summary>
     /// Models behaviour as transitions between a finite set of states.
     /// </summary>
     /// <typeparam name="TState">The type used to represent the states.</typeparam>
     /// <typeparam name="TTrigger">The type used to represent the triggers that cause state transitions.</typeparam>
-    public partial class StateMachine<TState, TTrigger>
+    public partial class StateMachine<TState, TTrigger> : IUnconfiguredStatemachine<TState, TTrigger>, IConfiguredStatemachine<TState, TTrigger>
     {
         readonly IDictionary<TState, StateRepresentation> _stateConfiguration = new Dictionary<TState, StateRepresentation>();
         readonly IDictionary<TTrigger, TriggerWithParameters> _triggerConfiguration = new Dictionary<TTrigger, TriggerWithParameters>();
@@ -23,7 +196,7 @@ namespace Stateless
         /// </summary>
         /// <param name="stateAccessor">A function that will be called to read the current state value.</param>
         /// <param name="stateMutator">An action that will be called to write new state values.</param>
-        public StateMachine(Func<TState> stateAccessor, Action<TState> stateMutator)
+        private StateMachine(Func<TState> stateAccessor, Action<TState> stateMutator)
         {
             _stateAccessor = Enforce.ArgumentNotNull(stateAccessor, "stateAccessor");
             _stateMutator = Enforce.ArgumentNotNull(stateMutator, "stateMutator");
@@ -33,7 +206,7 @@ namespace Stateless
         /// Construct a state machine.
         /// </summary>
         /// <param name="initialState">The initial state.</param>
-        public StateMachine(TState initialState)
+        private StateMachine(TState initialState)
         {
             var reference = new StateReference { State = initialState };
             _stateAccessor = () => reference.State;
@@ -41,24 +214,57 @@ namespace Stateless
         }
 
         /// <summary>
+        /// Construct a state machine.
+        /// </summary>
+        /// <param name="initialState">The initial state.</param>
+        public static IUnconfiguredStatemachine<TState, TTrigger> Create(TState initialState)
+        {
+            return new StateMachine<TState, TTrigger>(initialState);            
+        }
+
+        /// <summary>
+        /// Construct a state machine with external state storage.
+        /// </summary>
+        /// <param name="stateAccessor">A function that will be called to read the current state value.</param>
+        /// <param name="stateMutator">An action that will be called to write new state values.</param>
+        public static IUnconfiguredStatemachine<TState, TTrigger> Create(Func<TState> stateAccessor, Action<TState> stateMutator)
+        {
+            return new StateMachine<TState, TTrigger>(stateAccessor, stateMutator);
+        }
+
+        /// <summary>
         /// The current state.
         /// </summary>
-        public TState State
+        private TState State
         {
             get
             {
                 return _stateAccessor();
             }
-            private set
+            set
             {
                 _stateMutator(value);
             }
         }
 
         /// <summary>
+        /// The current state.
+        /// </summary>
+        TState IConfiguredStatemachine<TState, TTrigger>.State
+        {
+            get { return this.State; }
+        }
+
+        /// <summary>
         /// The currently-permissible trigger values.
         /// </summary>
-        public IEnumerable<TTrigger> PermittedTriggers
+        IEnumerable<TTrigger> IConfiguredStatemachine<TState, TTrigger>.PermittedTriggers
+        {
+            get { return this.PermittedTriggers; }
+        }
+        
+        private IEnumerable<TTrigger> PermittedTriggers
+        
         {
             get
             {
@@ -93,7 +299,7 @@ namespace Stateless
         /// </summary>
         /// <param name="state">The state to configure.</param>
         /// <returns>A configuration object through which the state can be configured.</returns>
-        public StateConfiguration Configure(TState state)
+        StateConfiguration IUnconfiguredStatemachine<TState, TTrigger>.Configure(TState state)
         {
             return new StateConfiguration(GetRepresentation(state), GetRepresentation);
         }
@@ -107,7 +313,7 @@ namespace Stateless
         /// <param name="trigger">The trigger to fire.</param>
         /// <exception cref="System.InvalidOperationException">The current state does
         /// not allow the trigger to be fired.</exception>
-        public void Fire(TTrigger trigger)
+        void IConfiguredStatemachine<TState, TTrigger>.Fire(TTrigger trigger)
         {
             InternalFire(trigger, new object[0]);
         }
@@ -123,7 +329,7 @@ namespace Stateless
         /// <param name="arg0">The first argument.</param>
         /// <exception cref="System.InvalidOperationException">The current state does
         /// not allow the trigger to be fired.</exception>
-        public void Fire<TArg0>(TriggerWithParameters<TArg0> trigger, TArg0 arg0)
+        void IConfiguredStatemachine<TState, TTrigger>.Fire<TArg0>(TriggerWithParameters<TArg0> trigger, TArg0 arg0)
         {
             Enforce.ArgumentNotNull(trigger, "trigger");
             InternalFire(trigger.Trigger, arg0);
@@ -142,7 +348,7 @@ namespace Stateless
         /// <param name="trigger">The trigger to fire.</param>
         /// <exception cref="System.InvalidOperationException">The current state does
         /// not allow the trigger to be fired.</exception>
-        public void Fire<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, TArg0 arg0, TArg1 arg1)
+        void IConfiguredStatemachine<TState, TTrigger>.Fire<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, TArg0 arg0, TArg1 arg1)
         {
             Enforce.ArgumentNotNull(trigger, "trigger");
             InternalFire(trigger.Trigger, arg0, arg1);
@@ -163,7 +369,7 @@ namespace Stateless
         /// <param name="trigger">The trigger to fire.</param>
         /// <exception cref="System.InvalidOperationException">The current state does
         /// not allow the trigger to be fired.</exception>
-        public void Fire<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, TArg0 arg0, TArg1 arg1, TArg2 arg2)
+        void IConfiguredStatemachine<TState, TTrigger>.Fire<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, TArg0 arg0, TArg1 arg1, TArg2 arg2)
         {
             Enforce.ArgumentNotNull(trigger, "trigger");
             InternalFire(trigger.Trigger, arg0, arg1, arg2);
@@ -204,7 +410,7 @@ namespace Stateless
         /// is fired.
         /// </summary>
         /// <param name="unhandledTriggerAction">An action to call when an unhandled trigger is fired.</param>
-        public void OnUnhandledTrigger(Action<TState, TTrigger> unhandledTriggerAction)
+        void IUnconfiguredStatemachine<TState, TTrigger>.OnUnhandledTrigger(Action<TState, TTrigger> unhandledTriggerAction)
         {
             if (unhandledTriggerAction == null) throw new ArgumentNullException("unhandledTriggerAction");
             _unhandledTriggerAction = unhandledTriggerAction;
@@ -216,7 +422,7 @@ namespace Stateless
         /// <param name="state">The state to test for.</param>
         /// <returns>True if the current state is equal to, or a substate of,
         /// the supplied state.</returns>
-        public bool IsInState(TState state)
+        bool IConfiguredStatemachine<TState, TTrigger>.IsInState(TState state)
         {
             return CurrentRepresentation.IsIncludedIn(state);
         }
@@ -227,9 +433,18 @@ namespace Stateless
         /// </summary>
         /// <param name="trigger">Trigger to test.</param>
         /// <returns>True if the trigger can be fired, false otherwise.</returns>
-        public bool CanFire(TTrigger trigger)
+        bool IConfiguredStatemachine<TState, TTrigger>.CanFire(TTrigger trigger)
         {
             return CurrentRepresentation.CanHandle(trigger);
+        }
+
+        /// <summary>
+        /// finished configuration and returns a configured statemachine
+        /// </summary>
+        /// <returns></returns>
+        IConfiguredStatemachine<TState, TTrigger> IUnconfiguredStatemachine<TState, TTrigger>.FinishConfiguration()
+        {
+            return this;
         }
 
         /// <summary>
@@ -251,7 +466,7 @@ namespace Stateless
         /// <param name="trigger">The underlying trigger value.</param>
         /// <returns>An object that can be passed to the Fire() method in order to 
         /// fire the parameterised trigger.</returns>
-        public TriggerWithParameters<TArg0> SetTriggerParameters<TArg0>(TTrigger trigger)
+        TriggerWithParameters<TArg0> IUnconfiguredStatemachine<TState, TTrigger>.SetTriggerParameters<TArg0>(TTrigger trigger)
         {
             var configuration = new TriggerWithParameters<TArg0>(trigger);
             SaveTriggerConfiguration(configuration);
@@ -266,7 +481,7 @@ namespace Stateless
         /// <param name="trigger">The underlying trigger value.</param>
         /// <returns>An object that can be passed to the Fire() method in order to 
         /// fire the parameterised trigger.</returns>
-        public TriggerWithParameters<TArg0, TArg1> SetTriggerParameters<TArg0, TArg1>(TTrigger trigger)
+        TriggerWithParameters<TArg0, TArg1> IUnconfiguredStatemachine<TState, TTrigger>.SetTriggerParameters<TArg0, TArg1>(TTrigger trigger)
         {
             var configuration = new TriggerWithParameters<TArg0, TArg1>(trigger);
             SaveTriggerConfiguration(configuration);
@@ -282,7 +497,7 @@ namespace Stateless
         /// <param name="trigger">The underlying trigger value.</param>
         /// <returns>An object that can be passed to the Fire() method in order to 
         /// fire the parameterised trigger.</returns>
-        public TriggerWithParameters<TArg0, TArg1, TArg2> SetTriggerParameters<TArg0, TArg1, TArg2>(TTrigger trigger)
+        TriggerWithParameters<TArg0, TArg1, TArg2> IUnconfiguredStatemachine<TState, TTrigger>.SetTriggerParameters<TArg0, TArg1, TArg2>(TTrigger trigger)
         {
             var configuration = new TriggerWithParameters<TArg0, TArg1, TArg2>(trigger);
             SaveTriggerConfiguration(configuration);
@@ -312,7 +527,7 @@ namespace Stateless
         /// </summary>
         /// <param name="onTransitionAction">The action to execute, accepting the details
         /// of the transition.</param>
-        public void OnTransitioned(Action<Transition> onTransitionAction)
+        void IUnconfiguredStatemachine<TState, TTrigger>.OnTransitioned(Action<Transition> onTransitionAction)
         {
             if (onTransitionAction == null) throw new ArgumentNullException("onTransitionAction");
             _onTransitioned += onTransitionAction;

--- a/TelephoneCallExample/Program.cs
+++ b/TelephoneCallExample/Program.cs
@@ -30,7 +30,7 @@ namespace TelephoneCallExample
 
         static void Main(string[] args)
         {
-            var phoneCall = new StateMachine<State, Trigger>(State.OffHook);
+            var phoneCall = StateMachine<State, Trigger>.Create(State.OffHook);
 
             phoneCall.Configure(State.OffHook)
 	            .Permit(Trigger.CallDialed, State.Ringing);
@@ -52,17 +52,19 @@ namespace TelephoneCallExample
                 .Permit(Trigger.HungUp, State.OffHook)
                 .Permit(Trigger.PhoneHurledAgainstWall, State.PhoneDestroyed);
 
-            Print(phoneCall);
-            Fire(phoneCall, Trigger.CallDialed);
-            Print(phoneCall);
-            Fire(phoneCall, Trigger.CallConnected);
-            Print(phoneCall);
-            Fire(phoneCall, Trigger.PlacedOnHold);
-            Print(phoneCall);
-            Fire(phoneCall, Trigger.TakenOffHold);
-            Print(phoneCall);
-            Fire(phoneCall, Trigger.HungUp);
-            Print(phoneCall);
+            var cphoneCall = phoneCall.FinishConfiguration();
+
+            Print(cphoneCall);
+            Fire(cphoneCall, Trigger.CallDialed);
+            Print(cphoneCall);
+            Fire(cphoneCall, Trigger.CallConnected);
+            Print(cphoneCall);
+            Fire(cphoneCall, Trigger.PlacedOnHold);
+            Print(cphoneCall);
+            Fire(cphoneCall, Trigger.TakenOffHold);
+            Print(cphoneCall);
+            Fire(cphoneCall, Trigger.HungUp);
+            Print(cphoneCall);
 
             Console.WriteLine("Press any key...");
             Console.ReadKey(true);
@@ -78,13 +80,13 @@ namespace TelephoneCallExample
             Console.WriteLine("[Timer:] Call ended at {0}", DateTime.Now);
         }
 
-        static void Fire(StateMachine<State, Trigger> phoneCall, Trigger trigger)
+        static void Fire(IConfiguredStatemachine<State, Trigger> phoneCall, Trigger trigger)
         {
             Console.WriteLine("[Firing:] {0}", trigger);
             phoneCall.Fire(trigger);
         }
 
-        static void Print(StateMachine<State, Trigger> phoneCall)
+        static void Print(IConfiguredStatemachine<State, Trigger> phoneCall)
         {
             Console.WriteLine("[Status:] {0}", phoneCall);
         }


### PR DESCRIPTION
- added two interfaces to the statemachine:
  - one for a not yet fully configured statemachine which only allows configuration stuff
  - one for a fully configurated statemachine which disallows configuration but allows operation stuff
- adjusted tests to work with the new interfaces
