### PR TITLE
#45 tried to improve adding of extension method

### DIFF
--- a/Stateless/StateConfiguration.cs
+++ b/Stateless/StateConfiguration.cs
@@ -12,15 +12,27 @@ namespace Stateless
         /// </summary>
         public class StateConfiguration
         {
+            private readonly StateMachine<TState, TTrigger> _machine;
             readonly StateRepresentation _representation;
             readonly Func<TState, StateRepresentation> _lookup;
             static readonly Func<bool> NoGuard = () => true;
 
-            internal StateConfiguration(StateRepresentation representation, Func<TState, StateRepresentation> lookup)
+            internal StateConfiguration(StateMachine<TState, TTrigger> machine, StateRepresentation representation, Func<TState, StateRepresentation> lookup)
             {
+                _machine = Enforce.ArgumentNotNull(machine, nameof(machine));
                 _representation = Enforce.ArgumentNotNull(representation, nameof(representation));
                 _lookup = Enforce.ArgumentNotNull(lookup, nameof(lookup));
             }
+
+            /// <summary>
+            /// The state that is configured with this configuration.
+            /// </summary>
+            public TState State { get { return _representation.UnderlyingState; } }
+
+            /// <summary>
+            /// The machine that is configured with this configuration.
+            /// </summary>
+            public StateMachine<TState, TTrigger> Machine { get { return _machine; } }
 
             /// <summary>
             /// Accept the specified trigger and transition to the destination state.

--- a/Stateless/StateMachine.cs
+++ b/Stateless/StateMachine.cs
@@ -95,7 +95,7 @@ namespace Stateless
         /// <returns>A configuration object through which the state can be configured.</returns>
         public StateConfiguration Configure(TState state)
         {
-            return new StateConfiguration(GetRepresentation(state), GetRepresentation);
+            return new StateConfiguration(this, GetRepresentation(state), GetRepresentation);
         }
 
         /// <summary>


### PR DESCRIPTION
Now the currently configured state machine and the configured state are
accessible through properties. This way you can use them within
extension methods without additional temporary variables and method
parameters. See issue #45.