### PR TITLE
Optimizing InternalFire by reducing calls to the state accessor.

### DIFF
--- a/Stateless/StateMachine.cs
+++ b/Stateless/StateMachine.cs
@@ -175,27 +175,29 @@ namespace Stateless
             if (_triggerConfiguration.TryGetValue(trigger, out configuration))
                 configuration.ValidateParameters(args);
 
+            var source = State;
+            var representativeState = GetRepresentation(source);
+
             TriggerBehaviour triggerBehaviour;
-            if (!CurrentRepresentation.TryFindHandler(trigger, out triggerBehaviour))
+            if (!representativeState.TryFindHandler(trigger, out triggerBehaviour))
             {
-                _unhandledTriggerAction(CurrentRepresentation.UnderlyingState, trigger);
+                _unhandledTriggerAction(representativeState.UnderlyingState, trigger);
                 return;
             }
 
-            var source = State;
+
             TState destination;
             if (triggerBehaviour.ResultsInTransitionFrom(source, args, out destination))
             {
                 var transition = new Transition(source, destination, trigger);
 
-                CurrentRepresentation.Exit(transition);
+                representativeState.Exit(transition);
 
                 State = transition.Destination;
                 var onTransitioned = _onTransitioned;
-                if (onTransitioned != null)
-                    onTransitioned(transition);
-                
-                CurrentRepresentation.Enter(transition, args);
+                onTransitioned?.Invoke(transition);
+
+                representativeState.Enter(transition, args);
             }
         }
 

--- a/Stateless/StateMachine.cs
+++ b/Stateless/StateMachine.cs
@@ -168,7 +168,7 @@ namespace Stateless
             Enforce.ArgumentNotNull(trigger, "trigger");
             InternalFire(trigger.Trigger, arg0, arg1, arg2);
         }
-        
+
         void InternalFire(TTrigger trigger, params object[] args)
         {
             TriggerWithParameters configuration;
@@ -195,7 +195,8 @@ namespace Stateless
 
                 State = transition.Destination;
                 var onTransitioned = _onTransitioned;
-                onTransitioned?.Invoke(transition);
+                if (onTransitioned != null)
+                    onTransitioned(transition);
 
                 representativeState.Enter(transition, args);
             }
@@ -251,7 +252,7 @@ namespace Stateless
         /// </summary>
         /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
         /// <param name="trigger">The underlying trigger value.</param>
-        /// <returns>An object that can be passed to the Fire() method in order to 
+        /// <returns>An object that can be passed to the Fire() method in order to
         /// fire the parameterised trigger.</returns>
         public TriggerWithParameters<TArg0> SetTriggerParameters<TArg0>(TTrigger trigger)
         {
@@ -266,7 +267,7 @@ namespace Stateless
         /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
         /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
         /// <param name="trigger">The underlying trigger value.</param>
-        /// <returns>An object that can be passed to the Fire() method in order to 
+        /// <returns>An object that can be passed to the Fire() method in order to
         /// fire the parameterised trigger.</returns>
         public TriggerWithParameters<TArg0, TArg1> SetTriggerParameters<TArg0, TArg1>(TTrigger trigger)
         {
@@ -282,7 +283,7 @@ namespace Stateless
         /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
         /// <typeparam name="TArg2">Type of the third trigger argument.</typeparam>
         /// <param name="trigger">The underlying trigger value.</param>
-        /// <returns>An object that can be passed to the Fire() method in order to 
+        /// <returns>An object that can be passed to the Fire() method in order to
         /// fire the parameterised trigger.</returns>
         public TriggerWithParameters<TArg0, TArg1, TArg2> SetTriggerParameters<TArg0, TArg1, TArg2>(TTrigger trigger)
         {

--- a/Stateless/StateMachine.cs
+++ b/Stateless/StateMachine.cs
@@ -185,7 +185,6 @@ namespace Stateless
                 return;
             }
 
-
             TState destination;
             if (triggerBehaviour.ResultsInTransitionFrom(source, args, out destination))
             {
@@ -194,11 +193,12 @@ namespace Stateless
                 representativeState.Exit(transition);
 
                 State = transition.Destination;
+                var newRepresentation = GetRepresentation(transition.Destination);
                 var onTransitioned = _onTransitioned;
                 if (onTransitioned != null)
                     onTransitioned(transition);
 
-                representativeState.Enter(transition, args);
+                newRepresentation.Enter(transition, args);
             }
         }
 


### PR DESCRIPTION
I found firing a trigger in my system required querying the database 4 times before state could be transitioned and during investigation found non local calls to the State property.

This pull fixes those for that single call.