### PR TITLE
Fix bug where an Ignored trigger shows up as a unknown destination in the dot graph

### DIFF
--- a/Stateless.Tests/DotGraphFixture.cs
+++ b/Stateless.Tests/DotGraphFixture.cs
@@ -211,5 +211,22 @@ namespace Stateless.Tests
 
             Assert.AreEqual(expected, sm.ToDotGraph());
         }
+
+        [Test]
+        public void TransitionWithIgnore()
+        {
+            var expected = "digraph {" + System.Environment.NewLine
+                         + " A -> A [label=\"Y\"];" + System.Environment.NewLine
+                         + " A -> B [label=\"X\"];" + System.Environment.NewLine
+                         + "}";
+
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+                .Ignore(Trigger.Y)
+                .Permit(Trigger.X, State.B);
+
+            Assert.AreEqual(expected, sm.ToDotGraph());
+        }
     }
 }

--- a/Stateless/DotGraph.cs
+++ b/Stateless/DotGraph.cs
@@ -26,7 +26,11 @@ namespace Stateless
                         if (behaviour is TransitioningTriggerBehaviour)
                         {
                             destination = ((TransitioningTriggerBehaviour)behaviour).Destination.ToString ();
-                        } 
+                        }
+                        else if (behaviour is IgnoredTriggerBehaviour)
+                        {
+                            destination = stateCfg.Key.ToString();
+                        }
                         else 
                         {
                             destination = "unknownDestination_" + unknownDestinations.Count;


### PR DESCRIPTION
Instead, show this a a transition back to the current state.