### PR TITLE
Do not include ignored triggers in the dot graph

### DIFF
--- a/Stateless.Tests/DotGraphFixture.cs
+++ b/Stateless.Tests/DotGraphFixture.cs
@@ -215,8 +215,8 @@ namespace Stateless.Tests
         [Test]
         public void TransitionWithIgnore()
         {
+            // Ignored triggers do not appear in the graph
             var expected = "digraph {" + System.Environment.NewLine
-                         + " A -> A [label=\"Y\"];" + System.Environment.NewLine
                          + " A -> B [label=\"X\"];" + System.Environment.NewLine
                          + "}";
 

--- a/Stateless/DotGraph.cs
+++ b/Stateless/DotGraph.cs
@@ -29,7 +29,7 @@ namespace Stateless
                         }
                         else if (behaviour is IgnoredTriggerBehaviour)
                         {
-                            destination = stateCfg.Key.ToString();
+                            continue; 
                         }
                         else 
                         {


### PR DESCRIPTION
 since both ignored and unhandled triggers do not cause state transitions to occur.