### PR TITLE
Async actions support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ Stateless.userprefs
 .vs/
 
 project.lock.json
+artifacts/
+TestResult.xml

--- a/Stateless.Tests/AsyncActionsFixture.cs
+++ b/Stateless.Tests/AsyncActionsFixture.cs
@@ -1,0 +1,179 @@
+﻿#if !NET40
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using NUnit.Framework;
+
+namespace Stateless.Tests
+{
+    [TestFixture]
+    public class AsyncActionsFixture
+    {
+        [Test]
+        public async Task CanFireAsyncEntryAction()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+              .Permit(Trigger.X, State.B);
+
+            var test = "";
+            sm.Configure(State.B)
+              .OnEntryAsync(() => Task.Run(() => test = "foo"));
+
+            await sm.FireAsync(Trigger.X);
+
+            Assert.AreEqual("foo", test, "Should await action");
+            Assert.AreEqual(State.B, sm.State, "Should transition to destination state");
+        }
+
+        [Test]
+        public void WhenSyncFireAsyncEntryAction()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+              .Permit(Trigger.X, State.B);
+
+            sm.Configure(State.B)
+              .OnEntryAsync(() => TaskResult.Done);
+
+            Assert.Throws<InvalidOperationException>(()=> sm.Fire(Trigger.X));
+        }
+
+        [Test]
+        public async Task CanFireAsyncExitAction()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            var test = "";
+            sm.Configure(State.A)
+              .OnExitAsync(() => Task.Run(() => test = "foo"))
+              .Permit(Trigger.X, State.B);
+
+            await sm.FireAsync(Trigger.X);
+
+            Assert.AreEqual("foo", test, "Should await action");
+            Assert.AreEqual(State.B, sm.State, "Should transition to destination state");
+        }
+
+        [Test]
+        public void WhenSyncFireAsyncExitAction()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+              .OnExitAsync(() => TaskResult.Done)
+              .Permit(Trigger.X, State.B);
+
+            Assert.Throws<InvalidOperationException>(() => sm.Fire(Trigger.X));
+        }
+
+        [Test]
+        public async Task CanFireInternalAsyncAction()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            var test = "";
+            sm.Configure(State.A)
+              .InternalTransitionAsync(Trigger.X, ()=> Task.Run(() => test = "foo"));
+
+            await sm.FireAsync(Trigger.X);
+
+            Assert.AreEqual("foo", test, "Should await action");
+        }
+
+        [Test]
+        public void WhenSyncFireInternalAsyncAction()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+              .InternalTransitionAsync(Trigger.X, ()=> TaskResult.Done);
+
+            Assert.Throws<InvalidOperationException>(() => sm.Fire(Trigger.X));
+        }
+
+        [Test]
+        public async Task CanInvokeOnTransitionedAsyncAction()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+              .Permit(Trigger.X, State.B);
+
+            var test = "";
+            sm.OnTransitionedAsync(_ => Task.Run(() => test = "foo"));
+
+            await sm.FireAsync(Trigger.X);
+
+            Assert.AreEqual("foo", test, "Should await action");
+        }
+
+        [Test]
+        public async Task WillInvokeSyncOnTransitionedIfRegisteredAlongWithAsyncAction()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+              .Permit(Trigger.X, State.B);
+
+            var test1 = "";
+            var test2 = "";
+            sm.OnTransitioned(_ => test1 = "foo1");
+            sm.OnTransitionedAsync(_ => Task.Run(() => test2 = "foo2"));
+
+            await sm.FireAsync(Trigger.X);
+
+            Assert.AreEqual("foo1", test1);
+            Assert.AreEqual("foo2", test2);
+        }
+
+        [Test]
+        public void WhenSyncFireAsyncOnTransitionedAction()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+              .Permit(Trigger.X, State.B);
+
+            sm.OnTransitionedAsync(_ => TaskResult.Done);
+
+            Assert.Throws<InvalidOperationException>(() => sm.Fire(Trigger.X));
+        }
+
+        [Test]
+        public async Task CanInvokeOnUnhandledTriggerAsyncAction()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+              .Permit(Trigger.X, State.B);
+
+            var test = "";
+            sm.OnUnhandledTriggerAsync((s, t)=>Task.Run(() => test = "foo"));
+
+            await sm.FireAsync(Trigger.Z);
+
+            Assert.AreEqual("foo", test, "Should await action");
+        }
+
+        [Test]
+        public void WhenSyncFireOnUnhandledTriggerAsyncAction()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+              .Permit(Trigger.X, State.B);
+
+            sm.OnUnhandledTriggerAsync((s,t) => TaskResult.Done);
+
+            Assert.Throws<InvalidOperationException>(() => sm.Fire(Trigger.Z));
+        }
+    }
+}
+
+#endif

--- a/Stateless/ExitActionBehaviour.cs
+++ b/Stateless/ExitActionBehaviour.cs
@@ -2,24 +2,68 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace Stateless
 {
     public partial class StateMachine<TState, TTrigger>
     {
-        internal class ExitActionBehavior
+        internal abstract class ExitActionBehavior
         {
             readonly string _actionDescription;
-            readonly Action<Transition> _action;
 
-            public ExitActionBehavior(Action<Transition> action, string actionDescription)
+            public abstract void Execute(Transition transition);
+            public abstract Task ExecuteAsync(Transition transition);
+
+            protected ExitActionBehavior(string actionDescription)
             {
-                _action = action;
                 _actionDescription = Enforce.ArgumentNotNull(actionDescription, nameof(actionDescription));
             }
 
             internal string ActionDescription { get { return _actionDescription; } }
-            internal Action<Transition> Action { get { return _action; } }
+
+            public class Sync : ExitActionBehavior
+            {
+                readonly Action<Transition> _action;
+
+                public Sync(Action<Transition> action, string actionDescription) : base(actionDescription)
+                {
+                    _action = action;
+                }
+
+                public override void Execute(Transition transition)
+                {
+                    _action(transition);
+                }
+
+                public override Task ExecuteAsync(Transition transition)
+                {
+                    Execute(transition);
+                    return TaskResult.Done;
+                }
+            }
+
+            public class Async : ExitActionBehavior
+            {
+                readonly Func<Transition, Task> _action;
+
+                public Async(Func<Transition, Task> action, string actionDescription) : base(actionDescription)
+                {
+                    _action = action;
+                }
+
+                public override void Execute(Transition transition)
+                {
+                    throw new InvalidOperationException(
+                        $"Cannot execute asynchronous action specified in OnExit event for '{transition.Source}' state. " +
+                         "Use asynchronous version of Fire [FireAsync]");
+                }
+
+                public override Task ExecuteAsync(Transition transition)
+                {
+                    return _action(transition);
+                }
+            }
         }
     }
 }

--- a/Stateless/InternalActionBehaviour.cs
+++ b/Stateless/InternalActionBehaviour.cs
@@ -8,25 +8,16 @@ namespace Stateless
 {
     public partial class StateMachine<TState, TTrigger>
     {
-        internal abstract class EntryActionBehavior
+        internal abstract class InternalActionBehaviour
         {
-            readonly string _actionDescription;
-
-            protected EntryActionBehavior(string actionDescription)
-            {
-                _actionDescription = Enforce.ArgumentNotNull(actionDescription, nameof(actionDescription));
-            }
-
-            internal string ActionDescription { get { return _actionDescription; } }
-
             public abstract void Execute(Transition transition, object[] args);
             public abstract Task ExecuteAsync(Transition transition, object[] args);
 
-            public class Sync : EntryActionBehavior
+            public class Sync : InternalActionBehaviour
             {
                 readonly Action<Transition, object[]> _action;
 
-                public Sync(Action<Transition, object[]> action, string actionDescription) : base(actionDescription)
+                public Sync(Action<Transition, object[]> action)
                 {
                     _action = action;
                 }
@@ -43,11 +34,11 @@ namespace Stateless
                 }
             }
 
-            public class Async : EntryActionBehavior
+            public class Async : InternalActionBehaviour
             {
                 readonly Func<Transition, object[], Task> _action;
 
-                public Async(Func<Transition, object[], Task> action, string actionDescription) : base(actionDescription)
+                public Async(Func<Transition, object[], Task> action)
                 {
                     _action = action;
                 }

--- a/Stateless/OnTransitionedEvent.cs
+++ b/Stateless/OnTransitionedEvent.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Stateless
+{
+    public partial class StateMachine<TState, TTrigger>
+    {
+        class OnTransitionedEvent
+        {
+            event Action<Transition> _onTransitioned;
+            readonly List<Func<Transition, Task>> _onTransitionedAsync = new List<Func<Transition, Task>>();
+
+            public void Invoke(Transition transition)
+            {
+                if (_onTransitionedAsync.Count != 0)
+                    throw new InvalidOperationException(
+                        "Cannot execute asynchronous action specified as OnTransitioned callback. " +
+                        "Use asynchronous version of Fire [FireAsync]");
+
+                _onTransitioned?.Invoke(transition);
+            }
+
+#if !NET40
+            public async Task InvokeAsync(Transition transition)
+            {
+                _onTransitioned?.Invoke(transition);
+
+                foreach (var callback in _onTransitionedAsync)
+                    await callback(transition);
+            }
+#endif
+
+            public void Register(Action<Transition> action)
+            {
+                _onTransitioned += action;
+            }
+
+            public void Register(Func<Transition, Task> action)
+            {
+                _onTransitionedAsync.Add(action);
+            }
+        }
+    }
+}

--- a/Stateless/StateConfiguration.Async.cs
+++ b/Stateless/StateConfiguration.Async.cs
@@ -1,0 +1,292 @@
+﻿#if !NET40
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Stateless
+{
+    public partial class StateMachine<TState, TTrigger>
+    {
+        public partial class StateConfiguration
+        {
+            /// <summary>
+            /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
+            /// </summary>
+            /// <param name="trigger"></param>
+            /// <param name="entryAction"></param>
+            /// <returns></returns>
+            public StateConfiguration InternalTransitionAsync(TTrigger trigger, Func<Transition, Task> entryAction)
+            {
+                if (entryAction == null) throw new ArgumentNullException(nameof(entryAction));
+
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger));
+                _representation.AddInternalAction(trigger, (t, args) => entryAction(t));
+                return this;
+            }
+            /// <summary>
+            /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
+            /// </summary>
+            /// <param name="trigger">The accepted trigger</param>
+            /// <param name="internalAction">The asynchronous action performed by the internal transition</param>
+            /// <returns></returns>
+            public StateConfiguration InternalTransitionAsync(TTrigger trigger, Func<Task> internalAction)
+            {
+                if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
+
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger));
+                _representation.AddInternalAction(trigger, (t, args) => internalAction());
+                return this;
+            }
+            /// <summary>
+            /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
+            /// </summary>
+            /// <typeparam name="TArg0"></typeparam>
+            /// <param name="trigger">The accepted trigger</param>
+            /// <param name="internalAction">The asynchronous action performed by the internal transition</param>
+            /// <returns></returns>
+            public StateConfiguration InternalTransitionAsync<TArg0>(TTrigger trigger, Func<Transition, Task> internalAction)
+            {
+                if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
+
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger));
+                _representation.AddInternalAction(trigger, (t, args) => internalAction(t));
+                return this;
+            }
+            /// <summary>
+            /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
+            /// </summary>
+            /// <typeparam name="TArg0"></typeparam>
+            /// <param name="trigger">The accepted trigger</param>
+            /// <param name="internalAction">The asynchronous action performed by the internal transition</param>
+            /// <returns></returns>
+            public StateConfiguration InternalTransitionAsync<TArg0>(TriggerWithParameters<TArg0> trigger, Func<TArg0, Transition, Task> internalAction)
+            {
+                if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
+
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger));
+                _representation.AddInternalAction(trigger.Trigger, (t, args) => internalAction(ParameterConversion.Unpack<TArg0>(args, 0), t));
+                return this;
+            }
+  
+            /// <summary>
+            /// Specify an asynchronous action that will execute when transitioning into
+            /// the configured state.
+            /// </summary>
+            /// <param name="entryAction">Action to execute.</param>
+            /// <param name="entryActionDescription">Action description.</param>
+            /// <returns>The receiver.</returns>
+            public StateConfiguration OnEntryAsync(Func<Task> entryAction, string entryActionDescription = null)
+            {
+                Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
+                return OnEntryAsync(
+                    t => entryAction(),
+                    entryActionDescription ?? entryAction.TryGetMethodName());
+            }
+
+            /// <summary>
+            /// Specify an asynchronous action that will execute when transitioning into
+            /// the configured state.
+            /// </summary>
+            /// <param name="entryAction">Action to execute, providing details of the transition.</param>
+            /// <param name="entryActionDescription">Action description.</param>
+            /// <returns>The receiver.</returns>
+            public StateConfiguration OnEntryAsync(Func<Transition, Task> entryAction, string entryActionDescription = null)
+            {
+                Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
+                _representation.AddEntryAction(
+                    (t, args) => entryAction(t),
+                    entryActionDescription ?? entryAction.TryGetMethodName());
+                return this;
+            }
+
+            /// <summary>
+            /// Specify an asynchronous action that will execute when transitioning into
+            /// the configured state.
+            /// </summary>
+            /// <param name="entryAction">Action to execute.</param>
+            /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
+            /// <param name="entryActionDescription">Action description.</param>
+            /// <returns>The receiver.</returns>
+            public StateConfiguration OnEntryFromAsync(TTrigger trigger, Func<Task> entryAction, string entryActionDescription = null)
+            {
+                Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
+                return OnEntryFromAsync(
+                    trigger,
+                    t => entryAction(),
+                    entryActionDescription ?? entryAction.TryGetMethodName());
+            }
+
+            /// <summary>
+            /// Specify an asynchronous action that will execute when transitioning into
+            /// the configured state.
+            /// </summary>
+            /// <param name="entryAction">Action to execute, providing details of the transition.</param>
+            /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
+            /// <param name="entryActionDescription">Action description.</param>
+            /// <returns>The receiver.</returns>
+            public StateConfiguration OnEntryFromAsync(TTrigger trigger, Func<Transition, Task> entryAction, string entryActionDescription = null)
+            {
+                Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
+                _representation.AddEntryAction(
+                    trigger,
+                    (t, args) => entryAction(t),
+                    entryActionDescription ?? entryAction.TryGetMethodName());
+                return this;
+            }
+
+            /// <summary>
+            /// Specify an asynchronous action that will execute when transitioning into
+            /// the configured state.
+            /// </summary>
+            /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
+            /// <param name="entryAction">Action to execute, providing details of the transition.</param>
+            /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
+            /// <param name="entryActionDescription">Action description.</param>
+            /// <returns>The receiver.</returns>
+            public StateConfiguration OnEntryFromAsync<TArg0>(TriggerWithParameters<TArg0> trigger, Func<TArg0, Task> entryAction, string entryActionDescription = null)
+            {
+                Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
+                return OnEntryFromAsync<TArg0>(
+                    trigger,
+                    (a0, t) => entryAction(a0),
+                    entryActionDescription ?? entryAction.TryGetMethodName());
+            }
+
+            /// <summary>
+            /// Specify an asynchronous action that will execute when transitioning into
+            /// the configured state.
+            /// </summary>
+            /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
+            /// <param name="entryAction">Action to execute, providing details of the transition.</param>
+            /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
+            /// <param name="entryActionDescription">Action description.</param>
+            /// <returns>The receiver.</returns>
+            public StateConfiguration OnEntryFromAsync<TArg0>(TriggerWithParameters<TArg0> trigger, Func<TArg0, Transition, Task> entryAction, string entryActionDescription = null)
+            {
+                Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
+                Enforce.ArgumentNotNull(trigger, nameof(trigger));
+                _representation.AddEntryAction(
+                    trigger.Trigger,
+                    (t, args) => entryAction(
+                        ParameterConversion.Unpack<TArg0>(args, 0), t),
+                        entryActionDescription ?? entryAction.TryGetMethodName());
+                return this;
+            }
+
+            /// <summary>
+            /// Specify an asynchronous action that will execute when transitioning into
+            /// the configured state.
+            /// </summary>
+            /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
+            /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
+            /// <param name="entryAction">Action to execute, providing details of the transition.</param>
+            /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
+            /// <param name="entryActionDescription">Action description.</param>
+            /// <returns>The receiver.</returns>
+            public StateConfiguration OnEntryFromAsync<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Func<TArg0, TArg1, Task> entryAction, string entryActionDescription = null)
+            {
+                Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
+                return OnEntryFromAsync<TArg0, TArg1>(
+                    trigger, 
+                    (a0, a1, t) => entryAction(a0, a1), entryActionDescription ?? entryAction.TryGetMethodName());
+            }
+
+            /// <summary>
+            /// Specify an asynchronous action that will execute when transitioning into
+            /// the configured state.
+            /// </summary>
+            /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
+            /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
+            /// <param name="entryAction">Action to execute, providing details of the transition.</param>
+            /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
+            /// <param name="entryActionDescription">Action description.</param>
+            /// <returns>The receiver.</returns>
+            public StateConfiguration OnEntryFromAsync<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Func<TArg0, TArg1, Transition, Task> entryAction, string entryActionDescription = null)
+            {
+                Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
+                Enforce.ArgumentNotNull(trigger, nameof(trigger));
+                _representation.AddEntryAction(trigger.Trigger, (t, args) => entryAction(
+                    ParameterConversion.Unpack<TArg0>(args, 0),
+                    ParameterConversion.Unpack<TArg1>(args, 1), t), entryActionDescription ?? entryAction.TryGetMethodName());
+                return this;
+            }
+
+            /// <summary>
+            /// Specify an asynchronous action that will execute when transitioning into
+            /// the configured state.
+            /// </summary>
+            /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
+            /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
+            /// <typeparam name="TArg2">Type of the third trigger argument.</typeparam>
+            /// <param name="entryAction">Action to execute, providing details of the transition.</param>
+            /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
+            /// <param name="entryActionDescription">Action description.</param>
+            /// <returns>The receiver.</returns>
+            public StateConfiguration OnEntryFromAsync<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Func<TArg0, TArg1, TArg2, Task> entryAction, string entryActionDescription = null)
+            {
+                Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
+                return OnEntryFromAsync<TArg0, TArg1, TArg2>(
+                    trigger, 
+                    (a0, a1, a2, t) => entryAction(a0, a1, a2), entryActionDescription ?? entryAction.TryGetMethodName());
+            }
+
+            /// <summary>
+            /// Specify an asynchronous action that will execute when transitioning into
+            /// the configured state.
+            /// </summary>
+            /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
+            /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
+            /// <typeparam name="TArg2">Type of the third trigger argument.</typeparam>
+            /// <param name="entryAction">Action to execute, providing details of the transition.</param>
+            /// <param name="trigger">The trigger by which the state must be entered in order for the action to execute.</param>
+            /// <param name="entryActionDescription">Action description.</param>
+            /// <returns>The receiver.</returns>
+            public StateConfiguration OnEntryFromAsync<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Func<TArg0, TArg1, TArg2, Transition, Task> entryAction, string entryActionDescription = null)
+            {
+                Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
+                Enforce.ArgumentNotNull(trigger, nameof(trigger));
+                _representation.AddEntryAction(trigger.Trigger, (t, args) => entryAction(
+                    ParameterConversion.Unpack<TArg0>(args, 0),
+                    ParameterConversion.Unpack<TArg1>(args, 1),
+                    ParameterConversion.Unpack<TArg2>(args, 2), t), entryActionDescription ?? entryAction.TryGetMethodName());
+                return this;
+            }
+
+            /// <summary>
+            /// Specify an asynchronous action that will execute when transitioning from
+            /// the configured state.
+            /// </summary>
+            /// <param name="exitAction">Action to execute.</param>
+            /// <param name="exitActionDescription">Action description.</param>
+            /// <returns>The receiver.</returns>
+            public StateConfiguration OnExitAsync(Func<Task> exitAction, string exitActionDescription = null)
+            {
+                Enforce.ArgumentNotNull(exitAction, nameof(exitAction));
+                return OnExitAsync(
+                    t => exitAction(),
+                    exitActionDescription ?? exitAction.TryGetMethodName());
+            }
+
+            /// <summary>
+            /// Specify an asynchronous action that will execute when transitioning from
+            /// the configured state.
+            /// </summary>
+            /// <param name="exitAction">Action to execute, providing details of the transition.</param>
+            /// <param name="exitActionDescription">Action description.</param>
+            /// <returns>The receiver.</returns>
+            public StateConfiguration OnExitAsync(Func<Transition, Task> exitAction, string exitActionDescription = null)
+            {
+                Enforce.ArgumentNotNull(exitAction, nameof(exitAction));
+                _representation.AddExitAction(
+                    exitAction,
+                    exitActionDescription ?? exitAction.TryGetMethodName());
+                return this;
+            }
+        }
+    }
+}
+#endif

--- a/Stateless/StateConfiguration.cs
+++ b/Stateless/StateConfiguration.cs
@@ -11,7 +11,7 @@ namespace Stateless
         /// <summary>
         /// The configuration for a single state value.
         /// </summary>
-        public class StateConfiguration
+        public partial class StateConfiguration
         {
             private readonly StateMachine<TState, TTrigger> _machine;
             readonly StateRepresentation _representation;
@@ -61,6 +61,7 @@ namespace Stateless
                 _representation.AddInternalAction(trigger, (t, args) => entryAction(t));
                 return this;
             }
+            
             /// <summary>
             /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
             /// </summary>
@@ -483,7 +484,6 @@ namespace Stateless
             {
                 return PermitDynamicIf(trigger, destinationStateSelector, NoGuard);
             }
-
 
             /// <summary>
             /// Accept the specified trigger and transition to the destination state, calculated

--- a/Stateless/StateMachine.Async.cs
+++ b/Stateless/StateMachine.Async.cs
@@ -1,0 +1,145 @@
+﻿#if !NET40
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Stateless
+{
+    public partial class StateMachine<TState, TTrigger>
+    {
+        /// <summary>
+        /// Transition from the current state via the specified trigger in async fashion.
+        /// The target state is determined by the configuration of the current state.
+        /// Actions associated with leaving the current state and entering the new one
+        /// will be invoked.
+        /// </summary>
+        /// <param name="trigger">The trigger to fire.</param>
+        /// <exception cref="System.InvalidOperationException">The current state does
+        /// not allow the trigger to be fired.</exception>
+        public Task FireAsync(TTrigger trigger)
+        {
+            return InternalFireAsync(trigger, new object[0]);
+        }
+
+        /// <summary>
+        /// Transition from the current state via the specified trigger in async fashion.
+        /// The target state is determined by the configuration of the current state.
+        /// Actions associated with leaving the current state and entering the new one
+        /// will be invoked.
+        /// </summary>
+        /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
+        /// <param name="trigger">The trigger to fire.</param>
+        /// <param name="arg0">The first argument.</param>
+        /// <exception cref="System.InvalidOperationException">The current state does
+        /// not allow the trigger to be fired.</exception>
+        public Task FireAsync<TArg0>(TriggerWithParameters<TArg0> trigger, TArg0 arg0)
+        {
+            Enforce.ArgumentNotNull(trigger, "trigger");
+            return InternalFireAsync(trigger.Trigger, arg0);
+        }
+
+        /// <summary>
+        /// Transition from the current state via the specified trigger in async fashion.
+        /// The target state is determined by the configuration of the current state.
+        /// Actions associated with leaving the current state and entering the new one
+        /// will be invoked.
+        /// </summary>
+        /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
+        /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
+        /// <param name="arg0">The first argument.</param>
+        /// <param name="arg1">The second argument.</param>
+        /// <param name="trigger">The trigger to fire.</param>
+        /// <exception cref="System.InvalidOperationException">The current state does
+        /// not allow the trigger to be fired.</exception>
+        public Task FireAsync<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, TArg0 arg0, TArg1 arg1)
+        {
+            Enforce.ArgumentNotNull(trigger, "trigger");
+            return InternalFireAsync(trigger.Trigger, arg0, arg1);
+        }
+
+        /// <summary>
+        /// Transition from the current state via the specified trigger in async fashion.
+        /// The target state is determined by the configuration of the current state.
+        /// Actions associated with leaving the current state and entering the new one
+        /// will be invoked.
+        /// </summary>
+        /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
+        /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
+        /// <typeparam name="TArg2">Type of the third trigger argument.</typeparam>
+        /// <param name="arg0">The first argument.</param>
+        /// <param name="arg1">The second argument.</param>
+        /// <param name="arg2">The third argument.</param>
+        /// <param name="trigger">The trigger to fire.</param>
+        /// <exception cref="System.InvalidOperationException">The current state does
+        /// not allow the trigger to be fired.</exception>
+        public Task FireAsync<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, TArg0 arg0, TArg1 arg1, TArg2 arg2)
+        {
+            Enforce.ArgumentNotNull(trigger, "trigger");
+            return InternalFireAsync(trigger.Trigger, arg0, arg1, arg2);
+        }
+
+        async Task InternalFireAsync(TTrigger trigger, params object[] args)
+        {
+            TriggerWithParameters configuration;
+            if (_triggerConfiguration.TryGetValue(trigger, out configuration))
+                configuration.ValidateParameters(args);
+
+            var source = State;
+            var representativeState = GetRepresentation(source);
+
+            TriggerBehaviour triggerBehaviour;
+            if (!representativeState.TryFindHandler(trigger, out triggerBehaviour))
+            {
+                await _unhandledTriggerAction.ExecuteAsync(representativeState.UnderlyingState, trigger);
+                return;
+            }
+
+            TState destination;
+            if (triggerBehaviour.ResultsInTransitionFrom(source, args, out destination))
+            {
+                var transition = new Transition(source, destination, trigger);
+
+                await representativeState.ExitAsync(transition);
+
+                State = transition.Destination;
+                var newRepresentation = GetRepresentation(transition.Destination);
+                await _onTransitionedEvent.InvokeAsync(transition);
+
+                await newRepresentation.EnterAsync(transition, args);
+            }
+            else
+            {
+                var transition = new Transition(source, destination, trigger);
+
+                await CurrentRepresentation.InternalActionAsync(transition, args);
+            }
+        }
+
+        /// <summary>
+        /// Override the default behaviour of throwing an exception when an unhandled trigger
+        /// is fired.
+        /// </summary>
+        /// <param name="unhandledTriggerAction">An asynchronous action to call when an unhandled trigger is fired.</param>
+        public void OnUnhandledTriggerAsync(Func<TState, TTrigger, Task> unhandledTriggerAction)
+        {
+            if (unhandledTriggerAction == null) throw new ArgumentNullException("unhandledTriggerAction");
+            _unhandledTriggerAction = new UnhandledTriggerAction.Async(unhandledTriggerAction);
+        }
+
+        /// <summary>
+        /// Registers an asynchronous callback that will be invoked every time the statemachine
+        /// transitions from one state into another.
+        /// </summary>
+        /// <param name="onTransitionAction">The asynchronous action to execute, accepting the details
+        /// of the transition.</param>
+        public void OnTransitionedAsync(Func<Transition, Task> onTransitionAction)
+        {
+            if (onTransitionAction == null) throw new ArgumentNullException("onTransitionAction");
+            _onTransitionedEvent.Register(onTransitionAction);
+        }
+    }
+}
+
+#endif

--- a/Stateless/StateRepresentation.Async.cs
+++ b/Stateless/StateRepresentation.Async.cs
@@ -1,0 +1,133 @@
+﻿#if !NET40
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Stateless
+{
+    public partial class StateMachine<TState, TTrigger>
+    {
+        internal partial class StateRepresentation
+        {
+            public void AddEntryAction(TTrigger trigger, Func<Transition, object[], Task> action, string entryActionDescription)
+            {
+                Enforce.ArgumentNotNull(action, nameof(action));
+                _entryActions.Add(
+                    new EntryActionBehavior.Async((t, args) =>
+                    {
+                        if (t.Trigger.Equals(trigger))
+                            return action(t, args);
+
+                        return TaskResult.Done;
+                    },
+                    Enforce.ArgumentNotNull(entryActionDescription, nameof(entryActionDescription))));
+            }
+
+            public void AddEntryAction(Func<Transition, object[], Task> action, string entryActionDescription)
+            {
+                _entryActions.Add(
+                    new EntryActionBehavior.Async(
+                        Enforce.ArgumentNotNull(action, nameof(action)),
+                        Enforce.ArgumentNotNull(entryActionDescription, nameof(entryActionDescription))));
+            }
+
+            public void AddExitAction(Func<Transition, Task> action, string exitActionDescription)
+            {
+                _exitActions.Add(
+                    new ExitActionBehavior.Async(
+                        Enforce.ArgumentNotNull(action, nameof(action)),
+                        Enforce.ArgumentNotNull(exitActionDescription, nameof(exitActionDescription))));
+            }
+
+            internal void AddInternalAction(TTrigger trigger, Func<Transition, object[], Task> action)
+            {
+                Enforce.ArgumentNotNull(action, "action");
+
+                _internalActions.Add(new InternalActionBehaviour.Async((t, args) =>
+                {
+                    if (t.Trigger.Equals(trigger))
+                        return action(t, args);
+
+                    return TaskResult.Done;
+                }));
+            }
+
+            public async Task EnterAsync(Transition transition, params object[] entryArgs)
+            {
+                Enforce.ArgumentNotNull(transition, nameof(transition));
+
+                if (transition.IsReentry)
+                {
+                    await ExecuteEntryActionsAsync(transition, entryArgs);
+                }
+                else if (!Includes(transition.Source))
+                {
+                    if (_superstate != null)
+                        await _superstate.EnterAsync(transition, entryArgs);
+
+                    await ExecuteEntryActionsAsync(transition, entryArgs);
+                }
+            }
+
+            public async Task ExitAsync(Transition transition)
+            {
+                Enforce.ArgumentNotNull(transition, nameof(transition));
+
+                if (transition.IsReentry)
+                {
+                    await ExecuteExitActionsAsync(transition);
+                }
+                else if (!Includes(transition.Destination))
+                {
+                    await ExecuteExitActionsAsync(transition);
+                    if (_superstate != null)
+                        await _superstate.ExitAsync(transition);
+                }
+            }
+
+            async Task ExecuteEntryActionsAsync(Transition transition, object[] entryArgs)
+            {
+                Enforce.ArgumentNotNull(transition, nameof(transition));
+                Enforce.ArgumentNotNull(entryArgs, nameof(entryArgs));
+                foreach (var action in _entryActions)
+                    await action.ExecuteAsync(transition, entryArgs);
+            }
+
+            async Task ExecuteExitActionsAsync(Transition transition)
+            {
+                Enforce.ArgumentNotNull(transition, nameof(transition));
+                foreach (var action in _exitActions)
+                    await action.ExecuteAsync(transition);
+            }
+
+            async Task ExecuteInternalActionsAsync(Transition transition, object[] args)
+            {
+                var possibleActions = new List<InternalActionBehaviour>();
+
+                // Look for actions in superstate(s) recursivly until we hit the topmost superstate
+                StateRepresentation aStateRep = this;
+                do
+                {
+                    possibleActions.AddRange(aStateRep._internalActions);
+                    aStateRep = aStateRep._superstate;
+                } while (aStateRep != null);
+
+                // Execute internal transition event handler
+                foreach (var action in possibleActions)
+                {
+                    await action.ExecuteAsync(transition, args);
+                }
+            }
+
+            internal Task InternalActionAsync(Transition transition, object[] args)
+            {
+                Enforce.ArgumentNotNull(transition, "transition");
+                return ExecuteInternalActionsAsync(transition, args);
+            }
+        }
+    }
+}
+
+#endif

--- a/Stateless/TaskResult.cs
+++ b/Stateless/TaskResult.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading.Tasks;
+
+namespace Stateless
+{
+    internal static class TaskResult
+    {
+        internal static readonly Task Done = FromResult(1);
+
+        static Task<T> FromResult<T>(T value)
+        {
+            var tcs = new TaskCompletionSource<T>();
+            tcs.SetResult(value);
+            return tcs.Task;
+        }
+    }
+}

--- a/Stateless/UnhandledTriggerAction.cs
+++ b/Stateless/UnhandledTriggerAction.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Stateless
+{
+    public partial class StateMachine<TState, TTrigger>
+    {
+        abstract class UnhandledTriggerAction
+        {
+            public abstract void Execute(TState state, TTrigger trigger);
+            public abstract Task ExecuteAsync(TState state, TTrigger trigger);
+
+            internal class Sync : UnhandledTriggerAction
+            {
+                readonly Action<TState, TTrigger> _action;
+
+                internal Sync(Action<TState, TTrigger> action = null)
+                {
+                    _action = action;
+                }
+
+                public override void Execute(TState state, TTrigger trigger)
+                {
+                    _action(state, trigger);
+                }
+
+                public override Task ExecuteAsync(TState state, TTrigger trigger)
+                {
+                    Execute(state, trigger);
+                    return TaskResult.Done;
+                }
+            }
+
+            internal class Async : UnhandledTriggerAction
+            {
+                readonly Func<TState, TTrigger, Task> _action;
+
+                internal Async(Func<TState, TTrigger, Task> action)
+                {
+                    _action = action;
+                }
+
+                public override void Execute(TState state, TTrigger trigger)
+                {
+                    throw new InvalidOperationException(
+                        "Cannot execute asynchronous action specified in OnUnhandledTrigger. " +
+                        "Use asynchronous version of Fire [FireAsync]");
+                }
+
+                public override Task ExecuteAsync(TState state, TTrigger trigger)
+                {
+                    return _action(state, trigger);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I like this library so much but can't use it with Orleans due to absence of support for async actions. In Orleans, actors are thread-safe turn-based and everything is based on promises (Tasks) and async/await. So having such support is required to be able to successfully build and execute FSM's inside actor.

Besides `FireAsync` I've added async support to all places where action could be specified:
- `OnUnhandledTrigger`
- `OnTransitioned`
- `OnEntry`
- `OnExit`
- `InternalTransition`

I've used Async suffix to not break binary compatibiilty with previous versions, since consumers may have callbacks specified as method groups and compiler won't be able to resolve ambiguity in such cases.

Also, I added checks for cases when consumer invoke synchronous `Fire` but current transition path involves execution of async actions. This will throw `IOP`. Includes, `OnTransitioned` and `OnUnhandledTrigger` callbacks as well.  It's ok to have sync actions called when using `FireAsync` - in this case completed task will be returned.

NOTE: Async version is not available for NET40 due to absence of async/await support. 
