### PR TITLE
Initial state activation

### DIFF
--- a/Stateless.Tests/ActiveStatesFixture.cs
+++ b/Stateless.Tests/ActiveStatesFixture.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using System.Collections.Generic;
+
+using NUnit.Framework;
+
+namespace Stateless.Tests
+{
+    [TestFixture]
+    public class ActiveStatesFixture
+    {
+        [Test]
+        public void WhenActivate()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            var expectedOrdering = new List<string> { "ActivatedC", "ActivatedA" };
+            var actualOrdering = new List<string>();
+
+            sm.Configure(State.A)
+              .SubstateOf(State.C)
+              .OnActivate(() => actualOrdering.Add("ActivatedA"));
+
+            sm.Configure(State.C)
+              .OnActivate(() => actualOrdering.Add("ActivatedC"));
+
+            // should not be called for activation
+            sm.OnTransitioned(t => actualOrdering.Add("OnTransitioned"));
+
+            sm.Activate();
+
+            Assert.AreEqual(expectedOrdering.Count, actualOrdering.Count);
+            for (int i = 0; i < expectedOrdering.Count; i++)
+                Assert.AreEqual(expectedOrdering[i], actualOrdering[i]);
+        }
+
+        [Test]
+        public void WhenActivateIsIdempotent()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            var actualOrdering = new List<string>();
+
+            sm.Configure(State.A)
+              .SubstateOf(State.C)
+              .OnActivate(() => actualOrdering.Add("ActivatedA"));
+
+            sm.Configure(State.C)
+              .OnActivate(() => actualOrdering.Add("ActivatedC"));
+
+            sm.Activate();
+
+            actualOrdering.Clear();
+            sm.Activate();
+
+            Assert.AreEqual(0, actualOrdering.Count);
+        }
+
+        [Test]
+        public void WhenDeactivate()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            var expectedOrdering = new List<string> { "DeactivatedA", "DeactivatedC" };
+            var actualOrdering = new List<string>();
+
+            sm.Configure(State.A)
+              .SubstateOf(State.C)
+              .OnDeactivate(() => actualOrdering.Add("DeactivatedA"));
+
+            sm.Configure(State.C)
+              .OnDeactivate(() => actualOrdering.Add("DeactivatedC"));
+
+            // should not be called for activation
+            sm.OnTransitioned(t => actualOrdering.Add("OnTransitioned"));
+
+            sm.Activate();
+            sm.Deactivate();
+
+            Assert.AreEqual(expectedOrdering.Count, actualOrdering.Count);
+            for (int i = 0; i < expectedOrdering.Count; i++)
+                Assert.AreEqual(expectedOrdering[i], actualOrdering[i]);
+        }
+
+        [Test]
+        public void WhenDeactivateIsIdempotent()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            var actualOrdering = new List<string>();
+
+            sm.Configure(State.A)
+              .SubstateOf(State.C)
+              .OnDeactivate(() => actualOrdering.Add("DeactivatedA"));
+
+            sm.Configure(State.C)
+              .OnDeactivate(() => actualOrdering.Add("DeactivatedC"));
+
+            sm.Activate();
+            sm.Deactivate();
+
+            actualOrdering.Clear();
+            sm.Activate();
+
+            Assert.AreEqual(0, actualOrdering.Count);
+        }
+
+        [Test]
+        public void WhenTransitioning()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            var expectedOrdering = new List<string>
+            {
+                "ActivatedA",
+
+                "DeactivatedA",
+                "ExitedA",
+                "OnTransitioned",
+                "EnteredB",
+                "ActivatedB",
+
+                "DeactivatedB",
+                "ExitedB",
+                "OnTransitioned",
+                "EnteredA",
+                "ActivatedA"
+            };
+
+            var actualOrdering = new List<string>();
+
+            sm.Configure(State.A)
+              .OnActivate(() => actualOrdering.Add("ActivatedA"))
+              .OnDeactivate(() => actualOrdering.Add("DeactivatedA"))
+              .OnEntry(() => actualOrdering.Add("EnteredA"))
+              .OnExit(() => actualOrdering.Add("ExitedA"))
+              .Permit(Trigger.X, State.B);
+
+            sm.Configure(State.B)
+              .OnActivate(() => actualOrdering.Add("ActivatedB"))
+              .OnDeactivate(() => actualOrdering.Add("DeactivatedB"))
+              .OnEntry(() => actualOrdering.Add("EnteredB"))
+              .OnExit(() => actualOrdering.Add("ExitedB"))
+              .Permit(Trigger.Y, State.A);
+
+            sm.OnTransitioned(t => actualOrdering.Add("OnTransitioned"));
+
+            sm.Activate();
+            sm.Fire(Trigger.X);
+            sm.Fire(Trigger.Y);
+
+            Assert.AreEqual(expectedOrdering.Count, actualOrdering.Count);
+            for (int i = 0; i < expectedOrdering.Count; i++)
+                Assert.AreEqual(expectedOrdering[i], actualOrdering[i]);
+        }
+
+        [Test]
+        public void WhenTransitioningWithinSameSuperstate()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            var expectedOrdering = new List<string>
+            {
+                "ActivatedC",
+                "ActivatedA",
+
+                "DeactivatedA",
+                "ActivatedB",
+
+                "DeactivatedB",
+                "ActivatedA",
+            };
+
+            var actualOrdering = new List<string>();
+
+            sm.Configure(State.A)
+              .SubstateOf(State.C)
+              .OnActivate(() => actualOrdering.Add("ActivatedA"))
+              .OnDeactivate(() => actualOrdering.Add("DeactivatedA"))
+              .Permit(Trigger.X, State.B);
+
+            sm.Configure(State.B)
+              .SubstateOf(State.C)
+              .OnActivate(() => actualOrdering.Add("ActivatedB"))
+              .OnDeactivate(() => actualOrdering.Add("DeactivatedB"))
+              .Permit(Trigger.Y, State.A);
+
+            sm.Configure(State.C)
+              .OnActivate(() => actualOrdering.Add("ActivatedC"))
+              .OnDeactivate(() => actualOrdering.Add("DeactivatedC"));
+
+            sm.Activate();
+            sm.Fire(Trigger.X);
+            sm.Fire(Trigger.Y);
+
+            Assert.AreEqual(expectedOrdering.Count, actualOrdering.Count);
+            for (int i = 0; i < expectedOrdering.Count; i++)
+                Assert.AreEqual(expectedOrdering[i], actualOrdering[i]);
+        }
+    }
+}

--- a/Stateless.Tests/AsyncActionsFixture.cs
+++ b/Stateless.Tests/AsyncActionsFixture.cs
@@ -173,6 +173,59 @@ namespace Stateless.Tests
 
             Assert.Throws<InvalidOperationException>(() => sm.Fire(Trigger.Z));
         }
+
+        [Test]
+        public async Task WhenActivateAsync()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            var activated = false;
+            sm.Configure(State.A)
+              .OnActivateAsync(() => Task.Run(()=> activated = true));
+
+            await sm.ActivateAsync();
+
+            Assert.AreEqual(true, activated, "Should await action");
+        }
+
+        [Test]
+        public async Task WhenDeactivateAsync()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            var deactivated = false;
+            sm.Configure(State.A)
+              .OnDeactivateAsync(() => Task.Run(()=> deactivated = true));
+
+            await sm.ActivateAsync();
+            await sm.DeactivateAsync();
+
+            Assert.AreEqual(true, deactivated, "Should await action");
+        }
+
+        [Test]
+        public void WhenSyncActivateAsyncOnActivateAction()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+              .OnActivateAsync(() => TaskResult.Done);
+
+            Assert.Throws<InvalidOperationException>(() => sm.Activate());
+        }
+
+        [Test]
+        public void WhenSyncDeactivateAsyncOnDeactivateAction()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+              .OnDeactivateAsync(() => TaskResult.Done);
+
+            sm.Activate();
+
+            Assert.Throws<InvalidOperationException>(() => sm.Deactivate());
+        }
     }
 }
 

--- a/Stateless/ActivateActionBehaviour.cs
+++ b/Stateless/ActivateActionBehaviour.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Stateless
+{
+    public partial class StateMachine<TState, TTrigger>
+    {
+        internal abstract class ActivateActionBehaviour
+        {
+            readonly TState _state;
+            readonly string _actionDescription;
+
+            protected ActivateActionBehaviour(TState state, string actionDescription)
+            {
+                _state = state;
+                _actionDescription = Enforce.ArgumentNotNull(actionDescription, nameof(actionDescription));
+            }
+
+            internal string ActionDescription { get { return _actionDescription; } }
+
+            public abstract void Execute();
+            public abstract Task ExecuteAsync();
+
+            public class Sync : ActivateActionBehaviour
+            {
+                readonly Action _action;
+
+                public Sync(TState state, Action action, string actionDescription)
+                    : base(state, actionDescription)
+                {
+                    _action = action;
+                }
+
+                public override void Execute()
+                {
+                    _action();
+                }
+
+                public override Task ExecuteAsync()
+                {
+                    Execute();
+                    return TaskResult.Done;
+                }
+            }
+
+            public class Async : ActivateActionBehaviour
+            {
+                readonly Func<Task> _action;
+
+                public Async(TState state, Func<Task> action, string actionDescription)
+                    : base(state, actionDescription)
+                {
+                    _action = action;
+                }
+
+                public override void Execute()
+                {
+                    throw new InvalidOperationException(
+                        $"Cannot execute asynchronous action specified in OnActivateAsync for '{_state}' state. " +
+                         "Use asynchronous version of Activate [ActivateAsync]");
+                }
+
+                public override Task ExecuteAsync()
+                {
+                    return _action();
+                }
+            }
+        }
+    }
+}

--- a/Stateless/DeactivateActionBehaviour.cs
+++ b/Stateless/DeactivateActionBehaviour.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Stateless
+{
+    public partial class StateMachine<TState, TTrigger>
+    {
+        internal abstract class DeactivateActionBehaviour
+        {
+            readonly TState _state;
+            readonly string _actionDescription;
+
+            protected DeactivateActionBehaviour(TState state, string actionDescription)
+            {
+                _state = state;
+                _actionDescription = Enforce.ArgumentNotNull(actionDescription, nameof(actionDescription));
+            }
+
+            internal string ActionDescription { get { return _actionDescription; } }
+
+            public abstract void Execute();
+            public abstract Task ExecuteAsync();
+
+            public class Sync : DeactivateActionBehaviour
+            {
+                readonly Action _action;
+
+                public Sync(TState state, Action action, string actionDescription)
+                    : base(state, actionDescription)
+                {
+                    _action = action;
+                }
+
+                public override void Execute()
+                {
+                    _action();
+                }
+
+                public override Task ExecuteAsync()
+                {
+                    Execute();
+                    return TaskResult.Done;
+                }
+            }
+
+            public class Async : DeactivateActionBehaviour
+            {
+                readonly Func<Task> _action;
+
+                public Async(TState state, Func<Task> action, string actionDescription)
+                    : base(state, actionDescription)
+                {
+                    _action = action;
+                }
+
+                public override void Execute()
+                {
+                    throw new InvalidOperationException(
+                        $"Cannot execute asynchronous action specified in OnDeactivateAsync for '{_state}' state. " +
+                         "Use asynchronous version of Deactivate [DeactivateAsync]");
+                }
+
+                public override Task ExecuteAsync()
+                {
+                    return _action();
+                }
+            }
+        }
+    }
+}

--- a/Stateless/StateConfiguration.Async.cs
+++ b/Stateless/StateConfiguration.Async.cs
@@ -71,7 +71,39 @@ namespace Stateless
                 _representation.AddInternalAction(trigger.Trigger, (t, args) => internalAction(ParameterConversion.Unpack<TArg0>(args, 0), t));
                 return this;
             }
-  
+
+            /// <summary>
+            /// Specify an asynchronous action that will execute when activating
+            /// the configured state.
+            /// </summary>
+            /// <param name="activateAction">Action to execute.</param>
+            /// <param name="activateActionDescription">Action description.</param>
+            /// <returns>The receiver.</returns>
+            public StateConfiguration OnActivateAsync(Func<Task> activateAction, string activateActionDescription = null)
+            {
+                Enforce.ArgumentNotNull(activateAction, nameof(activateAction));
+                _representation.AddActivateAction(
+                    activateAction,
+                    activateActionDescription ?? activateAction.TryGetMethodName());
+                return this;
+            }
+
+            /// <summary>
+            /// Specify an asynchronous action that will execute when deactivating
+            /// the configured state.
+            /// </summary>
+            /// <param name="deactivateAction">Action to execute.</param>
+            /// <param name="deactivateActionDescription">Action description.</param>
+            /// <returns>The receiver.</returns>
+            public StateConfiguration OnDeactivateAsync(Func<Task> deactivateAction, string deactivateActionDescription = null)
+            {
+                Enforce.ArgumentNotNull(deactivateAction, nameof(deactivateAction));
+                _representation.AddDeactivateAction(
+                    deactivateAction,
+                    deactivateActionDescription ?? deactivateAction.TryGetMethodName());
+                return this;
+            }
+
             /// <summary>
             /// Specify an asynchronous action that will execute when transitioning into
             /// the configured state.

--- a/Stateless/StateConfiguration.cs
+++ b/Stateless/StateConfiguration.cs
@@ -193,6 +193,38 @@ namespace Stateless
             }
 
             /// <summary>
+            /// Specify an action that will execute when activating
+            /// the configured state.
+            /// </summary>
+            /// <param name="activateAction">Action to execute.</param>
+            /// <param name="activateActionDescription">Action description.</param>
+            /// <returns>The receiver.</returns>
+            public StateConfiguration OnActivate(Action activateAction, string activateActionDescription = null)
+            {
+                Enforce.ArgumentNotNull(activateAction, nameof(activateAction));
+                _representation.AddActivateAction(
+                    activateAction, 
+                    activateActionDescription ?? activateAction.TryGetMethodName());
+                return this;
+            }
+
+            /// <summary>
+            /// Specify an action that will execute when deactivating
+            /// the configured state.
+            /// </summary>
+            /// <param name="deactivateAction">Action to execute.</param>
+            /// <param name="deactivateActionDescription">Action description.</param>
+            /// <returns>The receiver.</returns>
+            public StateConfiguration OnDeactivate(Action deactivateAction, string deactivateActionDescription = null)
+            {
+                Enforce.ArgumentNotNull(deactivateAction, nameof(deactivateAction));
+                _representation.AddDeactivateAction(
+                    deactivateAction,
+                    deactivateActionDescription ?? deactivateAction.TryGetMethodName());
+                return this;
+            }
+
+            /// <summary>
             /// Specify an action that will execute when transitioning into
             /// the configured state.
             /// </summary>

--- a/Stateless/StateMachine.Async.cs
+++ b/Stateless/StateMachine.Async.cs
@@ -10,6 +10,28 @@ namespace Stateless
     public partial class StateMachine<TState, TTrigger>
     {
         /// <summary>
+        /// Activates current state in asynchronous fashion. Actions associated with activating the currrent state
+        /// will be invoked. The activation is idempotent and subsequent activation of the same current state 
+        /// will not lead to re-execution of activation callbacks.
+        /// </summary>
+        public Task ActivateAsync()
+        {
+            var representativeState = GetRepresentation(State);
+            return representativeState.ActivateAsync();
+        }
+
+        /// <summary>
+        /// Deactivates current state in asynchronous fashion. Actions associated with deactivating the currrent state
+        /// will be invoked. The deactivation is idempotent and subsequent deactivation of the same current state 
+        /// will not lead to re-execution of deactivation callbacks.
+        /// </summary>
+        public Task DeactivateAsync()
+        {
+            var representativeState = GetRepresentation(State);
+            return representativeState.DeactivateAsync();
+        }
+
+        /// <summary>
         /// Transition from the current state via the specified trigger in async fashion.
         /// The target state is determined by the configuration of the current state.
         /// Actions associated with leaving the current state and entering the new one

--- a/Stateless/StateMachine.cs
+++ b/Stateless/StateMachine.cs
@@ -178,6 +178,28 @@ namespace Stateless
             InternalFire(trigger.Trigger, arg0, arg1, arg2);
         }
 
+        /// <summary>
+        /// Activates current state. Actions associated with activating the currrent state
+        /// will be invoked. The activation is idempotent and subsequent activation of the same current state 
+        /// will not lead to re-execution of activation callbacks.
+        /// </summary>
+        public void Activate()
+        {
+            var representativeState = GetRepresentation(State);
+            representativeState.Activate();
+        }
+
+        /// <summary>
+        /// Deactivates current state. Actions associated with deactivating the currrent state
+        /// will be invoked. The deactivation is idempotent and subsequent deactivation of the same current state 
+        /// will not lead to re-execution of deactivation callbacks.
+        /// </summary>
+        public void Deactivate()
+        {
+            var representativeState = GetRepresentation(State);
+            representativeState.Deactivate();
+        }
+
         void InternalFire(TTrigger trigger, params object[] args)
         {
             TriggerWithParameters configuration;


### PR DESCRIPTION
One more commit to make Stateless fully compatible with stateful single-threaded actors. 

In Orleans (and other actor frameworks, like Akka.Net), actors are activated by special event, like OnActivateAsync. At that moment previously persisted (in cold storage) state need to be reactivated, since actors are *active* entities. Current approach with specifying initial state via ctor doesn't cut for multiple reasons:

1. The most important - it doesn't enter state (and its superstates) and so OnEntry actions are not called
2. Even if it does - we don't have async ctors in C#

I did few changes to make that possible:

1. Added ability to activate state via special method - `Activate`/`ActivateAsync`. For that I've introduced special case transition `Activation` which doesn't trigger `OnTransitioned` but does trigger `OnEntry` for state and all of its superstates. Also, I've added check to ignore actions specifed via `OnEntry(Action<Transition>)` since its a special transition which doesn't make sense to intercept. Basically, only callbacks specified in parameterless `OnEntry` will run, which is completely inline with semantics of activation.
2. Added checks that state is actually intialized (either via ctor or `Activate`) before any kind of state access happens

In the end:

1. It's fully compatible with previous version. I've only made default ctor public.
2. There now 2 distinct but clear semantics - ctor is for initalizing machine without executing `OnEntry` callbacks defined for initial state (*passive mode*) and `Activate` will execute `OnEntry` callbacks for the given initial state (*active mode*)

Thanks!