### PR TITLE
Removed unneeded dependency NETStandard.Library for NET4x

### DIFF
--- a/src/Stateless/project.json
+++ b/src/Stateless/project.json
@@ -1,7 +1,6 @@
 {
   "version": "3.0.1-*",
   "dependencies": {
-    "NETStandard.Library": "1.6.0"
   },
   "packOptions": {
     "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
@@ -19,7 +18,10 @@
     "warningsAsErrors": true
   },
   "frameworks": {
-    "netstandard1.0": {      
+    "netstandard1.0": {
+      "dependencies": {
+        "NETStandard.Library": "1.6.0"
+      },
       "buildOptions": {
         "define": [ "PORTABLE_REFLECTION", "TASKS" ]
       }

--- a/src/Stateless/project.json
+++ b/src/Stateless/project.json
@@ -1,7 +1,5 @@
 {
   "version": "3.0.1-*",
-  "dependencies": {
-  },
   "packOptions": {
     "licenseUrl": "http://www.apache.org/licenses/LICENSE-2.0",
     "projectUrl": "https://github.com/dotnet-state-machine/stateless",
@@ -20,7 +18,7 @@
   "frameworks": {
     "netstandard1.0": {
       "dependencies": {
-        "NETStandard.Library": "1.6.0"
+        "NETStandard.Library": "1.6.1"
       },
       "buildOptions": {
         "define": [ "PORTABLE_REFLECTION", "TASKS" ]


### PR DESCRIPTION
As all the code is already in the framework (.NET 4.x is NETStandard 1.0 compatible) the dependency adds a lot of noise to .NET Framework projects. I didn't detect this right away, as System.Reactive made the same "mistake" but now corrected it with 3.1.1

See https://github.com/Reactive-Extensions/Rx.NET/commit/5f3ff8deb1ee6fa4434c76cb12fc91b3aa0cd426
for a similar change.

So here is a pull-request which removes the unneeded dependency.

This change didn't cause issues with dotnet restore / build, more tests were from my standpoint not needed as in the end the dependencies are not copied to the target directory (for NET4x).

I would event suggest to place this into master, and release a hotfix like System.Reactive did..

Keep up the good work!!!!