### PR TITLE
Fixed dialed/dialled typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 var phoneCall = new StateMachine<State, Trigger>(State.OffHook);
 
 phoneCall.Configure(State.OffHook)
-    .Permit(Trigger.CallDialed, State.Ringing);
+    .Permit(Trigger.CallDialled, State.Ringing);
 	
 phoneCall.Configure(State.Ringing)
     .Permit(Trigger.HungUp, State.OffHook)
@@ -140,7 +140,7 @@ It can be useful to visualize state machines on runtime. With this approach the 
  
 ```csharp
 phoneCall.Configure(State.OffHook)
-    .PermitIf(Trigger.CallDialed, State.Ringing, IsValidNumber);
+    .PermitIf(Trigger.CallDialled, State.Ringing, IsValidNumber);
     
 string graph = phoneCall.ToDotGraph();
 ```
@@ -149,7 +149,7 @@ The `StateMachine.ToDotGraph()` method returns a string representation of the st
 
 ```dot
 digraph {
-  OffHook -> Ringing [label="CallDialed [IsValidNumber]"];
+  OffHook -> Ringing [label="CallDialled [IsValidNumber]"];
 }
 ```
 


### PR DESCRIPTION
There where both versions of dialed/dialled in the README.md

I know its just a typo and a PR is probably a overhead but I thought why not fix it right away instead of creating an issue or ignoring it.

For an explanation on the correct writing of dialing/dialling see:
http://www.future-perfect.co.uk/grammar-tip/is-it-dialled-or-dialed/
I went for the british english version. However, if you decide to go for the american version, just make sure it is straight throughout the readme.md as there is a mix right now. :)