### PR TITLE
Added PCL target profile 259

### DIFF
--- a/src/Stateless/project.json
+++ b/src/Stateless/project.json
@@ -26,9 +26,17 @@
     },
     "net4.5": {
       "buildOptions": {
-        "define": ["TASKS"]
+        "define": [ "TASKS" ]
       }
     },
-    "net4.0": {}
+    "net4.0": {},
+    ".NETPortable,Version=4.5,Profile=Profile259": {
+      "dependencies": {
+        "NETStandard.Library": "1.6.1"
+      },
+      "buildOptions": {
+        "define": [ "PORTABLE_REFLECTION", "TASKS" ]
+      }
+    }
   }
 }


### PR DESCRIPTION
Added PCL target profile 259 like Stateless 2.5.x so that projects that are not completely caught up with .NETStandard can still use Stateless 3.x
