### PR TITLE
Added validation to `SubstateOf`

### DIFF
--- a/src/Stateless/StateConfiguration.cs
+++ b/src/Stateless/StateConfiguration.cs
@@ -453,6 +453,9 @@ namespace Stateless
             /// <returns>The receiver.</returns>
             public StateConfiguration SubstateOf(TState superstate)
             {
+                if(_representation.UnderlyingState.Equals(superstate)){ 
+                    throw new InvalidOperationException(string.Format("A given state cannot be defined as a substate of itself.  The problem state is {0}.", superstate));
+                }
                 var superRepresentation = _lookup(superstate);
                 _representation.Superstate = superRepresentation;
                 superRepresentation.AddSubstate(_representation);


### PR DESCRIPTION
Added validation against recursive substate definitions in SubstateOf.  Details of problem @ https://github.com/dotnet-state-machine/stateless/issues/121