### PR TITLE
Support InternalTransition for all TriggerWithParams

### DIFF
--- a/src/Stateless/StateConfiguration.Async.cs
+++ b/src/Stateless/StateConfiguration.Async.cs
@@ -73,6 +73,46 @@ namespace Stateless
             }
 
             /// <summary>
+            /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
+            /// </summary>
+            /// <typeparam name="TArg0"></typeparam>
+            /// <typeparam name="TArg1"></typeparam>
+            /// <param name="trigger">The accepted trigger</param>
+            /// <param name="internalAction">The asynchronous action performed by the internal transition</param>
+            /// <returns></returns>
+            public StateConfiguration InternalTransitionAsync<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Func<TArg0, TArg1, Transition, Task> internalAction)
+            {
+                if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
+
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger));
+                _representation.AddInternalAction(trigger.Trigger, (t, args) => internalAction(
+                    ParameterConversion.Unpack<TArg0>(args, 0),
+                    ParameterConversion.Unpack<TArg1>(args, 1), t));
+                return this;
+            }
+
+            /// <summary>
+            /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
+            /// </summary>
+            /// <typeparam name="TArg0"></typeparam>
+            /// <typeparam name="TArg1"></typeparam>
+            /// <typeparam name="TArg2"></typeparam>
+            /// <param name="trigger">The accepted trigger</param>
+            /// <param name="internalAction">The asynchronous action performed by the internal transition</param>
+            /// <returns></returns>
+            public StateConfiguration InternalTransitionAsync<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Func<TArg0, TArg1, TArg2, Transition, Task> internalAction)
+            {
+                if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
+
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger));
+                _representation.AddInternalAction(trigger.Trigger, (t, args) => internalAction(
+                    ParameterConversion.Unpack<TArg0>(args, 0),
+                    ParameterConversion.Unpack<TArg1>(args, 1),
+                    ParameterConversion.Unpack<TArg2>(args, 2), t));
+                return this;
+            }
+
+            /// <summary>
             /// Specify an asynchronous action that will execute when activating
             /// the configured state.
             /// </summary>

--- a/src/Stateless/StateConfiguration.cs
+++ b/src/Stateless/StateConfiguration.cs
@@ -106,6 +106,47 @@ namespace Stateless
                 _representation.AddInternalAction(trigger.Trigger, (t, args) => internalAction(ParameterConversion.Unpack<TArg0>(args, 0), t));
                 return this;
             }
+
+            /// <summary>
+            /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
+            /// </summary>
+            /// <typeparam name="TArg0"></typeparam>
+            /// <typeparam name="TArg1"></typeparam>
+            /// <param name="trigger">The accepted trigger</param>
+            /// <param name="internalAction">The action performed by the internal transition</param>
+            /// <returns></returns>
+            public StateConfiguration InternalTransition<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Action<TArg0, TArg1, Transition> internalAction)
+            {
+                if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
+
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger));
+                _representation.AddInternalAction(trigger.Trigger, (t, args) => internalAction(
+                    ParameterConversion.Unpack<TArg0>(args, 0),
+                    ParameterConversion.Unpack<TArg1>(args, 1), t));
+                return this;
+            }
+
+            /// <summary>
+            /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
+            /// </summary>
+            /// <typeparam name="TArg0"></typeparam>
+            /// <typeparam name="TArg1"></typeparam>
+            /// <typeparam name="TArg2"></typeparam>
+            /// <param name="trigger">The accepted trigger</param>
+            /// <param name="internalAction">The action performed by the internal transition</param>
+            /// <returns></returns>
+            public StateConfiguration InternalTransition<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Action<TArg0, TArg1, TArg2, Transition> internalAction)
+            {
+                if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
+
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger));
+                _representation.AddInternalAction(trigger.Trigger, (t, args) => internalAction(
+                    ParameterConversion.Unpack<TArg0>(args, 0),
+                    ParameterConversion.Unpack<TArg1>(args, 1),
+                    ParameterConversion.Unpack<TArg2>(args, 2), t));
+                return this;
+            }
+
             /// <summary>
             /// Accept the specified trigger and transition to the destination state.
             /// </summary>

--- a/test/Stateless.Tests/InternalTransitionFixture.cs
+++ b/test/Stateless.Tests/InternalTransitionFixture.cs
@@ -157,5 +157,43 @@ namespace Stateless.Tests
             sm.Fire(Trigger.Y);
             Assert.AreEqual(State.B, sm.State);
         }
+
+        [Test]
+        public void AllowTriggerWithTwoParameters()
+        {
+            var sm = new StateMachine<State, Trigger>(State.B);
+            var trigger = sm.SetTriggerParameters<int, string>(Trigger.X);
+            const int intParam = 5;
+            const string strParam = "Five";
+
+            sm.Configure(State.B)
+                .InternalTransition(trigger, (i, s, transition) =>
+                {
+                    Assert.That(i, Is.EqualTo(intParam));
+                    Assert.That(s, Is.EqualTo(strParam));
+                });
+
+            sm.Fire(trigger, intParam, strParam);
+        }
+
+        [Test]
+        public void AllowTriggerWithThreeParameters()
+        {
+            var sm = new StateMachine<State, Trigger>(State.B);
+            var trigger = sm.SetTriggerParameters<int, string, bool>(Trigger.X);
+            const int intParam = 5;
+            const string strParam = "Five";
+            var boolParam = true;
+
+            sm.Configure(State.B)
+                .InternalTransition(trigger, (i, s, b, transition) =>
+                {
+                    Assert.That(i, Is.EqualTo(intParam));
+                    Assert.That(s, Is.EqualTo(strParam));
+                    Assert.That(b, Is.EqualTo(boolParam));
+                });
+
+            sm.Fire(trigger, intParam, strParam, boolParam);
+        }
     }
 }

--- a/test/Stateless.Tests/InternalTransitionFixture.cs
+++ b/test/Stateless.Tests/InternalTransitionFixture.cs
@@ -165,15 +165,18 @@ namespace Stateless.Tests
             var trigger = sm.SetTriggerParameters<int, string>(Trigger.X);
             const int intParam = 5;
             const string strParam = "Five";
+            var callbackInvoked = false;
 
             sm.Configure(State.B)
                 .InternalTransition(trigger, (i, s, transition) =>
                 {
+                    callbackInvoked = true;
                     Assert.That(i, Is.EqualTo(intParam));
                     Assert.That(s, Is.EqualTo(strParam));
                 });
 
             sm.Fire(trigger, intParam, strParam);
+            Assert.That(callbackInvoked, Is.True);
         }
 
         [Test]
@@ -184,16 +187,19 @@ namespace Stateless.Tests
             const int intParam = 5;
             const string strParam = "Five";
             var boolParam = true;
+            var callbackInvoked = false;
 
             sm.Configure(State.B)
                 .InternalTransition(trigger, (i, s, b, transition) =>
                 {
+                    callbackInvoked = true;
                     Assert.That(i, Is.EqualTo(intParam));
                     Assert.That(s, Is.EqualTo(strParam));
                     Assert.That(b, Is.EqualTo(boolParam));
                 });
 
             sm.Fire(trigger, intParam, strParam, boolParam);
+            Assert.That(callbackInvoked, Is.True);
         }
     }
 }


### PR DESCRIPTION
This fixes #129 by adding support for internal transition for `TriggerWithParameters` that have up to three generic args.