### PR TITLE
Replace magic string usages with nameof()

### DIFF
--- a/src/Stateless/ParameterConversion.cs
+++ b/src/Stateless/ParameterConversion.cs
@@ -6,7 +6,7 @@ namespace Stateless
     {
         public static object Unpack(object[] args, Type argType, int index)
         {
-            Enforce.ArgumentNotNull(args, "args");
+            Enforce.ArgumentNotNull(args, nameof(args));
 
             if (args.Length <= index)
                 throw new ArgumentException(

--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -58,7 +58,7 @@ namespace Stateless
         /// not allow the trigger to be fired.</exception>
         public Task FireAsync<TArg0>(TriggerWithParameters<TArg0> trigger, TArg0 arg0)
         {
-            Enforce.ArgumentNotNull(trigger, "trigger");
+            Enforce.ArgumentNotNull(trigger, nameof(trigger));
             return InternalFireAsync(trigger.Trigger, arg0);
         }
 
@@ -77,7 +77,7 @@ namespace Stateless
         /// not allow the trigger to be fired.</exception>
         public Task FireAsync<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, TArg0 arg0, TArg1 arg1)
         {
-            Enforce.ArgumentNotNull(trigger, "trigger");
+            Enforce.ArgumentNotNull(trigger, nameof(trigger));
             return InternalFireAsync(trigger.Trigger, arg0, arg1);
         }
 
@@ -98,7 +98,7 @@ namespace Stateless
         /// not allow the trigger to be fired.</exception>
         public Task FireAsync<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, TArg0 arg0, TArg1 arg1, TArg2 arg2)
         {
-            Enforce.ArgumentNotNull(trigger, "trigger");
+            Enforce.ArgumentNotNull(trigger, nameof(trigger));
             return InternalFireAsync(trigger.Trigger, arg0, arg1, arg2);
         }
 

--- a/src/Stateless/StateRepresentation.Async.cs
+++ b/src/Stateless/StateRepresentation.Async.cs
@@ -61,7 +61,7 @@ namespace Stateless
 
             internal void AddInternalAction(TTrigger trigger, Func<Transition, object[], Task> action)
             {
-                Enforce.ArgumentNotNull(action, "action");
+                Enforce.ArgumentNotNull(action, nameof(action));
 
                 _internalActions.Add(new InternalActionBehaviour.Async((t, args) =>
                 {
@@ -182,7 +182,7 @@ namespace Stateless
 
             internal Task InternalActionAsync(Transition transition, object[] args)
             {
-                Enforce.ArgumentNotNull(transition, "transition");
+                Enforce.ArgumentNotNull(transition, nameof(transition));
                 return ExecuteInternalActionsAsync(transition, args);
             }
         }


### PR DESCRIPTION
Nothing special, just use of nameof() for all Enforce.ArgumentNotNull calls