### PR TITLE
Replace magic string usages with nameof()

### DIFF
--- a/src/Stateless/DynamicTriggerBehaviour.cs
+++ b/src/Stateless/DynamicTriggerBehaviour.cs
@@ -14,7 +14,7 @@ namespace Stateless
             public DynamicTriggerBehaviour(TTrigger trigger, Func<object[], TState> destination, TransitionGuard transitionGuard)
                 : base(trigger, transitionGuard)
             {
-                _destination = Enforce.ArgumentNotNull(destination, "destination");
+                _destination = Enforce.ArgumentNotNull(destination, nameof(destination));
             }
 
             public override bool ResultsInTransitionFrom(TState source, object[] args, out TState destination)

--- a/src/Stateless/ParameterConversion.cs
+++ b/src/Stateless/ParameterConversion.cs
@@ -6,7 +6,7 @@ namespace Stateless
     {
         public static object Unpack(object[] args, Type argType, int index)
         {
-            Enforce.ArgumentNotNull(args, "args");
+            Enforce.ArgumentNotNull(args, nameof(args));
 
             if (args.Length <= index)
                 throw new ArgumentException(

--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -58,7 +58,7 @@ namespace Stateless
         /// not allow the trigger to be fired.</exception>
         public Task FireAsync<TArg0>(TriggerWithParameters<TArg0> trigger, TArg0 arg0)
         {
-            Enforce.ArgumentNotNull(trigger, "trigger");
+            Enforce.ArgumentNotNull(trigger, nameof(trigger));
             return InternalFireAsync(trigger.Trigger, arg0);
         }
 
@@ -77,7 +77,7 @@ namespace Stateless
         /// not allow the trigger to be fired.</exception>
         public Task FireAsync<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, TArg0 arg0, TArg1 arg1)
         {
-            Enforce.ArgumentNotNull(trigger, "trigger");
+            Enforce.ArgumentNotNull(trigger, nameof(trigger));
             return InternalFireAsync(trigger.Trigger, arg0, arg1);
         }
 
@@ -98,7 +98,7 @@ namespace Stateless
         /// not allow the trigger to be fired.</exception>
         public Task FireAsync<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, TArg0 arg0, TArg1 arg1, TArg2 arg2)
         {
-            Enforce.ArgumentNotNull(trigger, "trigger");
+            Enforce.ArgumentNotNull(trigger, nameof(trigger));
             return InternalFireAsync(trigger.Trigger, arg0, arg1, arg2);
         }
 

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -34,8 +34,8 @@ namespace Stateless
         /// <param name="stateMutator">An action that will be called to write new state values.</param>
         public StateMachine(Func<TState> stateAccessor, Action<TState> stateMutator) : this()
         {
-            _stateAccessor = Enforce.ArgumentNotNull(stateAccessor, "stateAccessor");
-            _stateMutator = Enforce.ArgumentNotNull(stateMutator, "stateMutator");
+            _stateAccessor = Enforce.ArgumentNotNull(stateAccessor, nameof(stateAccessor));
+            _stateMutator = Enforce.ArgumentNotNull(stateMutator, nameof(stateMutator));
         }
 
         /// <summary>
@@ -143,7 +143,7 @@ namespace Stateless
         /// not allow the trigger to be fired.</exception>
         public void Fire<TArg0>(TriggerWithParameters<TArg0> trigger, TArg0 arg0)
         {
-            Enforce.ArgumentNotNull(trigger, "trigger");
+            Enforce.ArgumentNotNull(trigger, nameof(trigger));
             InternalFire(trigger.Trigger, arg0);
         }
 
@@ -162,7 +162,7 @@ namespace Stateless
         /// not allow the trigger to be fired.</exception>
         public void Fire<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, TArg0 arg0, TArg1 arg1)
         {
-            Enforce.ArgumentNotNull(trigger, "trigger");
+            Enforce.ArgumentNotNull(trigger, nameof(trigger));
             InternalFire(trigger.Trigger, arg0, arg1);
         }
 
@@ -183,7 +183,7 @@ namespace Stateless
         /// not allow the trigger to be fired.</exception>
         public void Fire<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, TArg0 arg0, TArg1 arg1, TArg2 arg2)
         {
-            Enforce.ArgumentNotNull(trigger, "trigger");
+            Enforce.ArgumentNotNull(trigger, nameof(trigger));
             InternalFire(trigger.Trigger, arg0, arg1, arg2);
         }
 

--- a/src/Stateless/StateRepresentation.Async.cs
+++ b/src/Stateless/StateRepresentation.Async.cs
@@ -61,7 +61,7 @@ namespace Stateless
 
             internal void AddInternalAction(TTrigger trigger, Func<Transition, object[], Task> action)
             {
-                Enforce.ArgumentNotNull(action, "action");
+                Enforce.ArgumentNotNull(action, nameof(action));
 
                 _internalActions.Add(new InternalActionBehaviour.Async((t, args) =>
                 {
@@ -182,7 +182,7 @@ namespace Stateless
 
             internal Task InternalActionAsync(Transition transition, object[] args)
             {
-                Enforce.ArgumentNotNull(transition, "transition");
+                Enforce.ArgumentNotNull(transition, nameof(transition));
                 return ExecuteInternalActionsAsync(transition, args);
             }
         }

--- a/src/Stateless/StateRepresentation.cs
+++ b/src/Stateless/StateRepresentation.cs
@@ -128,7 +128,7 @@ namespace Stateless
 
             internal void AddInternalAction(TTrigger trigger, Action<Transition, object[]> action)
             {
-                Enforce.ArgumentNotNull(action, "action");
+                Enforce.ArgumentNotNull(action, nameof(action));
 
                 _internalActions.Add(new InternalActionBehaviour.Sync((t, args) =>
                 {
@@ -311,7 +311,7 @@ namespace Stateless
 
             internal void InternalAction(Transition transition, object[] args)
             {
-                Enforce.ArgumentNotNull(transition, "transition");
+                Enforce.ArgumentNotNull(transition, nameof(transition));
                 ExecuteInternalActions(transition, args);
             }
         }

--- a/src/Stateless/TriggerWithParameters.cs
+++ b/src/Stateless/TriggerWithParameters.cs
@@ -22,7 +22,7 @@ namespace Stateless
             /// <param name="argumentTypes">The argument types expected by the trigger.</param>
             public TriggerWithParameters(TTrigger underlyingTrigger, params Type[] argumentTypes)
             {
-                Enforce.ArgumentNotNull(argumentTypes, "argumentTypes");
+                Enforce.ArgumentNotNull(argumentTypes, nameof(argumentTypes));
 
                 _underlyingTrigger = underlyingTrigger;
                 _argumentTypes = argumentTypes;
@@ -40,7 +40,7 @@ namespace Stateless
             /// <param name="args"></param>
             public void ValidateParameters(object[] args)
             {
-                Enforce.ArgumentNotNull(args, "args");
+                Enforce.ArgumentNotNull(args, nameof(args));
 
                 ParameterConversion.Validate(args, _argumentTypes);
             }


### PR DESCRIPTION
Nothing significant, just all nameof() for all Enforce.ArgumentNotNull calls.
