### PR TITLE
Add options to triggers

### DIFF
--- a/src/Stateless/StateConfiguration.Async.cs
+++ b/src/Stateless/StateConfiguration.Async.cs
@@ -24,8 +24,8 @@ namespace Stateless
             {
                 if (entryAction == null) throw new ArgumentNullException(nameof(entryAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, guard));
-                _representation.AddInternalAction(trigger, (t, args) => entryAction(t));
+                Representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, guard));
+                Representation.AddInternalAction(trigger, (t, args) => entryAction(t));
                 return this;
             }
 
@@ -40,8 +40,8 @@ namespace Stateless
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, guard));
-                _representation.AddInternalAction(trigger, (t, args) => internalAction());
+                Representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, guard));
+                Representation.AddInternalAction(trigger, (t, args) => internalAction());
                 return this;
             }
 
@@ -57,8 +57,8 @@ namespace Stateless
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, guard));
-                _representation.AddInternalAction(trigger, (t, args) => internalAction(t));
+                Representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, guard));
+                Representation.AddInternalAction(trigger, (t, args) => internalAction(t));
                 return this;
             }
 
@@ -74,8 +74,8 @@ namespace Stateless
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, guard));
-                _representation.AddInternalAction(trigger.Trigger, (t, args) => internalAction(ParameterConversion.Unpack<TArg0>(args, 0), t));
+                Representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, guard));
+                Representation.AddInternalAction(trigger.Trigger, (t, args) => internalAction(ParameterConversion.Unpack<TArg0>(args, 0), t));
                 return this;
             }
 
@@ -92,8 +92,8 @@ namespace Stateless
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, guard));
-                _representation.AddInternalAction(trigger.Trigger, (t, args) => internalAction(
+                Representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, guard));
+                Representation.AddInternalAction(trigger.Trigger, (t, args) => internalAction(
                     ParameterConversion.Unpack<TArg0>(args, 0),
                     ParameterConversion.Unpack<TArg1>(args, 1), t));
                 return this;
@@ -113,8 +113,8 @@ namespace Stateless
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, guard));
-                _representation.AddInternalAction(trigger.Trigger, (t, args) => internalAction(
+                Representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, guard));
+                Representation.AddInternalAction(trigger.Trigger, (t, args) => internalAction(
                     ParameterConversion.Unpack<TArg0>(args, 0),
                     ParameterConversion.Unpack<TArg1>(args, 1),
                     ParameterConversion.Unpack<TArg2>(args, 2), t));
@@ -202,7 +202,7 @@ namespace Stateless
             public StateConfiguration OnActivateAsync(Func<Task> activateAction, string activateActionDescription = null)
             {
                 Enforce.ArgumentNotNull(activateAction, nameof(activateAction));
-                _representation.AddActivateAction(
+                Representation.AddActivateAction(
                     activateAction,
                     Reflection.InvocationInfo.Create(activateAction, activateActionDescription, Reflection.InvocationInfo.Timing.Asynchronous));
                 return this;
@@ -218,7 +218,7 @@ namespace Stateless
             public StateConfiguration OnDeactivateAsync(Func<Task> deactivateAction, string deactivateActionDescription = null)
             {
                 Enforce.ArgumentNotNull(deactivateAction, nameof(deactivateAction));
-                _representation.AddDeactivateAction(
+                Representation.AddDeactivateAction(
                     deactivateAction,
                     Reflection.InvocationInfo.Create(deactivateAction, deactivateActionDescription, Reflection.InvocationInfo.Timing.Asynchronous));
                 return this;
@@ -234,7 +234,7 @@ namespace Stateless
             public StateConfiguration OnEntryAsync(Func<Task> entryAction, string entryActionDescription = null)
             {
                 Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
-                _representation.AddEntryAction(
+                Representation.AddEntryAction(
                     (t, args) => entryAction(),
                     Reflection.InvocationInfo.Create(entryAction, entryActionDescription, Reflection.InvocationInfo.Timing.Asynchronous));
                 return this;
@@ -251,7 +251,7 @@ namespace Stateless
             public StateConfiguration OnEntryAsync(Func<Transition, Task> entryAction, string entryActionDescription = null)
             {
                 Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
-                _representation.AddEntryAction(
+                Representation.AddEntryAction(
                     (t, args) => entryAction(t),
                     Reflection.InvocationInfo.Create(entryAction, entryActionDescription, Reflection.InvocationInfo.Timing.Asynchronous));
                 return this;
@@ -268,7 +268,7 @@ namespace Stateless
             public StateConfiguration OnEntryFromAsync(TTrigger trigger, Func<Task> entryAction, string entryActionDescription = null)
             {
                 Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
-                _representation.AddEntryAction(
+                Representation.AddEntryAction(
                     trigger,
                     (t, args) => entryAction(),
                     Reflection.InvocationInfo.Create(entryAction, entryActionDescription, Reflection.InvocationInfo.Timing.Asynchronous));
@@ -286,7 +286,7 @@ namespace Stateless
             public StateConfiguration OnEntryFromAsync(TTrigger trigger, Func<Transition, Task> entryAction, string entryActionDescription = null)
             {
                 Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
-                _representation.AddEntryAction(
+                Representation.AddEntryAction(
                     trigger,
                     (t, args) => entryAction(t),
                     Reflection.InvocationInfo.Create(entryAction, entryActionDescription, Reflection.InvocationInfo.Timing.Asynchronous));
@@ -306,7 +306,7 @@ namespace Stateless
             {
                 Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
                 Enforce.ArgumentNotNull(trigger, nameof(trigger));
-                _representation.AddEntryAction(
+                Representation.AddEntryAction(
                     trigger.Trigger,
                     (t, args) => entryAction(
                         ParameterConversion.Unpack<TArg0>(args, 0)),
@@ -327,7 +327,7 @@ namespace Stateless
             {
                 Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
                 Enforce.ArgumentNotNull(trigger, nameof(trigger));
-                _representation.AddEntryAction(
+                Representation.AddEntryAction(
                     trigger.Trigger,
                     (t, args) => entryAction(
                         ParameterConversion.Unpack<TArg0>(args, 0), t),
@@ -349,7 +349,7 @@ namespace Stateless
             {
                 Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
                 Enforce.ArgumentNotNull(trigger, nameof(trigger));
-                _representation.AddEntryAction(trigger.Trigger,
+                Representation.AddEntryAction(trigger.Trigger,
                     (t, args) => entryAction(
                         ParameterConversion.Unpack<TArg0>(args, 0),
                         ParameterConversion.Unpack<TArg1>(args, 1)),
@@ -371,7 +371,7 @@ namespace Stateless
             {
                 Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
                 Enforce.ArgumentNotNull(trigger, nameof(trigger));
-                _representation.AddEntryAction(trigger.Trigger,
+                Representation.AddEntryAction(trigger.Trigger,
                     (t, args) => entryAction(
                         ParameterConversion.Unpack<TArg0>(args, 0),
                         ParameterConversion.Unpack<TArg1>(args, 1), t),
@@ -394,7 +394,7 @@ namespace Stateless
             {
                 Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
                 Enforce.ArgumentNotNull(trigger, nameof(trigger));
-                _representation.AddEntryAction(trigger.Trigger,
+                Representation.AddEntryAction(trigger.Trigger,
                     (t, args) => entryAction(
                         ParameterConversion.Unpack<TArg0>(args, 0),
                         ParameterConversion.Unpack<TArg1>(args, 1),
@@ -418,7 +418,7 @@ namespace Stateless
             {
                 Enforce.ArgumentNotNull(entryAction, nameof(entryAction));
                 Enforce.ArgumentNotNull(trigger, nameof(trigger));
-                _representation.AddEntryAction(trigger.Trigger,
+                Representation.AddEntryAction(trigger.Trigger,
                     (t, args) => entryAction(
                         ParameterConversion.Unpack<TArg0>(args, 0),
                         ParameterConversion.Unpack<TArg1>(args, 1),
@@ -437,7 +437,7 @@ namespace Stateless
             public StateConfiguration OnExitAsync(Func<Task> exitAction, string exitActionDescription = null)
             {
                 Enforce.ArgumentNotNull(exitAction, nameof(exitAction));
-                _representation.AddExitAction(
+                Representation.AddExitAction(
                     t => exitAction(),
                     Reflection.InvocationInfo.Create(exitAction, exitActionDescription, Reflection.InvocationInfo.Timing.Asynchronous));
                 return this;
@@ -453,7 +453,7 @@ namespace Stateless
             public StateConfiguration OnExitAsync(Func<Transition, Task> exitAction, string exitActionDescription = null)
             {
                 Enforce.ArgumentNotNull(exitAction, nameof(exitAction));
-                _representation.AddExitAction(
+                Representation.AddExitAction(
                     exitAction,
                     Reflection.InvocationInfo.Create(exitAction, exitActionDescription, Reflection.InvocationInfo.Timing.Asynchronous));
                 return this;

--- a/src/Stateless/StateConfiguration.cs
+++ b/src/Stateless/StateConfiguration.cs
@@ -718,6 +718,29 @@ namespace Stateless
             }
 
             /// <summary>
+            /// Specify an action that will execute when transitioning from
+            /// the configured state.
+            /// </summary>
+            /// <param name="trigger">The trigger by which the state must be exited in order for the action to execute.</param>
+            /// <param name="exitAction">Action to execute.</param>
+            /// <param name="exitActionDescription">Action description.</param>
+            /// <returns>The receiver.</returns>
+            public StateConfiguration OnExitFrom(TTrigger trigger, Action exitAction, string exitActionDescription = null)
+            {
+                Enforce.ArgumentNotNull(exitAction, nameof(exitAction));
+
+                // Downside of doing it this way: the reflection API won't be able to tell
+                // that this action is only performed for the specific trigger
+
+                _representation.AddExitAction(
+                    (t) => { if (t.Trigger.Equals(trigger)) exitAction(); },
+                    Reflection.InvocationInfo.Create(exitAction, exitActionDescription));
+                return this;
+
+            }
+
+
+            /// <summary>
             /// Sets the superstate that the configured state is a substate of.
             /// </summary>
             /// <remarks>

--- a/src/Stateless/StateConfiguration.cs
+++ b/src/Stateless/StateConfiguration.cs
@@ -48,6 +48,30 @@ namespace Stateless
             }
 
             /// <summary>
+            /// Accept the specified trigger and transition to the destination state, executing
+            /// the specified action.
+            /// </summary>
+            /// <param name="trigger">The accepted trigger.</param>
+            /// <param name="destinationState">The state that the trigger will cause a
+            /// transition to.</param>
+            /// <param name="triggerAction">Action to execute when the trigger is fired.</param>
+            /// <param name="triggerActionDescription">Action description.</param>
+            /// <returns>The reciever.</returns>
+            public StateConfiguration Permit(TTrigger trigger, TState destinationState, Action triggerAction, string triggerActionDescription = null)
+            {
+                EnforceNotIdentityTransition(destinationState);
+                if (triggerAction == null) throw new ArgumentNullException(nameof(triggerAction));
+                _representation.AddTriggerBehaviour(
+                    new TransitioningTriggerBehaviour(
+                        trigger,
+                        destinationState,
+                        null,               // No guard function
+                        triggerAction,
+                        Reflection.InvocationInfo.Create(triggerAction, triggerActionDescription)));
+                return this;
+            }
+
+            /// <summary>
             /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
             /// </summary>
             /// <param name="trigger"></param>
@@ -239,7 +263,8 @@ namespace Stateless
             /// trigger to be accepted.</param>
             /// <param name="guardDescription">Guard description</param>
             /// <returns>The reciever.</returns>
-            public StateConfiguration PermitIf(TTrigger trigger, TState destinationState, Func<bool> guard, string guardDescription = null)
+            public StateConfiguration PermitIf(TTrigger trigger, TState destinationState,
+                Func<bool> guard, string guardDescription = null)
             {
                 EnforceNotIdentityTransition(destinationState);
 
@@ -247,6 +272,53 @@ namespace Stateless
                     trigger,
                     destinationState,
                     new TransitionGuard(guard, guardDescription));
+            }
+            /// <summary>
+            /// Accept the specified trigger and transition to the destination state.
+            /// </summary>
+            /// <param name="trigger">The accepted trigger.</param>
+            /// <param name="destinationState">The state that the trigger will cause a
+            /// transition to.</param>
+            /// <param name="guard">Function that must return true in order for the
+            /// trigger to be accepted.</param>
+            /// <param name="guardDescription">Guard description</param>
+            /// <param name="triggerAction">Action to execute when the trigger is fired.</param>
+            /// <param name="triggerActionDescription">Action description.</param>
+            /// <returns>The reciever.</returns>
+            public StateConfiguration PermitIf(TTrigger trigger, TState destinationState,
+                Func<bool> guard, string guardDescription,
+                Action triggerAction, string triggerActionDescription = null)
+            {
+                EnforceNotIdentityTransition(destinationState);
+                if (triggerAction == null) throw new ArgumentNullException(nameof(triggerAction));
+
+                _representation.AddTriggerBehaviour(
+                    new TransitioningTriggerBehaviour(
+                        trigger,
+                        destinationState,
+                        new TransitionGuard(guard, guardDescription),
+                        triggerAction,
+                        Reflection.InvocationInfo.Create(triggerAction, triggerActionDescription)
+                        )
+                    );
+                return this;
+            }
+            /// <summary>
+            /// Accept the specified trigger and transition to the destination state.
+            /// </summary>
+            /// <param name="trigger">The accepted trigger.</param>
+            /// <param name="destinationState">The state that the trigger will cause a
+            /// transition to.</param>
+            /// <param name="guard">Function that must return true in order for the
+            /// trigger to be accepted.</param>
+            /// <param name="triggerAction">Action to execute when the trigger is fired.</param>
+            /// <param name="triggerActionDescription">Action description.</param>
+            /// <returns>The reciever.</returns>
+            public StateConfiguration PermitIf(TTrigger trigger, TState destinationState,
+                Func<bool> guard, 
+                Action triggerAction, string triggerActionDescription = null)
+            {
+                return PermitIf(trigger, destinationState, guard, null, triggerAction, triggerActionDescription);
             }
             /// <summary>
             /// Accept the specified trigger and transition to the destination state.

--- a/src/Stateless/StateConfiguration.cs
+++ b/src/Stateless/StateConfiguration.cs
@@ -725,7 +725,7 @@ namespace Stateless
             /// <param name="exitAction">Action to execute.</param>
             /// <param name="exitActionDescription">Action description.</param>
             /// <returns>The receiver.</returns>
-            public StateConfiguration OnExitFrom(TTrigger trigger, Action exitAction, string exitActionDescription = null)
+            public StateConfiguration OnExitBy(TTrigger trigger, Action exitAction, string exitActionDescription = null)
             {
                 Enforce.ArgumentNotNull(exitAction, nameof(exitAction));
 

--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -148,10 +148,12 @@ namespace Stateless
                 return;
             }
 
+            TransitioningTriggerBehaviour ttb = result.Handler as TransitioningTriggerBehaviour;
+
             TState destination;
             if (result.Handler.ResultsInTransitionFrom(source, args, out destination))
             {
-                var transition = new Transition(source, destination, trigger);
+                var transition = new Transition(source, destination, trigger, ttb?.Tag);
 
                 await representativeState.ExitAsync(transition);
 
@@ -163,7 +165,7 @@ namespace Stateless
             }
             else
             {
-                var transition = new Transition(source, destination, trigger);
+                var transition = new Transition(source, destination, trigger, ttb?.Tag);
 
                 await CurrentRepresentation.InternalActionAsync(transition, args);
             }

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -286,6 +286,8 @@ namespace Stateless
             TState destination;
             if (result.Handler.ResultsInTransitionFrom(source, args, out destination))
             {
+                result.Handler.IsFiring();
+
                 var transition = new Transition(source, destination, trigger);
 
                 representativeState.Exit(transition);

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -283,12 +283,14 @@ namespace Stateless
                 return;
             }
 
+            TransitioningTriggerBehaviour ttb = result.Handler as TransitioningTriggerBehaviour;
+
             TState destination;
             if (result.Handler.ResultsInTransitionFrom(source, args, out destination))
             {
                 result.Handler.IsFiring();
 
-                var transition = new Transition(source, destination, trigger);
+                var transition = new Transition(source, destination, trigger, ttb?.Tag);
 
                 representativeState.Exit(transition);
 
@@ -300,7 +302,7 @@ namespace Stateless
             }
             else
             {
-                var transition = new Transition(source, destination, trigger);
+                var transition = new Transition(source, destination, trigger, ttb?.Tag);
 
                 CurrentRepresentation.InternalAction(transition, args);
             }

--- a/src/Stateless/Transition.cs
+++ b/src/Stateless/Transition.cs
@@ -15,6 +15,7 @@ namespace Stateless
             readonly TState _source;
             readonly TState _destination;
             readonly TTrigger _trigger;
+            readonly object _tag;
 
             /// <summary>
             /// Construct a transition.
@@ -22,11 +23,13 @@ namespace Stateless
             /// <param name="source">The state transitioned from.</param>
             /// <param name="destination">The state transitioned to.</param>
             /// <param name="trigger">The trigger that caused the transition.</param>
-            public Transition(TState source, TState destination, TTrigger trigger)
+            /// <param name="tag">Optional data associated with the transition.</param>
+            public Transition(TState source, TState destination, TTrigger trigger, object tag = null)
             {
                 _source = source;
                 _destination = destination;
                 _trigger = trigger;
+                _tag = tag;
             }
 
             /// <summary>
@@ -43,6 +46,11 @@ namespace Stateless
             /// The trigger that caused the transition.
             /// </summary>
             public TTrigger Trigger { get { return _trigger; } }
+
+            /// <summary>
+            /// Optional data associated with the transition.
+            /// </summary>
+            public object Tag { get { return _tag; } }
 
             /// <summary>
             /// True if the transition is a re-entry, i.e. the identity transition.

--- a/src/Stateless/TransitioningTriggerBehaviour.cs
+++ b/src/Stateless/TransitioningTriggerBehaviour.cs
@@ -10,6 +10,8 @@ namespace Stateless
         internal class TransitioningTriggerBehaviour : TriggerBehaviour
         {
             readonly TState _destination;
+            readonly Action _triggerAction = null;
+            readonly Reflection.InvocationInfo _triggerActionInfo = null;
 
             internal TState Destination { get { return _destination; } }
 
@@ -20,10 +22,25 @@ namespace Stateless
                 _destination = destination;
             }
 
+            public TransitioningTriggerBehaviour(TTrigger trigger, TState destination, TransitionGuard transitionGuard,
+                Action action, Reflection.InvocationInfo invocationInfo)
+                : base(trigger, transitionGuard)
+            {
+                _destination = destination;
+                _triggerAction = action;
+                _triggerActionInfo = invocationInfo;
+            }
+
             public override bool ResultsInTransitionFrom(TState source, object[] args, out TState destination)
             {
                 destination = _destination;
                 return true;
+            }
+
+            public override void IsFiring()
+            {
+                if (_triggerAction != null)
+                    _triggerAction();
             }
         }
     }

--- a/src/Stateless/TransitioningTriggerBehaviour.cs
+++ b/src/Stateless/TransitioningTriggerBehaviour.cs
@@ -10,8 +10,10 @@ namespace Stateless
         internal class TransitioningTriggerBehaviour : TriggerBehaviour
         {
             readonly TState _destination;
-            readonly Action _triggerAction = null;
-            readonly Reflection.InvocationInfo _triggerActionInfo = null;
+            Action _triggerAction = null;
+            Reflection.InvocationInfo _triggerActionInfo = null;
+
+            public object Tag { get; internal set; } = null;
 
             internal TState Destination { get { return _destination; } }
 
@@ -29,6 +31,12 @@ namespace Stateless
                 _destination = destination;
                 _triggerAction = action;
                 _triggerActionInfo = invocationInfo;
+            }
+
+            public void SetAction(Action action, Reflection.InvocationInfo info)
+            {
+                _triggerAction = action;
+                _triggerActionInfo = info;
             }
 
             public override bool ResultsInTransitionFrom(TState source, object[] args, out TState destination)

--- a/src/Stateless/TriggerBehaviour.cs
+++ b/src/Stateless/TriggerBehaviour.cs
@@ -10,18 +10,13 @@ namespace Stateless
         internal abstract class TriggerBehaviour
         {
             /// <summary>
-            /// If there is no guard function, _guard is set to TransitionGuard.Empty
-            /// </summary>
-            readonly TransitionGuard _guard;
-
-            /// <summary>
             /// TriggerBehaviour constructor
             /// </summary>
             /// <param name="trigger"></param>
             /// <param name="guard">TransitionGuard (null if no guard function)</param>
             protected TriggerBehaviour(TTrigger trigger, TransitionGuard guard)
             {
-                _guard = guard ?? TransitionGuard.Empty;
+                Guard = guard ?? TransitionGuard.Empty;
                 Trigger = trigger;
             }
 
@@ -31,24 +26,24 @@ namespace Stateless
             /// Guard is the transition guard for this trigger.  Equal to
             /// TransitionGuard.Empty if there is no transition guard
             /// </summary>
-            internal TransitionGuard Guard => _guard;
+            internal TransitionGuard Guard { get; set; }
 
             /// <summary>
             /// Guards is the list of guard functions for the transition guard for this trigger
             /// </summary>
-            internal ICollection<Func<bool>> Guards =>_guard.Guards;
+            internal ICollection<Func<bool>> Guards => Guard.Guards;
 
             /// <summary>
             /// GuardConditionsMet is true if all of the guard functions return true
             /// or if there are no guard functions
             /// </summary>
-            public bool GuardConditionsMet => _guard.GuardConditionsMet;
+            public bool GuardConditionsMet => Guard.GuardConditionsMet;
 
             /// <summary>
             /// UnmetGuardConditions is a list of the descriptions of all guard conditions
             /// whose guard function returns false
             /// </summary>
-            public ICollection<string> UnmetGuardConditions => _guard.UnmetGuardConditions;
+            public ICollection<string> UnmetGuardConditions => Guard.UnmetGuardConditions;
 
             public abstract bool ResultsInTransitionFrom(TState source, object[] args, out TState destination);
 

--- a/src/Stateless/TriggerBehaviour.cs
+++ b/src/Stateless/TriggerBehaviour.cs
@@ -51,6 +51,9 @@ namespace Stateless
             public ICollection<string> UnmetGuardConditions => _guard.UnmetGuardConditions;
 
             public abstract bool ResultsInTransitionFrom(TState source, object[] args, out TState destination);
+
+            public virtual void IsFiring()
+            { }
         }
     }
 }

--- a/test/Stateless.Tests/DotGraphFixture.cs
+++ b/test/Stateless.Tests/DotGraphFixture.cs
@@ -66,7 +66,7 @@ namespace Stateless.Tests
             var sm = new StateMachine<State, Trigger>(State.A);
 
             sm.Configure(State.A)
-                .PermitIf(Trigger.X, State.B, anonymousGuard);
+                .Permit(Trigger.X, State.B).If(anonymousGuard);
 
             Assert.Equal(expected, DotGraphFormatter.Format(sm.GetInfo()));
         }
@@ -83,7 +83,7 @@ namespace Stateless.Tests
             var sm = new StateMachine<State, Trigger>(State.A);
 
             sm.Configure(State.A)
-                .PermitIf(Trigger.X, State.B, anonymousGuard, "description");
+                .Permit(Trigger.X, State.B).If(anonymousGuard, "description");
 
             Assert.Equal(expected, DotGraphFormatter.Format(sm.GetInfo()));
         }

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -415,13 +415,13 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        public void ActionOnExitFrom()
+        public void ActionOnExitBy()
         {
             var sm = new StateMachine<State, Trigger>(State.A);
             bool fired = false;
 
             sm.Configure(State.A)
-                .Permit(Trigger.X, State.B).OnExitFrom(Trigger.X, () => fired = true);
+                .Permit(Trigger.X, State.B).OnExitBy(Trigger.X, () => fired = true);
 
             sm.Fire(Trigger.X);
 
@@ -445,16 +445,16 @@ namespace Stateless.Tests
             Assert.Equal(value, 1);
         }
 
-        // OnExitFrom doesn't work as well with PermitIf():
+        // OnExitBy doesn't work as well with PermitIf():
         //[Fact]
-        //public void ActionOnExitFromIf()
+        //public void ActionOnExitByIf()
         //{
         //    var sm = new StateMachine<State, Trigger>(State.A);
         //    int value = 0;
 
         //    sm.Configure(State.A)
-        //        .PermitIf(Trigger.X, State.B, () => true).OnExitFrom(Trigger.X, () => value = 1)
-        //        .PermitIf(Trigger.X, State.C, () => false).OnExitFrom(Trigger.X,  () => value = 2);
+        //        .PermitIf(Trigger.X, State.B, () => true).OnExitBy(Trigger.X, () => value = 1)
+        //        .PermitIf(Trigger.X, State.C, () => false).OnExitBy(Trigger.X,  () => value = 2);
 
         //    sm.Fire(Trigger.X);
 

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -415,6 +415,21 @@ namespace Stateless.Tests
         }
 
         [Fact]
+        public void ActionOnExitFrom()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            bool fired = false;
+
+            sm.Configure(State.A)
+                .Permit(Trigger.X, State.B).OnExitFrom(Trigger.X, () => fired = true);
+
+            sm.Fire(Trigger.X);
+
+            Assert.Equal(State.B, sm.State);
+            Assert.True(fired);
+        }
+
+        [Fact]
         public void ActionOnPermitIf()
         {
             var sm = new StateMachine<State, Trigger>(State.A);
@@ -429,5 +444,22 @@ namespace Stateless.Tests
             Assert.Equal(State.B, sm.State);
             Assert.Equal(value, 1);
         }
+
+        // OnExitFrom doesn't work as well with PermitIf():
+        //[Fact]
+        //public void ActionOnExitFromIf()
+        //{
+        //    var sm = new StateMachine<State, Trigger>(State.A);
+        //    int value = 0;
+
+        //    sm.Configure(State.A)
+        //        .PermitIf(Trigger.X, State.B, () => true).OnExitFrom(Trigger.X, () => value = 1)
+        //        .PermitIf(Trigger.X, State.C, () => false).OnExitFrom(Trigger.X,  () => value = 2);
+
+        //    sm.Fire(Trigger.X);
+
+        //    Assert.Equal(State.B, sm.State);
+        //    Assert.Equal(value, 1);
+        //}
     }
 }

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -398,5 +398,36 @@ namespace Stateless.Tests
 
             Assert.Throws(typeof(ArgumentException), () => { sm.Configure(State.C).SubstateOf(State.B); });
         }
+
+        [Fact]
+        public void ActionOnPermit()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            bool fired = false;
+
+            sm.Configure(State.A)
+                .Permit(Trigger.X, State.B, () => fired = true);
+
+            sm.Fire(Trigger.X);
+
+            Assert.Equal(State.B, sm.State);
+            Assert.True(fired);
+        }
+
+        [Fact]
+        public void ActionOnPermitIf()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            int value = 0;
+
+            sm.Configure(State.A)
+                .PermitIf(Trigger.X, State.B, () => true, () => value = 1)
+                .PermitIf(Trigger.X, State.C, () => false, () => value = 2);
+
+            sm.Fire(Trigger.X);
+
+            Assert.Equal(State.B, sm.State);
+            Assert.Equal(value, 1);
+        }
     }
 }

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -406,7 +406,7 @@ namespace Stateless.Tests
             bool fired = false;
 
             sm.Configure(State.A)
-                .Permit(Trigger.X, State.B, () => fired = true);
+                .Permit(Trigger.X, State.B).Do(() => fired = true);
 
             sm.Fire(Trigger.X);
 
@@ -436,8 +436,8 @@ namespace Stateless.Tests
             int value = 0;
 
             sm.Configure(State.A)
-                .PermitIf(Trigger.X, State.B, () => true, () => value = 1)
-                .PermitIf(Trigger.X, State.C, () => false, () => value = 2);
+                .Permit(Trigger.X, State.B).If(() => true).Do(() => value = 1)
+                .Permit(Trigger.X, State.C).If(() => false).Do(() => value = 2);
 
             sm.Fire(Trigger.X);
 


### PR DESCRIPTION
This code satisfies both issues #166  and #167 

By having Permit() return a TriggerConfiguration instead of a StateConfiguration (where TriggerConfiguration is a subclass of StateConfiguration), we make it easy to add options to the trigger using fluent syntax.

For example:

```
sm.Configure(State.A)
    .Permit(Trigger.X, State.B).If(anonymousGuard, "description");

sm.Configure(State.A)
    .Permit(Trigger.X, State.B).If(() => true).Do(() => value = 1)
    .Permit(Trigger.X, State.C).If(() => false).Do(() => value = 2);

sm.Configure(State.A)
    .Permit(Trigger.X, State.B).If(() => true).Tag(1)
    .Permit(Trigger.X, State.C).If(() => false).Tag("blue");
```

