### PR TITLE
#191 Modified StateRepresentation.Exit to allow recursive Exit action…

### DIFF
--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -156,7 +156,7 @@ namespace Stateless
             {
                 var transition = new Transition(source, destination, trigger);
 
-                await representativeState.ExitAsync(transition);
+                transition = await representativeState.ExitAsync(transition);
 
                 State = transition.Destination;
                 var newRepresentation = GetRepresentation(transition.Destination);

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -283,7 +283,7 @@ namespace Stateless
             {
                 var transition = new Transition(source, destination, trigger);
 
-                representativeState.Exit(transition);
+                transition = representativeState.Exit(transition);
 
                 State = transition.Destination;
                 var newRepresentation = GetRepresentation(transition.Destination);

--- a/src/Stateless/StateRepresentation.Async.cs
+++ b/src/Stateless/StateRepresentation.Async.cs
@@ -115,7 +115,7 @@ namespace Stateless
                 }
             }
 
-            public async Task ExitAsync(Transition transition)
+            public async Task<Transition> ExitAsync(Transition transition)
             {
                 if (transition.IsReentry)
                 {
@@ -128,8 +128,12 @@ namespace Stateless
                     await ExecuteExitActionsAsync(transition);
 
                     if (_superstate != null)
-                        await _superstate.ExitAsync(transition);
+                    {
+                        transition = new Transition(_superstate.UnderlyingState, transition.Destination, transition.Trigger);
+                        return await _superstate.ExitAsync(transition);
+                    }
                 }
+                return transition;
             }
 
             async Task ExecuteEntryActionsAsync(Transition transition, object[] entryArgs)

--- a/src/Stateless/StateRepresentation.cs
+++ b/src/Stateless/StateRepresentation.cs
@@ -176,7 +176,7 @@ namespace Stateless
                 }
             }
 
-            public void Exit(Transition transition)
+            public Transition Exit(Transition transition)
             {
                 if (transition.IsReentry)
                 {
@@ -189,8 +189,12 @@ namespace Stateless
                     ExecuteExitActions(transition);
 
                     if (_superstate != null)
-                        _superstate.Exit(transition);
+                    {
+                        transition = new Transition(_superstate.UnderlyingState, transition.Destination, transition.Trigger);
+                         return _superstate.Exit(transition);
+                    }
                 }
+                return transition;
             }
 
             void ExecuteEntryActions(Transition transition, object[] entryArgs)

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -442,6 +442,7 @@ namespace Stateless.Tests
 
             Assert.Equal(1, _numCalls);
         }
+
         [Fact]
         public void IfSelfTransitionPermited_ActionsFire_InSubstate()
         {

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -442,5 +442,30 @@ namespace Stateless.Tests
 
             Assert.Equal(1, _numCalls);
         }
+        [Fact]
+        public void IfSelfTransitionPermited_ActionsFire_InSubstate()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            bool onEntryStateBfired = false;
+            bool onExitStateBfired = false;
+            bool onExitStateAfired = false;
+
+            sm.Configure(State.B)
+                .OnEntry(t => onEntryStateBfired = true)
+                .PermitReentry(Trigger.X)
+                .OnExit(t => onExitStateBfired = true);
+
+            sm.Configure(State.A)
+                .SubstateOf(State.B)
+                .OnExit(t => onExitStateAfired = true);
+
+            sm.Fire(Trigger.X);
+
+            Assert.Equal(State.B, sm.State);
+            Assert.True(onEntryStateBfired);
+            Assert.True(onExitStateBfired);
+            Assert.True(onExitStateAfired);
+        }
     }
 }


### PR DESCRIPTION
…s to be executed. It now modifies the Transition object as it executes Exit recursively. It returns a new transistion object when done, so that the source is set to the topmost superstate.

Modified StateMachine.InternalFireOne to accept the modified transition object returned by StateRepresentation.Exit.
Added needed test to verify correct handling of reeantrant transitions, as pointed out by @dpavlenkov