### PR TITLE
Add Guard Clauses with Parameter Arguments (Issue #155)

### DIFF
--- a/src/Stateless/GuardCondition.cs
+++ b/src/Stateless/GuardCondition.cs
@@ -8,6 +8,18 @@ namespace Stateless
         {
             Reflection.InvocationInfo _methodDescription;
 
+            /// <summary>
+            /// Constructor that takes in a guard with no argument.
+            /// This is needed because we wrap the no-arg guard with a lamba and therefore method description won't match what was origianlly passed in.
+            /// We need to preserve the method description before wrapping so Reflection methods will work.
+            /// </summary>
+            /// <param name="guard">No Argument Guard Condition</param>
+            /// <param name="description"></param>
+            internal GuardCondition(Func<bool> guard, Reflection.InvocationInfo description)
+                : this(args => guard(), description)
+            {
+            }
+
             internal GuardCondition(Func<object[], bool> guard, Reflection.InvocationInfo description)
             {
                 Guard = guard ?? throw new ArgumentNullException(nameof(guard));

--- a/src/Stateless/GuardCondition.cs
+++ b/src/Stateless/GuardCondition.cs
@@ -8,12 +8,13 @@ namespace Stateless
         {
             Reflection.InvocationInfo _methodDescription;
 
-            internal GuardCondition(Func<bool> guard, Reflection.InvocationInfo description)
+            internal GuardCondition(Func<object[], bool> guard, Reflection.InvocationInfo description)
             {
                 Guard = guard ?? throw new ArgumentNullException(nameof(guard));
                 _methodDescription = description ?? throw new ArgumentNullException(nameof(description));
             }
-            internal Func<bool> Guard { get; }
+
+            internal Func<object[], bool> Guard { get; }
 
             // Return the description of the guard method: the caller-defined description if one
             // was provided, else the name of the method itself

--- a/src/Stateless/InternalTriggerBehaviour.cs
+++ b/src/Stateless/InternalTriggerBehaviour.cs
@@ -6,10 +6,16 @@ namespace Stateless
     {
         internal class InternalTriggerBehaviour : TriggerBehaviour
         {
+            public InternalTriggerBehaviour(TTrigger trigger, Func<bool> guard)
+                : base(trigger, new TransitionGuard(guard, "Internal Transition"))
+            {
+            }
+
             public InternalTriggerBehaviour(TTrigger trigger, Func<object[], bool> guard)
                 : base(trigger, new TransitionGuard(guard, "Internal Transition"))
             {
             }
+
             public override bool ResultsInTransitionFrom(TState source, object[] args, out TState destination)
             {
                 destination = source;

--- a/src/Stateless/InternalTriggerBehaviour.cs
+++ b/src/Stateless/InternalTriggerBehaviour.cs
@@ -6,7 +6,7 @@ namespace Stateless
     {
         internal class InternalTriggerBehaviour : TriggerBehaviour
         {
-            public InternalTriggerBehaviour(TTrigger trigger, Func<bool> guard)
+            public InternalTriggerBehaviour(TTrigger trigger, Func<object[], bool> guard)
                 : base(trigger, new TransitionGuard(guard, "Internal Transition"))
             {
             }

--- a/src/Stateless/StateConfiguration.Async.cs
+++ b/src/Stateless/StateConfiguration.Async.cs
@@ -24,7 +24,7 @@ namespace Stateless
             {
                 if (entryAction == null) throw new ArgumentNullException(nameof(entryAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, args => guard()));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, guard));
                 _representation.AddInternalAction(trigger, (t, args) => entryAction(t));
                 return this;
             }
@@ -40,7 +40,7 @@ namespace Stateless
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, args => guard()));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, guard));
                 _representation.AddInternalAction(trigger, (t, args) => internalAction());
                 return this;
             }
@@ -57,7 +57,7 @@ namespace Stateless
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, args => guard()));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, guard));
                 _representation.AddInternalAction(trigger, (t, args) => internalAction(t));
                 return this;
             }
@@ -74,7 +74,7 @@ namespace Stateless
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, args => guard()));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, guard));
                 _representation.AddInternalAction(trigger.Trigger, (t, args) => internalAction(ParameterConversion.Unpack<TArg0>(args, 0), t));
                 return this;
             }
@@ -92,7 +92,7 @@ namespace Stateless
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, args => guard()));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, guard));
                 _representation.AddInternalAction(trigger.Trigger, (t, args) => internalAction(
                     ParameterConversion.Unpack<TArg0>(args, 0),
                     ParameterConversion.Unpack<TArg1>(args, 1), t));
@@ -113,7 +113,7 @@ namespace Stateless
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, args => guard()));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, guard));
                 _representation.AddInternalAction(trigger.Trigger, (t, args) => internalAction(
                     ParameterConversion.Unpack<TArg0>(args, 0),
                     ParameterConversion.Unpack<TArg1>(args, 1),

--- a/src/Stateless/StateConfiguration.Async.cs
+++ b/src/Stateless/StateConfiguration.Async.cs
@@ -24,7 +24,7 @@ namespace Stateless
             {
                 if (entryAction == null) throw new ArgumentNullException(nameof(entryAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, guard));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, args => guard()));
                 _representation.AddInternalAction(trigger, (t, args) => entryAction(t));
                 return this;
             }
@@ -40,7 +40,7 @@ namespace Stateless
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, guard));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, args => guard()));
                 _representation.AddInternalAction(trigger, (t, args) => internalAction());
                 return this;
             }
@@ -57,7 +57,7 @@ namespace Stateless
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, guard));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, args => guard()));
                 _representation.AddInternalAction(trigger, (t, args) => internalAction(t));
                 return this;
             }
@@ -74,7 +74,7 @@ namespace Stateless
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, guard));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, args => guard()));
                 _representation.AddInternalAction(trigger.Trigger, (t, args) => internalAction(ParameterConversion.Unpack<TArg0>(args, 0), t));
                 return this;
             }
@@ -92,7 +92,7 @@ namespace Stateless
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, guard));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, args => guard()));
                 _representation.AddInternalAction(trigger.Trigger, (t, args) => internalAction(
                     ParameterConversion.Unpack<TArg0>(args, 0),
                     ParameterConversion.Unpack<TArg1>(args, 1), t));
@@ -113,7 +113,7 @@ namespace Stateless
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, guard));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, args => guard()));
                 _representation.AddInternalAction(trigger.Trigger, (t, args) => internalAction(
                     ParameterConversion.Unpack<TArg0>(args, 0),
                     ParameterConversion.Unpack<TArg1>(args, 1),

--- a/src/Stateless/StateConfiguration.cs
+++ b/src/Stateless/StateConfiguration.cs
@@ -248,7 +248,25 @@ namespace Stateless
                     destinationState,
                     new TransitionGuard(guard, guardDescription));
             }
+            
+            /// <summary>
+            /// Accept the specified trigger and transition to the destination state.
+            /// </summary>
+            /// <param name="trigger">The accepted trigger.</param>
+            /// <param name="guards">Functions and their descriptions that must return true in order for the
+            /// trigger to be accepted.</param>
+            /// <param name="destinationState">State of the destination.</param>
+            /// <returns>The receiver.</returns>
+            public StateConfiguration PermitIf(TTrigger trigger, TState destinationState, params Tuple<Func<bool>, string>[] guards)
+            {
+                EnforceNotIdentityTransition(destinationState);
 
+                return InternalPermitIf(
+                    trigger,
+                    destinationState,
+                    new TransitionGuard(guards));
+            }
+            
             /// <summary>
             ///  Accept the specified trigger, transition to the destination state, and guard condition. 
             /// </summary>
@@ -267,9 +285,30 @@ namespace Stateless
                 return InternalPermitIf(
                     trigger.Trigger,
                     destinationState,
-                    new TransitionGuard(args => guard(ParameterConversion.Unpack<TArg0>(args, 0)), guardDescription));
+                    new TransitionGuard(TransitionGuard.ToPackedGuard(guard), guardDescription));
             }
+            
+            /// <summary>
+            /// Accept the specified trigger, transition to the destination state, and guard conditions.
+            /// </summary>
+            /// <typeparam name="TArg0"></typeparam>
+            /// <param name="trigger">The accepted trigger.</param>
+            /// <param name="guards">Functions and their descriptions that must return true in order for the
+            /// trigger to be accepted. Functions take a single argument of type TArg0.</param>
+            /// <param name="destinationState">State of the destination.</param>
+            /// <returns>The receiver.</returns>
+            /// <returns></returns>
+            public StateConfiguration PermitIf<TArg0>(TriggerWithParameters<TArg0> trigger, TState destinationState, params Tuple<Func<TArg0, bool>, string>[] guards)
+            {
+                EnforceNotIdentityTransition(destinationState);
 
+                return InternalPermitIf(
+                    trigger.Trigger,
+                    destinationState,
+                    new TransitionGuard(TransitionGuard.ToPackedGuards(guards))
+                );
+            }
+            
             /// <summary>
             ///  Accept the specified trigger, transition to the destination state, and guard condition. 
             /// </summary>
@@ -289,51 +328,76 @@ namespace Stateless
                 return InternalPermitIf(
                     trigger.Trigger,
                     destinationState,
-                    new TransitionGuard(
-                        args => guard(ParameterConversion.Unpack<TArg0>(args, 0), ParameterConversion.Unpack<TArg1>(args, 1)), // cast the Func<TArg0, TArg1, bool> to Func<object, object, bool>
-                        guardDescription)); 
+                    new TransitionGuard(TransitionGuard.ToPackedGuard(guard), guardDescription));
             }
 
             /// <summary>
-            /// Accept the specified trigger and transition to the destination state.
-            /// </summary>
-            /// <param name="trigger">The accepted trigger.</param>
-            /// <param name="guards">Functions and their descriptions that must return true in order for the
-            /// trigger to be accepted.</param>
-            /// <param name="destinationState">State of the destination.</param>
-            /// <returns>The receiver.</returns>
-            public StateConfiguration PermitIf(TTrigger trigger, TState destinationState, params Tuple<Func<bool>, string>[] guards)
-            {
-                EnforceNotIdentityTransition(destinationState);
-
-                return InternalPermitIf(
-                    trigger,
-                    destinationState,
-                    new TransitionGuard(guards));
-            }
-
-            /// <summary>
-            /// Accept the specified trigger, transition to the destination state, and guard conditions.
+            ///  Accept the specified trigger, transition to the destination state, and guard condition. 
             /// </summary>
             /// <typeparam name="TArg0"></typeparam>
+            /// <typeparam name="TArg1"></typeparam>
             /// <param name="trigger">The accepted trigger.</param>
             /// <param name="guards">Functions and their descriptions that must return true in order for the
             /// trigger to be accepted. Functions take a single argument of type TArg0.</param>
             /// <param name="destinationState">State of the destination.</param>
             /// <returns>The receiver.</returns>
             /// <returns></returns>
-            public StateConfiguration PermitIf<TArg0>(TriggerWithParameters<TArg0> trigger, TState destinationState, params Tuple<Func<TArg0, bool>, string>[] guards)
+            /// <returns>The reciever.</returns>
+            public StateConfiguration PermitIf<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, TState destinationState, params Tuple<Func<TArg0, TArg1, bool>, string>[] guards)
             {
                 EnforceNotIdentityTransition(destinationState);
 
                 return InternalPermitIf(
                     trigger.Trigger,
                     destinationState,
-                    new TransitionGuard(
-                        guards.Select(guard =>
-                                new Tuple<Func<object[], bool>, string>(
-                                    args => guard.Item1(ParameterConversion.Unpack<TArg0>(args, 0)), guard.Item2))
-                            .ToArray())
+                    new TransitionGuard(TransitionGuard.ToPackedGuards(guards))
+                );
+            }
+
+            /// <summary>
+            ///  Accept the specified trigger, transition to the destination state, and guard condition. 
+            /// </summary>
+            /// <typeparam name="TArg0"></typeparam>
+            /// <typeparam name="TArg1"></typeparam>
+            /// <typeparam name="TArg2"></typeparam>
+            /// <param name="trigger">The accepted trigger.</param>
+            /// <param name="destinationState">The state that the trigger will cause a
+            /// transition to.</param>
+            /// <param name="guard">Function that must return true in order for the
+            /// trigger to be accepted. Takes a single argument of type TArg0</param>
+            /// <param name="guardDescription">Guard description</param>
+            /// <returns>The reciever.</returns>
+            public StateConfiguration PermitIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, TState destinationState, Func<TArg0, TArg1, TArg2, bool> guard, string guardDescription = null)
+            {
+                EnforceNotIdentityTransition(destinationState);
+
+                return InternalPermitIf(
+                    trigger.Trigger,
+                    destinationState,
+                    new TransitionGuard(TransitionGuard.ToPackedGuard(guard), guardDescription));
+            }
+
+            /// <summary>
+            ///  Accept the specified trigger, transition to the destination state, and guard condition. 
+            /// </summary>
+            /// <typeparam name="TArg0"></typeparam>
+            /// <typeparam name="TArg1"></typeparam>
+            /// <typeparam name="TArg2"></typeparam>
+            /// <param name="trigger">The accepted trigger.</param>
+            /// <param name="guards">Functions and their descriptions that must return true in order for the
+            /// trigger to be accepted. Functions take a single argument of type TArg0.</param>
+            /// <param name="destinationState">State of the destination.</param>
+            /// <returns>The receiver.</returns>
+            /// <returns></returns>
+            /// <returns>The reciever.</returns>
+            public StateConfiguration PermitIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, TState destinationState, params Tuple<Func<TArg0, TArg1, TArg2, bool>, string>[] guards)
+            {
+                EnforceNotIdentityTransition(destinationState);
+
+                return InternalPermitIf(
+                    trigger.Trigger,
+                    destinationState,
+                    new TransitionGuard(TransitionGuard.ToPackedGuards(guards))
                 );
             }
 
@@ -394,6 +458,122 @@ namespace Stateless
             }
 
             /// <summary>
+            ///  Accept the specified trigger, transition to the destination state, and guard condition. 
+            /// </summary>
+            /// <typeparam name="TArg0"></typeparam>
+            /// <param name="trigger">The accepted trigger.</param>
+            /// <param name="guard">Function that must return true in order for the
+            /// trigger to be accepted. Takes a single argument of type TArg0</param>
+            /// <param name="guardDescription">Guard description</param>
+            /// <returns>The reciever.</returns>
+            public StateConfiguration PermitReentryIf<TArg0>(TriggerWithParameters<TArg0> trigger, Func<TArg0, bool> guard, string guardDescription = null)
+            {
+                return InternalPermitIf(
+                    trigger.Trigger,
+                    _representation.UnderlyingState,
+                    new TransitionGuard(TransitionGuard.ToPackedGuard(guard), guardDescription)
+                );
+            }
+
+            /// <summary>
+            /// Accept the specified trigger, transition to the destination state, and guard conditions.
+            /// </summary>
+            /// <typeparam name="TArg0"></typeparam>
+            /// <param name="trigger">The accepted trigger.</param>
+            /// <param name="guards">Functions and their descriptions that must return true in order for the
+            /// trigger to be accepted. Functions take a single argument of type TArg0.</param>
+            /// <returns>The receiver.</returns>
+            /// <returns></returns>
+            public StateConfiguration PermitReentryIf<TArg0>(TriggerWithParameters<TArg0> trigger, params Tuple<Func<TArg0, bool>, string>[] guards)
+            {
+                return InternalPermitIf(
+                    trigger.Trigger,
+                    _representation.UnderlyingState,
+                    new TransitionGuard(TransitionGuard.ToPackedGuards(guards))
+                );
+            }
+
+            /// <summary>
+            ///  Accept the specified trigger, transition to the destination state, and guard condition. 
+            /// </summary>
+            /// <typeparam name="TArg0"></typeparam>
+            /// <typeparam name="TArg1"></typeparam>
+            /// <param name="trigger">The accepted trigger.</param>
+            /// <param name="guard">Function that must return true in order for the
+            /// trigger to be accepted. Takes a single argument of type TArg0</param>
+            /// <param name="guardDescription">Guard description</param>
+            /// <returns>The reciever.</returns>
+            public StateConfiguration PermitReentryIf<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Func<TArg0, TArg1, bool> guard, string guardDescription = null)
+            {
+                return InternalPermitIf(
+                    trigger.Trigger,
+                    _representation.UnderlyingState,
+                    new TransitionGuard(TransitionGuard.ToPackedGuard(guard), guardDescription)
+                );
+            }
+
+            /// <summary>
+            ///  Accept the specified trigger, transition to the destination state, and guard condition. 
+            /// </summary>
+            /// <typeparam name="TArg0"></typeparam>
+            /// <typeparam name="TArg1"></typeparam>
+            /// <param name="trigger">The accepted trigger.</param>
+            /// <param name="guards">Functions and their descriptions that must return true in order for the
+            /// trigger to be accepted. Functions take a single argument of type TArg0.</param>
+            /// <returns>The receiver.</returns>
+            /// <returns></returns>
+            /// <returns>The reciever.</returns>
+            public StateConfiguration PermitReentryIf<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, params Tuple<Func<TArg0, TArg1, bool>, string>[] guards)
+            {
+                return InternalPermitIf(
+                    trigger.Trigger,
+                    _representation.UnderlyingState,
+                    new TransitionGuard(TransitionGuard.ToPackedGuards(guards))
+                );
+            }
+
+            /// <summary>
+            ///  Accept the specified trigger, transition to the destination state, and guard condition. 
+            /// </summary>
+            /// <typeparam name="TArg0"></typeparam>
+            /// <typeparam name="TArg1"></typeparam>
+            /// <typeparam name="TArg2"></typeparam>
+            /// <param name="trigger">The accepted trigger.</param>
+            /// <param name="guard">Function that must return true in order for the
+            /// trigger to be accepted. Takes a single argument of type TArg0</param>
+            /// <param name="guardDescription">Guard description</param>
+            /// <returns>The reciever.</returns>
+            public StateConfiguration PermitReentryIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Func<TArg0, TArg1, TArg2, bool> guard, string guardDescription = null)
+            {
+                return InternalPermitIf(
+                    trigger.Trigger,
+                    _representation.UnderlyingState,
+                    new TransitionGuard(TransitionGuard.ToPackedGuard(guard), guardDescription)
+                );
+            }
+
+            /// <summary>
+            ///  Accept the specified trigger, transition to the destination state, and guard condition. 
+            /// </summary>
+            /// <typeparam name="TArg0"></typeparam>
+            /// <typeparam name="TArg1"></typeparam>
+            /// <typeparam name="TArg2"></typeparam>
+            /// <param name="trigger">The accepted trigger.</param>
+            /// <param name="guards">Functions and their descriptions that must return true in order for the
+            /// trigger to be accepted. Functions take a single argument of type TArg0.</param>
+            /// <returns>The receiver.</returns>
+            /// <returns></returns>
+            /// <returns>The reciever.</returns>
+            public StateConfiguration PermitReentryIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, params Tuple<Func<TArg0, TArg1, TArg2, bool>, string>[] guards)
+            {
+                return InternalPermitIf(
+                    trigger.Trigger,
+                    _representation.UnderlyingState,
+                    new TransitionGuard(TransitionGuard.ToPackedGuards(guards))
+                );
+            }
+            
+            /// <summary>
             /// Ignore the specified trigger when in the configured state.
             /// </summary>
             /// <param name="trigger">The trigger to ignore.</param>
@@ -442,6 +622,42 @@ namespace Stateless
                     new IgnoredTriggerBehaviour(
                         trigger,
                         new TransitionGuard(guards)));
+                return this;
+            }
+
+            /// <summary>
+            /// Ignore the specified trigger when in the configured state, if the guard
+            /// returns true..
+            /// </summary>
+            /// <param name="trigger">The trigger to ignore.</param>
+            /// <param name="guardDescription">Guard description</param>
+            /// <param name="guard">Function that must return true in order for the
+            /// trigger to be ignored.</param>
+            /// <returns>The receiver.</returns>
+            public StateConfiguration IgnoreIf<TArg0>(TriggerWithParameters<TArg0> trigger, Func<TArg0, bool> guard, string guardDescription = null)
+            {
+                _representation.AddTriggerBehaviour(
+                    new IgnoredTriggerBehaviour(
+                        trigger.Trigger,
+                        new TransitionGuard(TransitionGuard.ToPackedGuard(guard), guardDescription)
+                    ));
+                return this;
+            }
+
+            /// <summary>
+            /// Ignore the specified trigger when in the configured state, if the guard
+            /// returns true..
+            /// </summary>
+            /// <param name="trigger">The trigger to ignore.</param>
+            /// <param name="guards">Functions and their descriptions that must return true in order for the
+            /// trigger to be ignored.</param>
+            /// <returns>The receiver.</returns>
+            public StateConfiguration IgnoreIf<TArg0>(TriggerWithParameters<TArg0> trigger, params Tuple<Func<TArg0, bool>, string>[] guards)
+            {
+                _representation.AddTriggerBehaviour(
+                    new IgnoredTriggerBehaviour(
+                        trigger.Trigger,
+                        new TransitionGuard(TransitionGuard.ToPackedGuards(guards))));
                 return this;
             }
 
@@ -1134,7 +1350,7 @@ namespace Stateless
                     new TransitionGuard(guards),
                     null);      // List of possible destination states not specified
             }
-
+            
             /// <summary>
             /// Accept the specified trigger and transition to the destination state, calculated
             /// dynamically by the supplied function.
@@ -1157,7 +1373,32 @@ namespace Stateless
                     args => destinationStateSelector(
                         ParameterConversion.Unpack<TArg0>(args, 0)),
                     null,    // destinationStateSelectorString
-                    new TransitionGuard(args => guard(ParameterConversion.Unpack<TArg0>(args, 0)), guardDescription),
+                    new TransitionGuard(TransitionGuard.ToPackedGuard(guard), guardDescription),
+                    null);      // List of possible destination states not specified
+            }
+
+            /// <summary>
+            /// Accept the specified trigger and transition to the destination state, calculated
+            /// dynamically by the supplied function.
+            /// </summary>
+            /// <param name="trigger">The accepted trigger.</param>
+            /// <param name="destinationStateSelector">Function to calculate the state
+            /// that the trigger will cause a transition to.</param>
+            /// <param name="guards">Functions and their descriptions that must return true in order for the
+            /// trigger to be accepted.</param>
+            /// <returns>The reciever.</returns>
+            /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
+            public StateConfiguration PermitDynamicIf<TArg0>(TriggerWithParameters<TArg0> trigger, Func<TArg0, TState> destinationStateSelector, params Tuple<Func<TArg0, bool>, string>[] guards)
+            {
+                if (trigger == null) throw new ArgumentNullException(nameof(trigger));
+                if (destinationStateSelector == null) throw new ArgumentNullException(nameof(destinationStateSelector));
+
+                return InternalPermitDynamicIf(
+                    trigger.Trigger,
+                    args => destinationStateSelector(
+                        ParameterConversion.Unpack<TArg0>(args, 0)),
+                    null,    // destinationStateSelectorString
+                    new TransitionGuard(TransitionGuard.ToPackedGuards(guards)),
                     null);      // List of possible destination states not specified
             }
 
@@ -1185,7 +1426,93 @@ namespace Stateless
                         ParameterConversion.Unpack<TArg0>(args, 0),
                         ParameterConversion.Unpack<TArg1>(args, 1)),
                     null,    // destinationStateSelectorString
-                    new TransitionGuard(args => guard(ParameterConversion.Unpack<TArg0>(args, 0), ParameterConversion.Unpack<TArg1>(args, 1)), guardDescription),
+                    new TransitionGuard(TransitionGuard.ToPackedGuard(guard), guardDescription),
+                    null);      // List of possible destination states not specified
+            }
+
+            /// <summary>
+            /// Accept the specified trigger and transition to the destination state, calculated
+            /// dynamically by the supplied function.
+            /// </summary>
+            /// <param name="trigger">The accepted trigger.</param>
+            /// <param name="destinationStateSelector">Function to calculate the state
+            /// that the trigger will cause a transition to.</param>
+            /// <param name="guards">Functions that must return true in order for the
+            /// trigger to be accepted.</param>
+            /// <returns>The reciever.</returns>
+            /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
+            /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
+            public StateConfiguration PermitDynamicIf<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Func<TArg0, TArg1, TState> destinationStateSelector, Tuple<Func<TArg0, TArg1, bool>, string>[] guards)
+            {
+                if (trigger == null) throw new ArgumentNullException(nameof(trigger));
+                if (destinationStateSelector == null) throw new ArgumentNullException(nameof(destinationStateSelector));
+
+                return InternalPermitDynamicIf(
+                    trigger.Trigger,
+                    args => destinationStateSelector(
+                        ParameterConversion.Unpack<TArg0>(args, 0),
+                        ParameterConversion.Unpack<TArg1>(args, 1)),
+                    null,    // destinationStateSelectorString
+                    new TransitionGuard(TransitionGuard.ToPackedGuards(guards)),
+                    null);      // List of possible destination states not specified
+            }
+
+            /// <summary>
+            /// Accept the specified trigger and transition to the destination state, calculated
+            /// dynamically by the supplied function.
+            /// </summary>
+            /// <param name="trigger">The accepted trigger.</param>
+            /// <param name="destinationStateSelector">Function to calculate the state
+            /// that the trigger will cause a transition to.</param>
+            /// <param name="guard">Function that must return true in order for the
+            /// trigger to be accepted.</param>
+            /// <param name="guardDescription">Guard description</param>
+            /// <returns>The reciever.</returns>
+            /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
+            /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
+            /// <typeparam name="TArg2"></typeparam>
+            public StateConfiguration PermitDynamicIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Func<TArg0, TArg1, TArg2, TState> destinationStateSelector, Func<TArg0, TArg1, TArg2, bool> guard, string guardDescription = null)
+            {
+                if (trigger == null) throw new ArgumentNullException(nameof(trigger));
+                if (destinationStateSelector == null) throw new ArgumentNullException(nameof(destinationStateSelector));
+
+                return InternalPermitDynamicIf(
+                    trigger.Trigger,
+                    args => destinationStateSelector(
+                        ParameterConversion.Unpack<TArg0>(args, 0),
+                        ParameterConversion.Unpack<TArg1>(args, 1),
+                        ParameterConversion.Unpack<TArg2>(args, 2)),
+                    null,    // destinationStateSelectorString
+                    new TransitionGuard(TransitionGuard.ToPackedGuard(guard), guardDescription),
+                    null);      // List of possible destination states not specified
+            }
+
+            /// <summary>
+            /// Accept the specified trigger and transition to the destination state, calculated
+            /// dynamically by the supplied function.
+            /// </summary>
+            /// <param name="trigger">The accepted trigger.</param>
+            /// <param name="destinationStateSelector">Function to calculate the state
+            /// that the trigger will cause a transition to.</param>
+            /// <param name="guards">Functions that must return true in order for the
+            /// trigger to be accepted.</param>
+            /// <returns>The reciever.</returns>
+            /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
+            /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
+            /// <typeparam name="TArg2"></typeparam>
+            public StateConfiguration PermitDynamicIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Func<TArg0, TArg1, TArg2, TState> destinationStateSelector, Tuple<Func<TArg0, TArg1, TArg2, bool>, string>[] guards)
+            {
+                if (trigger == null) throw new ArgumentNullException(nameof(trigger));
+                if (destinationStateSelector == null) throw new ArgumentNullException(nameof(destinationStateSelector));
+
+                return InternalPermitDynamicIf(
+                    trigger.Trigger,
+                    args => destinationStateSelector(
+                        ParameterConversion.Unpack<TArg0>(args, 0),
+                        ParameterConversion.Unpack<TArg1>(args, 1),
+                        ParameterConversion.Unpack<TArg2>(args, 2)),
+                    null,    // destinationStateSelectorString
+                    new TransitionGuard(TransitionGuard.ToPackedGuards(guards)),
                     null);      // List of possible destination states not specified
             }
 

--- a/src/Stateless/StateConfiguration.cs
+++ b/src/Stateless/StateConfiguration.cs
@@ -1147,6 +1147,60 @@ namespace Stateless
                     null);      // List of possible destination states not specified
             }
 
+            /// <summary>
+            /// Accept the specified trigger and transition to the destination state, calculated
+            /// dynamically by the supplied function.
+            /// </summary>
+            /// <param name="trigger">The accepted trigger.</param>
+            /// <param name="destinationStateSelector">Function to calculate the state
+            /// that the trigger will cause a transition to.</param>
+            /// <param name="guard">Parameterized Function that must return true in order for the
+            /// trigger to be accepted.</param>
+            /// <param name="guardDescription">Guard description</param>
+            /// <returns>The reciever.</returns>
+            /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
+            public StateConfiguration PermitDynamicIf<TArg0>(TriggerWithParameters<TArg0> trigger, Func<TArg0, TState> destinationStateSelector, Func<TArg0, bool> guard, string guardDescription = null)
+            {
+                if (trigger == null) throw new ArgumentNullException(nameof(trigger));
+                if (destinationStateSelector == null) throw new ArgumentNullException(nameof(destinationStateSelector));
+
+                return InternalPermitDynamicIf(
+                    trigger.Trigger,
+                    args => destinationStateSelector(
+                        ParameterConversion.Unpack<TArg0>(args, 0)),
+                    null,    // destinationStateSelectorString
+                    new TransitionGuard(args => guard(ParameterConversion.Unpack<TArg0>(args, 0)), guardDescription),
+                    null);      // List of possible destination states not specified
+            }
+
+            /// <summary>
+            /// Accept the specified trigger and transition to the destination state, calculated
+            /// dynamically by the supplied function.
+            /// </summary>
+            /// <param name="trigger">The accepted trigger.</param>
+            /// <param name="destinationStateSelector">Function to calculate the state
+            /// that the trigger will cause a transition to.</param>
+            /// <param name="guard">Function that must return true in order for the
+            /// trigger to be accepted.</param>
+            /// <param name="guardDescription">Guard description</param>
+            /// <returns>The reciever.</returns>
+            /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
+            /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
+            public StateConfiguration PermitDynamicIf<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Func<TArg0, TArg1, TState> destinationStateSelector, Func<TArg0, TArg1, bool> guard, string guardDescription = null)
+            {
+                if (trigger == null) throw new ArgumentNullException(nameof(trigger));
+                if (destinationStateSelector == null) throw new ArgumentNullException(nameof(destinationStateSelector));
+
+                return InternalPermitDynamicIf(
+                    trigger.Trigger,
+                    args => destinationStateSelector(
+                        ParameterConversion.Unpack<TArg0>(args, 0),
+                        ParameterConversion.Unpack<TArg1>(args, 1)),
+                    null,    // destinationStateSelectorString
+                    new TransitionGuard(args => guard(ParameterConversion.Unpack<TArg0>(args, 0), ParameterConversion.Unpack<TArg1>(args, 1)), guardDescription),
+                    null);      // List of possible destination states not specified
+            }
+
             void EnforceNotIdentityTransition(TState destination)
             {
                 if (destination.Equals(_representation.UnderlyingState))

--- a/src/Stateless/StateConfiguration.cs
+++ b/src/Stateless/StateConfiguration.cs
@@ -69,7 +69,7 @@ namespace Stateless
             {
                 if (entryAction == null) throw new ArgumentNullException(nameof(entryAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, args => guard()));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, guard));
                 _representation.AddInternalAction(trigger, (t, args) => entryAction(t));
                 return this;
             }
@@ -96,7 +96,7 @@ namespace Stateless
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, args => guard()));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, guard));
                 _representation.AddInternalAction(trigger, (t, args) => internalAction());
                 return this;
             }
@@ -113,7 +113,7 @@ namespace Stateless
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, args => guard()));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, guard));
                 _representation.AddInternalAction(trigger, (t, args) => internalAction(t));
                 return this;
             }
@@ -154,7 +154,7 @@ namespace Stateless
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, args => guard()));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, guard));
                 _representation.AddInternalAction(trigger.Trigger, (t, args) => internalAction(ParameterConversion.Unpack<TArg0>(args, 0), t));
                 return this;
             }
@@ -186,7 +186,7 @@ namespace Stateless
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, args => guard()));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, guard));
                 _representation.AddInternalAction(trigger.Trigger, (t, args) => internalAction(
                     ParameterConversion.Unpack<TArg0>(args, 0),
                     ParameterConversion.Unpack<TArg1>(args, 1), t));
@@ -207,7 +207,7 @@ namespace Stateless
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, args => guard()));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, guard));
                 _representation.AddInternalAction(trigger.Trigger, (t, args) => internalAction(
                     ParameterConversion.Unpack<TArg0>(args, 0),
                     ParameterConversion.Unpack<TArg1>(args, 1),
@@ -246,7 +246,7 @@ namespace Stateless
                 return InternalPermitIf(
                     trigger,
                     destinationState,
-                    new TransitionGuard(args => guard(), guardDescription));
+                    new TransitionGuard(guard, guardDescription));
             }
 
             /// <summary>
@@ -309,9 +309,7 @@ namespace Stateless
                 return InternalPermitIf(
                     trigger,
                     destinationState,
-                    new TransitionGuard(
-                        guards.Select(guard => new Tuple<Func<object[], bool>, string>(args => guard.Item1(), guard.Item2)).ToArray())
-                );
+                    new TransitionGuard(guards));
             }
 
             /// <summary>
@@ -372,7 +370,7 @@ namespace Stateless
                 return InternalPermitIf(
                     trigger,
                     _representation.UnderlyingState,
-                    new TransitionGuard(args => guard(), guardDescription));
+                    new TransitionGuard(guard, guardDescription));
             }
 
             /// <summary>
@@ -392,9 +390,7 @@ namespace Stateless
                 return InternalPermitIf(
                     trigger,
                     _representation.UnderlyingState,
-                    new TransitionGuard(guards.Select(guard =>
-                            new Tuple<Func<object[], bool>, string>(args => guard.Item1(), guard.Item2))
-                        .ToArray()));
+                    new TransitionGuard(guards));
             }
 
             /// <summary>
@@ -427,7 +423,7 @@ namespace Stateless
                 _representation.AddTriggerBehaviour(
                     new IgnoredTriggerBehaviour(
                         trigger,
-                        new TransitionGuard(args => guard(), guardDescription)
+                        new TransitionGuard(guard, guardDescription)
                         ));
                 return this;
             }
@@ -445,9 +441,7 @@ namespace Stateless
                 _representation.AddTriggerBehaviour(
                     new IgnoredTriggerBehaviour(
                         trigger,
-                        new TransitionGuard(guards.Select(guard =>
-                            new Tuple<Func<object[], bool>, string>(args => guard.Item1(), guard.Item2)).ToArray()))
-                );
+                        new TransitionGuard(guards)));
                 return this;
             }
 
@@ -911,6 +905,7 @@ namespace Stateless
             {
                 return PermitDynamicIf(trigger, destinationStateSelector, null, guard, guardDescription);
             }
+            
             /// <summary>
             /// Accept the specified trigger and transition to the destination state, calculated
             /// dynamically by the supplied function.
@@ -932,7 +927,7 @@ namespace Stateless
                     trigger,
                     args => destinationStateSelector(),
                     destinationStateSelectorDescription,
-                    new TransitionGuard(args => guard(), guardDescription),
+                    new TransitionGuard(guard, guardDescription),
                     null);      // List of possible destination states not specified
             }
 
@@ -950,6 +945,7 @@ namespace Stateless
             {
                 return PermitDynamicIf(trigger, destinationStateSelector, null, guards);
             }
+            
             /// <summary>
             /// Accept the specified trigger and transition to the destination state, calculated
             /// dynamically by the supplied function.
@@ -970,9 +966,7 @@ namespace Stateless
                     trigger,
                     args => destinationStateSelector(),
                     destinationStateSelectorDescription,
-                    new TransitionGuard(guards.Select(guard =>
-                            new Tuple<Func<object[], bool>, string>(args => guard.Item1(), guard.Item2))
-                        .ToArray()),
+                    new TransitionGuard(guards),
                     null);      // List of possible destination states not specified
             }
 
@@ -998,7 +992,7 @@ namespace Stateless
                     args => destinationStateSelector(
                         ParameterConversion.Unpack<TArg0>(args, 0)),
                     null,    // destinationStateSelectorString
-                    new TransitionGuard(args => guard(), guardDescription),
+                    new TransitionGuard(guard, guardDescription),
                     null);      // List of possible destination states not specified
             }
 
@@ -1023,9 +1017,7 @@ namespace Stateless
                     args => destinationStateSelector(
                         ParameterConversion.Unpack<TArg0>(args, 0)),
                     null,    // destinationStateSelectorString
-                    new TransitionGuard(guards.Select(guard =>
-                            new Tuple<Func<object[], bool>, string>(args => guard.Item1(), guard.Item2))
-                        .ToArray()),
+                    new TransitionGuard(guards),
                     null);      // List of possible destination states not specified
             }
 
@@ -1053,7 +1045,7 @@ namespace Stateless
                         ParameterConversion.Unpack<TArg0>(args, 0),
                         ParameterConversion.Unpack<TArg1>(args, 1)),
                     null,    // destinationStateSelectorString
-                    new TransitionGuard(args => guard(), guardDescription),
+                    new TransitionGuard(guard, guardDescription),
                     null);      // List of possible destination states not specified
             }
 
@@ -1080,9 +1072,7 @@ namespace Stateless
                         ParameterConversion.Unpack<TArg0>(args, 0),
                         ParameterConversion.Unpack<TArg1>(args, 1)),
                     null,    // destinationStateSelectorString
-                    new TransitionGuard(guards.Select(guard =>
-                            new Tuple<Func<object[], bool>, string>(args => guard.Item1(), guard.Item2))
-                        .ToArray()),
+                    new TransitionGuard(guards),
                     null);      // List of possible destination states not specified
             }
 
@@ -1112,7 +1102,7 @@ namespace Stateless
                         ParameterConversion.Unpack<TArg1>(args, 1),
                         ParameterConversion.Unpack<TArg2>(args, 2)),
                     null,    // destinationStateSelectorString
-                    new TransitionGuard(args => guard(), guardDescription),
+                    new TransitionGuard(guard, guardDescription),
                     null);      // List of possible destination states not specified
             }
 
@@ -1141,9 +1131,7 @@ namespace Stateless
                         ParameterConversion.Unpack<TArg1>(args, 1),
                         ParameterConversion.Unpack<TArg2>(args, 2)),
                     null,    // destinationStateSelectorString
-                    new TransitionGuard(guards.Select(guard =>
-                            new Tuple<Func<object[], bool>, string>(args => guard.Item1(), guard.Item2))
-                        .ToArray()),
+                    new TransitionGuard(guards),
                     null);      // List of possible destination states not specified
             }
 

--- a/src/Stateless/StateConfiguration.cs
+++ b/src/Stateless/StateConfiguration.cs
@@ -163,6 +163,23 @@ namespace Stateless
             /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
             /// </summary>
             /// <typeparam name="TArg0"></typeparam>
+            /// <param name="trigger">The accepted trigger</param>
+            /// <param name="guard">Function that must return true in order for the trigger to be accepted.</param>
+            /// <param name="internalAction">The action performed by the internal transition</param>
+            /// <returns></returns>
+            public StateConfiguration InternalTransitionIf<TArg0>(TriggerWithParameters<TArg0> trigger, Func<TArg0, bool> guard, Action<TArg0, Transition> internalAction)
+            {
+                if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
+
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, TransitionGuard.ToPackedGuard(guard)));
+                _representation.AddInternalAction(trigger.Trigger, (t, args) => internalAction(ParameterConversion.Unpack<TArg0>(args, 0), t));
+                return this;
+            }
+
+            /// <summary>
+            /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
+            /// </summary>
+            /// <typeparam name="TArg0"></typeparam>
             /// <typeparam name="TArg1"></typeparam>
             /// <param name="trigger">The accepted trigger</param>
             /// <param name="internalAction">The action performed by the internal transition</param>
@@ -198,6 +215,26 @@ namespace Stateless
             /// </summary>
             /// <typeparam name="TArg0"></typeparam>
             /// <typeparam name="TArg1"></typeparam>
+            /// <param name="trigger">The accepted trigger</param>
+            /// <param name="guard">Function that must return true in order for the trigger to be accepted.</param>
+            /// <param name="internalAction">The action performed by the internal transition</param>
+            /// <returns></returns>
+            public StateConfiguration InternalTransitionIf<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Func<TArg0, TArg1, bool> guard, Action<TArg0, TArg1, Transition> internalAction)
+            {
+                if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
+
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, TransitionGuard.ToPackedGuard(guard)));
+                _representation.AddInternalAction(trigger.Trigger, (t, args) => internalAction(
+                    ParameterConversion.Unpack<TArg0>(args, 0),
+                    ParameterConversion.Unpack<TArg1>(args, 1), t));
+                return this;
+            }
+
+            /// <summary>
+            /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
+            /// </summary>
+            /// <typeparam name="TArg0"></typeparam>
+            /// <typeparam name="TArg1"></typeparam>
             /// <typeparam name="TArg2"></typeparam>
             /// <param name="trigger">The accepted trigger</param>
             /// <param name="guard">Function that must return true in order for the trigger to be accepted.</param>
@@ -208,6 +245,28 @@ namespace Stateless
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
                 _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, guard));
+                _representation.AddInternalAction(trigger.Trigger, (t, args) => internalAction(
+                    ParameterConversion.Unpack<TArg0>(args, 0),
+                    ParameterConversion.Unpack<TArg1>(args, 1),
+                    ParameterConversion.Unpack<TArg2>(args, 2), t));
+                return this;
+            }
+
+            /// <summary>
+            /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
+            /// </summary>
+            /// <typeparam name="TArg0"></typeparam>
+            /// <typeparam name="TArg1"></typeparam>
+            /// <typeparam name="TArg2"></typeparam>
+            /// <param name="trigger">The accepted trigger</param>
+            /// <param name="guard">Function that must return true in order for the trigger to be accepted.</param>
+            /// <param name="internalAction">The action performed by the internal transition</param>
+            /// <returns></returns>
+            public StateConfiguration InternalTransitionIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Func<TArg0, TArg1, TArg2, bool> guard, Action<TArg0, TArg1, TArg2, Transition> internalAction)
+            {
+                if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
+
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, TransitionGuard.ToPackedGuard(guard)));
                 _representation.AddInternalAction(trigger.Trigger, (t, args) => internalAction(
                     ParameterConversion.Unpack<TArg0>(args, 0),
                     ParameterConversion.Unpack<TArg1>(args, 1),

--- a/src/Stateless/StateConfiguration.cs
+++ b/src/Stateless/StateConfiguration.cs
@@ -662,6 +662,78 @@ namespace Stateless
             }
 
             /// <summary>
+            /// Ignore the specified trigger when in the configured state, if the guard
+            /// returns true..
+            /// </summary>
+            /// <param name="trigger">The trigger to ignore.</param>
+            /// <param name="guardDescription">Guard description</param>
+            /// <param name="guard">Function that must return true in order for the
+            /// trigger to be ignored.</param>
+            /// <returns>The receiver.</returns>
+            public StateConfiguration IgnoreIf<TArg0, TArgo1>(TriggerWithParameters<TArg0, TArgo1> trigger, Func<TArg0, TArgo1, bool> guard, string guardDescription = null)
+            {
+                _representation.AddTriggerBehaviour(
+                    new IgnoredTriggerBehaviour(
+                        trigger.Trigger,
+                        new TransitionGuard(TransitionGuard.ToPackedGuard(guard), guardDescription)
+                    ));
+                return this;
+            }
+
+            /// <summary>
+            /// Ignore the specified trigger when in the configured state, if the guard
+            /// returns true..
+            /// </summary>
+            /// <param name="trigger">The trigger to ignore.</param>
+            /// <param name="guards">Functions and their descriptions that must return true in order for the
+            /// trigger to be ignored.</param>
+            /// <returns>The receiver.</returns>
+            public StateConfiguration IgnoreIf<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, params Tuple<Func<TArg0, TArg1, bool>, string>[] guards)
+            {
+                _representation.AddTriggerBehaviour(
+                    new IgnoredTriggerBehaviour(
+                        trigger.Trigger,
+                        new TransitionGuard(TransitionGuard.ToPackedGuards(guards))));
+                return this;
+            }
+
+            /// <summary>
+            /// Ignore the specified trigger when in the configured state, if the guard
+            /// returns true..
+            /// </summary>
+            /// <param name="trigger">The trigger to ignore.</param>
+            /// <param name="guardDescription">Guard description</param>
+            /// <param name="guard">Function that must return true in order for the
+            /// trigger to be ignored.</param>
+            /// <returns>The receiver.</returns>
+            public StateConfiguration IgnoreIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Func<TArg0, TArg1, TArg2, bool> guard, string guardDescription = null)
+            {
+                _representation.AddTriggerBehaviour(
+                    new IgnoredTriggerBehaviour(
+                        trigger.Trigger,
+                        new TransitionGuard(TransitionGuard.ToPackedGuard(guard), guardDescription)
+                    ));
+                return this;
+            }
+
+            /// <summary>
+            /// Ignore the specified trigger when in the configured state, if the guard
+            /// returns true..
+            /// </summary>
+            /// <param name="trigger">The trigger to ignore.</param>
+            /// <param name="guards">Functions and their descriptions that must return true in order for the
+            /// trigger to be ignored.</param>
+            /// <returns>The receiver.</returns>
+            public StateConfiguration IgnoreIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, params Tuple<Func<TArg0, TArg1, TArg2, bool>, string>[] guards)
+            {
+                _representation.AddTriggerBehaviour(
+                    new IgnoredTriggerBehaviour(
+                        trigger.Trigger,
+                        new TransitionGuard(TransitionGuard.ToPackedGuards(guards))));
+                return this;
+            }
+
+            /// <summary>
             /// Specify an action that will execute when activating
             /// the configured state.
             /// </summary>

--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -145,7 +145,7 @@ namespace Stateless
             var representativeState = GetRepresentation(source);
 
             TriggerBehaviourResult result;
-            if (!representativeState.TryFindHandler(trigger, out result))
+            if (!representativeState.TryFindHandler(trigger, args, out result))
             {
                 await _unhandledTriggerAction.ExecuteAsync(representativeState.UnderlyingState, trigger, result?.UnmetGuardConditions);
                 return;

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -74,6 +74,17 @@ namespace Stateless
             }
         }
 
+		/// <summary>
+        /// The currently-permissible trigger values.
+        /// </summary>
+        public IEnumerable<TTrigger> PermittedTriggers
+        {
+            get
+            {
+                return GetPermittedTriggers();
+            }
+        }
+		
         /// <summary>
         /// The currently-permissible trigger values.
         /// </summary>

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -77,12 +77,9 @@ namespace Stateless
         /// <summary>
         /// The currently-permissible trigger values.
         /// </summary>
-        public IEnumerable<TTrigger> PermittedTriggers
+        public IEnumerable<TTrigger> GetPermittedTriggers(params object[] args)
         {
-            get
-            {
-                return CurrentRepresentation.PermittedTriggers;
-            }
+            return CurrentRepresentation.GetPermittedTriggers(args);
         }
 
         StateRepresentation CurrentRepresentation
@@ -273,7 +270,7 @@ namespace Stateless
             var source = State;
             var representativeState = GetRepresentation(source);
 
-            if (!representativeState.TryFindHandler(trigger, out TriggerBehaviourResult result))
+            if (!representativeState.TryFindHandler(trigger, args, out TriggerBehaviourResult result))
             {
                 _unhandledTriggerAction.Execute(representativeState.UnderlyingState, trigger, result?.UnmetGuardConditions);
                 return;
@@ -352,7 +349,7 @@ namespace Stateless
             return string.Format(
                 "StateMachine {{ State = {0}, PermittedTriggers = {{ {1} }}}}",
                 State,
-                string.Join(", ", PermittedTriggers.Select(t => t.ToString()).ToArray()));
+                string.Join(", ", GetPermittedTriggers().Select(t => t.ToString()).ToArray()));
         }
 
         /// <summary>

--- a/src/Stateless/StateRepresentation.cs
+++ b/src/Stateless/StateRepresentation.cs
@@ -45,18 +45,18 @@ namespace Stateless
                 return _substates;
             }
 
-            public bool CanHandle(TTrigger trigger)
+            public bool CanHandle(TTrigger trigger, params object[] args)
             {
-                return TryFindHandler(trigger, out TriggerBehaviourResult unused);
+                return TryFindHandler(trigger, args, out TriggerBehaviourResult unused);
             }
 
-            public bool TryFindHandler(TTrigger trigger, out TriggerBehaviourResult handler)
+            public bool TryFindHandler(TTrigger trigger, object[] args, out TriggerBehaviourResult handler)
             {
-                return (TryFindLocalHandler(trigger, out handler) ||
-                    (Superstate != null && Superstate.TryFindHandler(trigger, out handler)));
+                return (TryFindLocalHandler(trigger, args, out handler) ||
+                    (Superstate != null && Superstate.TryFindHandler(trigger, args, out handler)));
             }
 
-            bool TryFindLocalHandler(TTrigger trigger, out TriggerBehaviourResult handlerResult)
+            bool TryFindLocalHandler(TTrigger trigger, object[] args, out TriggerBehaviourResult handlerResult)
             {
                 if (!_triggerBehaviours.TryGetValue(trigger, out ICollection<TriggerBehaviour> possible))
                 {
@@ -66,7 +66,7 @@ namespace Stateless
 
                 // Guard functions executed
                 var actual = possible
-                    .Select(h => new TriggerBehaviourResult(h, h.UnmetGuardConditions));
+                    .Select(h => new TriggerBehaviourResult(h, h.UnmetGuardConditions(args)));
 
                 handlerResult = TryFindLocalHandlerResult(trigger, actual, r => !r.UnmetGuardConditions.Any())
                     ?? TryFindLocalHandlerResult(trigger, actual, r => r.UnmetGuardConditions.Any());
@@ -216,7 +216,7 @@ namespace Stateless
                 StateRepresentation aStateRep = this;
                 while (aStateRep != null)
                 {
-                    if (aStateRep.TryFindLocalHandler(transition.Trigger, out TriggerBehaviourResult result))
+                    if (aStateRep.TryFindLocalHandler(transition.Trigger, args, out TriggerBehaviourResult result))
                     {
                         // Trigger handler(s) found in this state
                         possibleActions.AddRange(aStateRep._internalActions);
@@ -279,19 +279,16 @@ namespace Stateless
                     (_superstate != null && _superstate.IsIncludedIn(state));
             }
 
-            public IEnumerable<TTrigger> PermittedTriggers
+            public IEnumerable<TTrigger> GetPermittedTriggers(params object[] args)
             {
-                get
-                {
-                    var result = _triggerBehaviours
-                        .Where(t => t.Value.Any(a => !a.UnmetGuardConditions.Any()))
-                        .Select(t => t.Key);
+                var result = _triggerBehaviours
+                    .Where(t => t.Value.Any(a => !a.UnmetGuardConditions(args).Any()))
+                    .Select(t => t.Key);
 
-                    if (Superstate != null)
-                        result = result.Union(Superstate.PermittedTriggers);
+                if (Superstate != null)
+                    result = result.Union(Superstate.GetPermittedTriggers(args));
 
-                    return result.ToArray();
-                }
+                return result.ToArray();
             }
         }
     }

--- a/src/Stateless/StateRepresentation.cs
+++ b/src/Stateless/StateRepresentation.cs
@@ -279,6 +279,14 @@ namespace Stateless
                     (_superstate != null && _superstate.IsIncludedIn(state));
             }
 
+			public IEnumerable<TTrigger> PermittedTriggers
+			{
+				get
+				{
+					return GetPermittedTriggers();
+				}
+			}
+
             public IEnumerable<TTrigger> GetPermittedTriggers(params object[] args)
             {
                 var result = _triggerBehaviours

--- a/src/Stateless/StateRepresentation.cs
+++ b/src/Stateless/StateRepresentation.cs
@@ -66,7 +66,7 @@ namespace Stateless
 
                 // Guard functions executed
                 var actual = possible
-                    .Select(h => new TriggerBehaviourResult(h, h.UnmetGuardConditions)).ToArray();
+                    .Select(h => new TriggerBehaviourResult(h, h.UnmetGuardConditions(args))).ToArray();
 
                 handlerResult = TryFindLocalHandlerResult(trigger, actual, r => !r.UnmetGuardConditions.Any())
                     ?? TryFindLocalHandlerResult(trigger, actual, r => r.UnmetGuardConditions.Any());

--- a/src/Stateless/TransitionGuard.cs
+++ b/src/Stateless/TransitionGuard.cs
@@ -89,7 +89,7 @@ namespace Stateless
             internal ICollection<Func<object[], bool>> Guards => Conditions.Select(g => g.Guard).ToList();
 
             /// <summary>
-            /// GetGuardConditionsMet is true if all of the guard functions return true
+            /// GuardConditionsMet is true if all of the guard functions return true
             /// or if there are no guard functions
             /// </summary>
             public bool GuardConditionsMet(object[] args)

--- a/src/Stateless/TransitionGuard.cs
+++ b/src/Stateless/TransitionGuard.cs
@@ -12,6 +12,21 @@ namespace Stateless
 
             public static readonly TransitionGuard Empty = new TransitionGuard(new Tuple<Func<object[],bool>, string>[0]);
 
+            internal TransitionGuard(Tuple<Func<bool>, string>[] guards)
+            {
+                Conditions = guards
+                    .Select(g => new GuardCondition(g.Item1, Reflection.InvocationInfo.Create(g.Item1, g.Item2)))
+                    .ToList();
+            }
+
+            internal TransitionGuard(Func<bool> guard, string description = null)
+            {
+                Conditions = new List<GuardCondition>
+                {
+                    new GuardCondition(guard, Reflection.InvocationInfo.Create(guard, description))
+                };
+            }
+
             internal TransitionGuard(Tuple<Func<object[],bool>, string>[] guards)
             {
                 Conditions = guards

--- a/src/Stateless/TransitionGuard.cs
+++ b/src/Stateless/TransitionGuard.cs
@@ -12,6 +12,47 @@ namespace Stateless
 
             public static readonly TransitionGuard Empty = new TransitionGuard(new Tuple<Func<object[],bool>, string>[0]);
 
+            public static Func<object[], bool> ToPackedGuard<TArg0>(Func<TArg0, bool> guard)
+            {
+                return args => guard(ParameterConversion.Unpack<TArg0>(args, 0));
+            }
+
+            public static Func<object[], bool> ToPackedGuard<TArg0, TArg1>(Func<TArg0, TArg1, bool> guard)
+            {
+                return args => guard(
+                    ParameterConversion.Unpack<TArg0>(args, 0), 
+                    ParameterConversion.Unpack<TArg1>(args, 1));
+            }
+
+            public static Func<object[], bool> ToPackedGuard<TArg0, TArg1, TArg2>(Func<TArg0, TArg1, TArg2, bool> guard)
+            {
+                return args => guard(
+                    ParameterConversion.Unpack<TArg0>(args, 0),
+                    ParameterConversion.Unpack<TArg1>(args, 1),
+                    ParameterConversion.Unpack<TArg2>(args, 2));
+            }
+
+            public static Tuple<Func<object[], bool>, string>[] ToPackedGuards<TArg0>(Tuple<Func<TArg0, bool>, string>[] guards)
+            {
+                return guards.Select(guard => new Tuple<Func<object[], bool>, string>(
+                        ToPackedGuard(guard.Item1), guard.Item2))
+                    .ToArray();
+            }
+
+            public static Tuple<Func<object[], bool>, string>[] ToPackedGuards<TArg0, TArg1>(Tuple<Func<TArg0, TArg1, bool>, string>[] guards)
+            {
+                return guards.Select(guard => new Tuple<Func<object[], bool>, string>(
+                        ToPackedGuard(guard.Item1), guard.Item2))
+                    .ToArray();
+            }
+
+            public static Tuple<Func<object[], bool>, string>[] ToPackedGuards<TArg0, TArg1, TArg2>(Tuple<Func<TArg0, TArg1, TArg2, bool>, string>[] guards)
+            {
+                return guards.Select(guard => new Tuple<Func<object[], bool>, string>(
+                        ToPackedGuard(guard.Item1), guard.Item2))
+                    .ToArray();
+            }
+
             internal TransitionGuard(Tuple<Func<bool>, string>[] guards)
             {
                 Conditions = guards
@@ -27,7 +68,7 @@ namespace Stateless
                 };
             }
 
-            internal TransitionGuard(Tuple<Func<object[],bool>, string>[] guards)
+            internal TransitionGuard(Tuple<Func<object[], bool>, string>[] guards)
             {
                 Conditions = guards
                     .Select(g => new GuardCondition(g.Item1, Reflection.InvocationInfo.Create(g.Item1, g.Item2)))

--- a/src/Stateless/TransitionGuard.cs
+++ b/src/Stateless/TransitionGuard.cs
@@ -10,44 +10,47 @@ namespace Stateless
         {
             internal IList<GuardCondition> Conditions { get; }
 
-            public static readonly TransitionGuard Empty = new TransitionGuard(new Tuple<Func<bool>, string>[0]);
+            public static readonly TransitionGuard Empty = new TransitionGuard(new Tuple<Func<object[],bool>, string>[0]);
 
-            internal TransitionGuard(Tuple<Func<bool>, string>[] guards)
+            internal TransitionGuard(Tuple<Func<object[],bool>, string>[] guards)
             {
                 Conditions = guards
                     .Select(g => new GuardCondition(g.Item1, Reflection.InvocationInfo.Create(g.Item1, g.Item2)))
                     .ToList();
             }
 
-            internal TransitionGuard(Func<bool> guard, string description = null)
+            internal TransitionGuard(Func<object[], bool> guard, string description = null)
             {
-                Conditions = new List<GuardCondition> { new GuardCondition(guard, Reflection.InvocationInfo.Create(guard, description)) };
+                Conditions = new List<GuardCondition>
+                {
+                    new GuardCondition(guard, Reflection.InvocationInfo.Create(guard, description))
+                };
             }
-
+            
             /// <summary>
             /// Guards is the list of the guard functions for all guard conditions for this transition
             /// </summary>
-            internal ICollection<Func<bool>> Guards => Conditions.Select(g => g.Guard).ToList();
+            internal ICollection<Func<object[], bool>> Guards => Conditions.Select(g => g.Guard).ToList();
 
             /// <summary>
-            /// GuardConditionsMet is true if all of the guard functions return true
+            /// GetGuardConditionsMet is true if all of the guard functions return true
             /// or if there are no guard functions
             /// </summary>
-            public bool GuardConditionsMet => Conditions.All(c => c.Guard());
+            public bool GuardConditionsMet(object[] args)
+            {
+                return Conditions.All(c => c.Guard == null || c.Guard(args));
+            }
 
             /// <summary>
             /// UnmetGuardConditions is a list of the descriptions of all guard conditions
             /// whose guard function returns false
             /// </summary>
-            public ICollection<string> UnmetGuardConditions
+            public ICollection<string> UnmetGuardConditions(object[] args)
             {
-                get
-                {
-                    return Conditions
-                        .Where(c => !c.Guard())
-                        .Select(c => c.Description)
-                        .ToList();
-                }
+                return Conditions
+                    .Where(c => !c.Guard(args))
+                    .Select(c => c.Description)
+                    .ToList();
             }
         }
     }

--- a/src/Stateless/TransitionGuard.cs
+++ b/src/Stateless/TransitionGuard.cs
@@ -12,6 +12,8 @@ namespace Stateless
 
             public static readonly TransitionGuard Empty = new TransitionGuard(new Tuple<Func<object[],bool>, string>[0]);
 
+            #region Generic TArg0, ... to object[] converters
+
             public static Func<object[], bool> ToPackedGuard<TArg0>(Func<TArg0, bool> guard)
             {
                 return args => guard(ParameterConversion.Unpack<TArg0>(args, 0));
@@ -52,6 +54,8 @@ namespace Stateless
                         ToPackedGuard(guard.Item1), guard.Item2))
                     .ToArray();
             }
+
+            #endregion
 
             internal TransitionGuard(Tuple<Func<bool>, string>[] guards)
             {

--- a/src/Stateless/TriggerBehaviour.cs
+++ b/src/Stateless/TriggerBehaviour.cs
@@ -39,10 +39,10 @@ namespace Stateless
             internal ICollection<Func<object[], bool>> Guards =>_guard.Guards;
 
             /// <summary>
-            /// GetGuardConditionsMet is true if all of the guard functions return true
+            /// GuardConditionsMet is true if all of the guard functions return true
             /// or if there are no guard functions
             /// </summary>
-            public bool GetGuardConditionsMet(params object[] args) => _guard.GuardConditionsMet(args);
+            public bool GuardConditionsMet(params object[] args) => _guard.GuardConditionsMet(args);
 
             /// <summary>
             /// UnmetGuardConditions is a list of the descriptions of all guard conditions

--- a/src/Stateless/TriggerBehaviour.cs
+++ b/src/Stateless/TriggerBehaviour.cs
@@ -36,19 +36,19 @@ namespace Stateless
             /// <summary>
             /// Guards is the list of guard functions for the transition guard for this trigger
             /// </summary>
-            internal ICollection<Func<bool>> Guards =>_guard.Guards;
+            internal ICollection<Func<object[], bool>> Guards =>_guard.Guards;
 
             /// <summary>
-            /// GuardConditionsMet is true if all of the guard functions return true
+            /// GetGuardConditionsMet is true if all of the guard functions return true
             /// or if there are no guard functions
             /// </summary>
-            public bool GuardConditionsMet => _guard.GuardConditionsMet;
+            public bool GetGuardConditionsMet(params object[] args) => _guard.GuardConditionsMet(args);
 
             /// <summary>
             /// UnmetGuardConditions is a list of the descriptions of all guard conditions
             /// whose guard function returns false
             /// </summary>
-            public ICollection<string> UnmetGuardConditions => _guard.UnmetGuardConditions;
+            public ICollection<string> UnmetGuardConditions(object[] args) => _guard.UnmetGuardConditions(args);
 
             public abstract bool ResultsInTransitionFrom(TState source, object[] args, out TState destination);
         }

--- a/test/Stateless.Tests/IgnoredTriggerBehaviourFixture.cs
+++ b/test/Stateless.Tests/IgnoredTriggerBehaviourFixture.cs
@@ -36,7 +36,7 @@ namespace Stateless.Tests
             var ignored = new StateMachine<State, Trigger>.IgnoredTriggerBehaviour(
                 Trigger.X, new StateMachine<State, Trigger>.TransitionGuard(False));
 
-            Assert.False(ignored.GetGuardConditionsMet());
+            Assert.False(ignored.GuardConditionsMet());
         }
 
         protected bool True(params object[] args)
@@ -50,7 +50,7 @@ namespace Stateless.Tests
             var ignored = new StateMachine<State, Trigger>.IgnoredTriggerBehaviour(
                 Trigger.X, new StateMachine<State, Trigger>.TransitionGuard(True));
 
-            Assert.True(ignored.GetGuardConditionsMet());
+            Assert.True(ignored.GuardConditionsMet());
         }
     }
 }

--- a/test/Stateless.Tests/IgnoredTriggerBehaviourFixture.cs
+++ b/test/Stateless.Tests/IgnoredTriggerBehaviourFixture.cs
@@ -25,7 +25,7 @@ namespace Stateless.Tests
             Assert.Equal(Trigger.X, ignored.Trigger);
         }
 
-        protected bool False()
+        protected bool False(params object[] args)
         {
             return false;
         }
@@ -36,10 +36,10 @@ namespace Stateless.Tests
             var ignored = new StateMachine<State, Trigger>.IgnoredTriggerBehaviour(
                 Trigger.X, new StateMachine<State, Trigger>.TransitionGuard(False));
 
-            Assert.False(ignored.GuardConditionsMet);
+            Assert.False(ignored.GetGuardConditionsMet());
         }
 
-        protected bool True()
+        protected bool True(params object[] args)
         {
             return true;
         }
@@ -50,7 +50,7 @@ namespace Stateless.Tests
             var ignored = new StateMachine<State, Trigger>.IgnoredTriggerBehaviour(
                 Trigger.X, new StateMachine<State, Trigger>.TransitionGuard(True));
 
-            Assert.True(ignored.GuardConditionsMet);
+            Assert.True(ignored.GetGuardConditionsMet());
         }
     }
 }

--- a/test/Stateless.Tests/InternalTransitionFixture.cs
+++ b/test/Stateless.Tests/InternalTransitionFixture.cs
@@ -210,9 +210,9 @@ namespace Stateless.Tests
             sm.Configure(State.A)
                 .InternalTransitionIf(Trigger.X, () => isPermitted, t => { });
 
-            Assert.Equal(1, sm.PermittedTriggers.ToArray().Length);
+            Assert.Equal(1, sm.GetPermittedTriggers().ToArray().Length);
             isPermitted = false;
-            Assert.Equal(0, sm.PermittedTriggers.ToArray().Length);
+            Assert.Equal(0, sm.GetPermittedTriggers().ToArray().Length);
         }
 
         [Fact]

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -654,6 +654,7 @@ namespace Stateless.Tests
             sm.Configure(State.A).IgnoreIf(x, (i) => i == 3);
 
             Assert.Throws<InvalidOperationException>(() => sm.Fire(x, 2));
+        }
 
         /// <summary>
         /// Verifies guard clauses are only called one time during a transition evaluation.

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using Xunit;
 
 namespace Stateless.Tests
@@ -561,116 +563,7 @@ namespace Stateless.Tests
 
             Assert.Throws<InvalidOperationException>(() => sm.Fire(x, 2));
         }
-
-        [Fact]
-        public void ExceptionWhenPermitIfHasMultipleExclusiveParameterizedGuardsBothFalse()
-        {
-            var sm = new StateMachine<State, Trigger>(State.A);
-            bool onUnhandledTriggerWasCalled = false;
-            sm.OnUnhandledTrigger((s, t) => { onUnhandledTriggerWasCalled = true; });  // Override
-            var x = sm.SetTriggerParameters<int>(Trigger.X);
-            sm.Configure(State.A)
-                .PermitIf(x, State.B, (i) => i == 3)
-                .PermitIf(x, State.C, (i) => i == 2);
-
-            sm.Fire(x, 5);  // This shouldn't throw an exception and we should just ignore it
-            Assert.True(onUnhandledTriggerWasCalled, "OnUnhandledTrigger was called");
-            Assert.Equal(sm.State, State.A);
-        }
-
-        [Fact]
-        public void NoExceptionWhenPermitIfHasMultipleExclusiveGuardsBothFalse()
-        {
-            var sm = new StateMachine<State, Trigger>(State.A);
-            bool onUnhandledTriggerWasCalled = false;
-            sm.OnUnhandledTrigger((s, t) => { onUnhandledTriggerWasCalled = true; });  // Override
-            int i = 0;
-            sm.Configure(State.A)
-                .PermitIf(Trigger.X, State.B, () => i == 2)
-                .PermitIf(Trigger.X, State.C, () => i == 1);
-
-            sm.Fire(Trigger.X);  // This shouldn't throw an exception and we should just ignore it
-
-            Assert.True(onUnhandledTriggerWasCalled, "OnUnhandledTrigger was called");
-            Assert.Equal(sm.State, State.A);
-        }
-
-        [Fact]
-        public void NoExceptionWhenPermitIfHasMultipleExclusiveGuardsOneTrue()
-        {
-            var sm = new StateMachine<State, Trigger>(State.A);
-
-            int i = 0;
-            sm.Configure(State.A)
-                .PermitIf(Trigger.X, State.B, () => i == 2)
-                .PermitIf(Trigger.X, State.C, () => i == 1)
-                .PermitIf(Trigger.X, State.D, () => i == 0);
-
-            sm.Fire(Trigger.X);  // This shouldn't throw an exception and we should just ignore it
-            
-            Assert.Equal(sm.State, State.D);
-        }
-
-        [Fact]
-        public void SuperStateIgnoreIfOverridesChildWithSimilarGuardPermit()
-        {
-            var sm = new StateMachine<State, Trigger>(State.B);
-            int i = 0;
-            sm.Configure(State.A).IgnoreIf(Trigger.X, () => i <= 0);
-            {
-                sm.Configure(State.B).SubstateOf(State.A)
-                    .PermitIf(Trigger.X, State.D, () => i == 1);
-            }
-
-            sm.Fire(Trigger.X);  // This shouldn't throw an exception and we should just ignore it
-            Assert.Equal(sm.State, State.B);
-        }
-
-        [Fact]
-        public void SuperStateIgnoreProtectsChildState()
-        {
-            var sm = new StateMachine<State, Trigger>(State.B);
-
-            sm.Configure(State.A).Ignore(Trigger.X);
-            {
-                sm.Configure(State.B).SubstateOf(State.A);
-            }
-
-            sm.Fire(Trigger.X);  // This shouldn't throw an exception and we should just ignore it
-            Assert.Equal(sm.State, State.B);
-        }
-
-        [Fact]
-        public void SuperStateIgnoreOverridesChildPermit()
-        {
-            var sm = new StateMachine<State, Trigger>(State.B);
-
-            sm.Configure(State.A).Ignore(Trigger.X);
-            {
-                sm.Configure(State.B).SubstateOf(State.A)
-                    .Permit(Trigger.X, State.C);
-            }
-
-            sm.Fire(Trigger.X);  // This shouldn't throw an exception and we should just ignore it
-            Assert.Equal(sm.State, State.B);
-        }
-
-        [Fact]
-        public void SuperStateIgnoreOverridesChildPermitIfGuardFalse()
-        {
-            var sm = new StateMachine<State, Trigger>(State.B);
-
-            int i = 0;
-            sm.Configure(State.A).Ignore(Trigger.X);
-            {
-                sm.Configure(State.B).SubstateOf(State.A)
-                    .PermitIf(Trigger.X, State.C, () => i == 2);
-            }
-
-            sm.Fire(Trigger.X);  // This shouldn't throw an exception and we should just ignore it
-            Assert.Equal(sm.State, State.B);
-        }
-
+        
         [Fact]
         public void TransitionWhenPermitDyanmicIfHasMultipleExclusiveGuards()
         {

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -632,5 +632,26 @@ namespace Stateless.Tests
 
             Assert.Throws<InvalidOperationException>(() => sm.Fire(x, 2));
         }
+
+        [Fact]
+        public void NoTransitionWhenIgnoreIfParameterizedGuardTrue()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var x = sm.SetTriggerParameters<int>(Trigger.X);
+            sm.Configure(State.A).IgnoreIf(x, (i) => i == 3);
+            sm.Fire(x, 3);
+
+            Assert.Equal(sm.State, State.A);
+        }
+
+        [Fact]
+        public void ExceptionWhenIgnoreIfParameterizedGuardFalse()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var x = sm.SetTriggerParameters<int>(Trigger.X);
+            sm.Configure(State.A).IgnoreIf(x, (i) => i == 3);
+
+            Assert.Throws<InvalidOperationException>(() => sm.Fire(x, 2));
+        }
     }
 }

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -470,74 +470,167 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        public void ParametersWithInValidGuardConditionAreRejected()
+        public void TransitionWhenParameterizedGuardTrue()
         {
             var sm = new StateMachine<State, Trigger>(State.A);
-            var twp = sm.SetTriggerParameters<string>(Trigger.X);
-            sm.Configure(State.A).PermitIf(twp, State.B, o => o == "3");
-            Assert.Equal(sm.State, State.A);
-
-            Assert.Throws<InvalidOperationException>(() => sm.Fire(twp, "2"));
-        }
-
-        [Fact]
-        public void ParametersWithValidGuardConditionAreAccepted()
-        {
-            var sm = new StateMachine<State, Trigger>(State.A);
-            var twp = sm.SetTriggerParameters<string>(Trigger.X);
-            sm.Configure(State.A).PermitIf(twp, State.B, o => o == "2");
-            sm.Fire(twp, "2");
-            Assert.Equal(sm.State, State.B);
-        }
-
-        [Fact]
-        public void ExceptionThrownWhenBothParameterizedGuardClausesReturnFalse()
-        {
-            var sm = new StateMachine<State, Trigger>(State.A);
-            var twp = sm.SetTriggerParameters<int>(Trigger.X);
-            // Create Two guards that both must be true
-            var positiveGuard = Tuple.Create(new Func<int, bool>(o => o == 2), "Positive Guard");
-            var negativeGuard = Tuple.Create(new Func<int, bool>(o => o != 3), "Negative Guard");
-            sm.Configure(State.A).PermitIf(twp, State.B, positiveGuard, negativeGuard);
-
-            Assert.Throws<InvalidOperationException>(() => sm.Fire(twp, 3));
-        }
-
-        [Fact]
-        public void TransitionWhenBothParameterizedGuardClausesReturnTrue()
-        {
-            var sm = new StateMachine<State, Trigger>(State.A);
-            var twp = sm.SetTriggerParameters<int>(Trigger.X);
-            // Create Two guards that both must be true
-            var positiveGuard = Tuple.Create(new Func<int, bool>(o => o == 2), "Positive Guard");
-            var negativeGuard = Tuple.Create(new Func<int, bool>(o => o != 3), "Negative Guard");
-            sm.Configure(State.A).PermitIf(twp, State.B, positiveGuard, negativeGuard);
-            sm.Fire(twp, 2);
+            var x = sm.SetTriggerParameters<int>(Trigger.X);
+            sm.Configure(State.A).PermitIf(x, State.B, i => i == 2);
+            sm.Fire(x, 2);
 
             Assert.Equal(sm.State, State.B);
         }
 
         [Fact]
-        public void ExceptionThrownWhenGuardReturnsFalseOnTriggerWithMultipleParameters()
+        public void ExceptionWhenParameterizedGuardFalse()
         {
             var sm = new StateMachine<State, Trigger>(State.A);
-            var twp = sm.SetTriggerParameters<string, int>(Trigger.X);
-            sm.Configure(State.A).PermitIf(twp, State.B, (s, i) => s == "3" && i == 3);
-            Assert.Equal(sm.State, State.A);
+            var x = sm.SetTriggerParameters<int>(Trigger.X);
+            sm.Configure(State.A).PermitIf(x, State.B, i => i == 3);
 
-            Assert.Throws<InvalidOperationException>(() => sm.Fire(twp, "2", 2));
-            Assert.Throws<InvalidOperationException>(() => sm.Fire(twp, "3", 2));
-            Assert.Throws<InvalidOperationException>(() => sm.Fire(twp, "2", 3));
+            Assert.Throws<InvalidOperationException>(() => sm.Fire(x, 2));
+        }
+
+        [Fact]
+        public void TransitionWhenBothParameterizedGuardClausesTrue()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var x = sm.SetTriggerParameters<int>(Trigger.X);
+            var positiveGuard = Tuple.Create(new Func<int, bool>(o => o == 2), "Positive Guard");
+            var negativeGuard = Tuple.Create(new Func<int, bool>(o => o != 3), "Negative Guard");
+            sm.Configure(State.A).PermitIf(x, State.B, positiveGuard, negativeGuard);
+            sm.Fire(x, 2);
+
+            Assert.Equal(sm.State, State.B);
+        }
+
+        [Fact]
+        public void ExceptionWhenBothParameterizedGuardClausesFalse()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var x = sm.SetTriggerParameters<int>(Trigger.X);
+            // Create Two guards that both must be true
+            var positiveGuard = Tuple.Create(new Func<int, bool>(o => o == 2), "Positive Guard");
+            var negativeGuard = Tuple.Create(new Func<int, bool>(o => o != 3), "Negative Guard");
+            sm.Configure(State.A).PermitIf(x, State.B, positiveGuard, negativeGuard);
+
+            Assert.Throws<InvalidOperationException>(() => sm.Fire(x, 3));
         }
 
         [Fact]
         public void TransitionWhenGuardReturnsTrueOnTriggerWithMultipleParameters()
         {
             var sm = new StateMachine<State, Trigger>(State.A);
-            var twp = sm.SetTriggerParameters<string, int>(Trigger.X);
-            sm.Configure(State.A).PermitIf(twp, State.B, (s, i) => s == "3" && i == 3);
-            sm.Fire(twp, "3", 3);
+            var x = sm.SetTriggerParameters<string, int>(Trigger.X);
+            sm.Configure(State.A).PermitIf(x, State.B, (s, i) => s == "3" && i == 3);
+            sm.Fire(x, "3", 3);
             Assert.Equal(sm.State, State.B);
+        }
+
+        [Fact]
+        public void ExceptionWhenGuardFalseOnTriggerWithMultipleParameters()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var x = sm.SetTriggerParameters<string, int>(Trigger.X);
+            sm.Configure(State.A).PermitIf(x, State.B, (s, i) => s == "3" && i == 3);
+            Assert.Equal(sm.State, State.A);
+
+            Assert.Throws<InvalidOperationException>(() => sm.Fire(x, "2", 2));
+            Assert.Throws<InvalidOperationException>(() => sm.Fire(x, "3", 2));
+            Assert.Throws<InvalidOperationException>(() => sm.Fire(x, "2", 3));
+        }
+
+        [Fact]
+        public void TransitionWhenPermitIfHasMultipleExclusiveGuards()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var x = sm.SetTriggerParameters<int>(Trigger.X);
+            sm.Configure(State.A)
+                .PermitIf(x, State.B, (i) => i == 3)
+                .PermitIf(x, State.C, (i) => i == 2);
+            sm.Fire(x, 3);
+            Assert.Equal(sm.State, State.B);
+        }
+
+        [Fact]
+        public void ExceptionWhenPermitIfHasMultipleNonExclusiveGuards()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var x = sm.SetTriggerParameters<int>(Trigger.X);
+            sm.Configure(State.A).PermitIf(x, State.B, (i) => i % 2 == 0)  // Is Even
+                .PermitIf(x, State.C, (i) => i == 2);
+
+            Assert.Throws<InvalidOperationException>(() => sm.Fire(x, 2));
+        }
+
+        [Fact]
+        public void TransitionWhenPermitDyanmicIfHasMultipleExclusiveGuards()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var x = sm.SetTriggerParameters<int>(Trigger.X);
+            sm.Configure(State.A)
+                .PermitDynamicIf(x, (i) => i == 3 ? State.B : State.C, (i) => i == 3 || i == 5)
+                .PermitDynamicIf(x, (i) => i == 2 ? State.C : State.D, (i) => i == 2 || i == 4);
+            sm.Fire(x, 3);
+            Assert.Equal(sm.State, State.B);
+        }
+
+        [Fact]
+        public void ExceptionWhenPermitDyanmicIfHasMultipleNonExclusiveGuards()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var x = sm.SetTriggerParameters<int>(Trigger.X);
+            sm.Configure(State.A).PermitDynamicIf(x, (i) => i == 4 ? State.B : State.C, (i) => i % 2 == 0)
+                .PermitDynamicIf(x, (i) => i == 2 ? State.C : State.D, (i) => i == 2);
+
+            Assert.Throws<InvalidOperationException>(() => sm.Fire(x, 2));
+        }
+
+        [Fact]
+        public void TransitionWhenPermitIfHasMultipleExclusiveGuardsWithSuperStateTrue()
+        {
+            var sm = new StateMachine<State, Trigger>(State.B);
+            var x = sm.SetTriggerParameters<int>(Trigger.X);
+            sm.Configure(State.A).PermitIf(x, State.D, (i) => i == 3);
+            {
+                sm.Configure(State.B).SubstateOf(State.A).PermitIf(x, State.C, (i) => i == 2);
+            }
+            sm.Fire(x, 3);
+            Assert.Equal(sm.State, State.D);
+        }
+
+        [Fact]
+        public void TransitionWhenPermitIfHasMultipleExclusiveGuardsWithSuperStateFalse()
+        {
+            var sm = new StateMachine<State, Trigger>(State.B);
+            var x = sm.SetTriggerParameters<int>(Trigger.X);
+            sm.Configure(State.A).PermitIf(x, State.D, (i) => i == 3);
+            {
+                sm.Configure(State.B).SubstateOf(State.A).PermitIf(x, State.C, (i) => i == 2);
+            }
+            sm.Fire(x, 2);
+            Assert.Equal(sm.State, State.C);
+        }
+
+        [Fact]
+        public void TransitionWhenPermitReentryIfParameterizedGuardTrue()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var x = sm.SetTriggerParameters<int>(Trigger.X);
+            sm.Configure(State.A)
+                .PermitReentryIf(x, (i) => i == 3 );
+            sm.Fire(x, 3);
+            Assert.Equal(sm.State, State.A);
+        }
+
+        [Fact]
+        public void TransitionWhenPermitReentryIfParameterizedGuardFalse()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var x = sm.SetTriggerParameters<int>(Trigger.X);
+            sm.Configure(State.A)
+                .PermitReentryIf(x, (i) => i == 3);
+
+            Assert.Throws<InvalidOperationException>(() => sm.Fire(x, 2));
         }
     }
 }

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -566,13 +566,15 @@ namespace Stateless.Tests
         public void ExceptionWhenPermitIfHasMultipleExclusiveParameterizedGuardsBothFalse()
         {
             var sm = new StateMachine<State, Trigger>(State.A);
-            sm.OnUnhandledTrigger((s, t) => { });  // Override
+            bool onUnhandledTriggerWasCalled = false;
+            sm.OnUnhandledTrigger((s, t) => { onUnhandledTriggerWasCalled = true; });  // Override
             var x = sm.SetTriggerParameters<int>(Trigger.X);
             sm.Configure(State.A)
                 .PermitIf(x, State.B, (i) => i == 3)
                 .PermitIf(x, State.C, (i) => i == 2);
 
             sm.Fire(x, 5);  // This shouldn't throw an exception and we should just ignore it
+            Assert.True(onUnhandledTriggerWasCalled, "OnUnhandledTrigger was called");
             Assert.Equal(sm.State, State.A);
         }
 
@@ -580,25 +582,58 @@ namespace Stateless.Tests
         public void NoExceptionWhenPermitIfHasMultipleExclusiveGuardsBothFalse()
         {
             var sm = new StateMachine<State, Trigger>(State.A);
+            bool onUnhandledTriggerWasCalled = false;
+            sm.OnUnhandledTrigger((s, t) => { onUnhandledTriggerWasCalled = true; });  // Override
             int i = 0;
             sm.Configure(State.A)
-                .PermitIf(Trigger.X, State.B, () => i == 3)  // Is Even
-                .PermitIf(Trigger.X, State.C, () => i == 2);
+                .PermitIf(Trigger.X, State.B, () => i == 2)
+                .PermitIf(Trigger.X, State.C, () => i == 1);
 
             sm.Fire(Trigger.X);  // This shouldn't throw an exception and we should just ignore it
+
+            Assert.True(onUnhandledTriggerWasCalled, "OnUnhandledTrigger was called");
             Assert.Equal(sm.State, State.A);
         }
 
         [Fact]
-        public void SuperStateIgnoreIfOverridesChildPermit()
+        public void NoExceptionWhenPermitIfHasMultipleExclusiveGuardsOneTrue()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            int i = 0;
+            sm.Configure(State.A)
+                .PermitIf(Trigger.X, State.B, () => i == 2)
+                .PermitIf(Trigger.X, State.C, () => i == 1)
+                .PermitIf(Trigger.X, State.D, () => i == 0);
+
+            sm.Fire(Trigger.X);  // This shouldn't throw an exception and we should just ignore it
+            
+            Assert.Equal(sm.State, State.D);
+        }
+
+        [Fact]
+        public void SuperStateIgnoreIfOverridesChildWithSimilarGuardPermit()
         {
             var sm = new StateMachine<State, Trigger>(State.B);
             int i = 0;
-            sm.Configure(State.A).IgnoreIf(Trigger.X, () => i == 0);
+            sm.Configure(State.A).IgnoreIf(Trigger.X, () => i <= 0);
             {
                 sm.Configure(State.B).SubstateOf(State.A)
-                    .PermitIf(Trigger.X, State.C, () => i == 3)
-                    .PermitIf(Trigger.X, State.D, () => i == 2);
+                    .PermitIf(Trigger.X, State.D, () => i == 1);
+            }
+
+            sm.Fire(Trigger.X);  // This shouldn't throw an exception and we should just ignore it
+            Assert.Equal(sm.State, State.B);
+        }
+
+        [Fact]
+        public void SuperStateIgnoreProtectsChildState()
+        {
+            var sm = new StateMachine<State, Trigger>(State.B);
+
+            sm.Configure(State.A).Ignore(Trigger.X);
+            {
+                sm.Configure(State.B).SubstateOf(State.A);
             }
 
             sm.Fire(Trigger.X);  // This shouldn't throw an exception and we should just ignore it
@@ -614,6 +649,22 @@ namespace Stateless.Tests
             {
                 sm.Configure(State.B).SubstateOf(State.A)
                     .Permit(Trigger.X, State.C);
+            }
+
+            sm.Fire(Trigger.X);  // This shouldn't throw an exception and we should just ignore it
+            Assert.Equal(sm.State, State.B);
+        }
+
+        [Fact]
+        public void SuperStateIgnoreOverridesChildPermitIfGuardFalse()
+        {
+            var sm = new StateMachine<State, Trigger>(State.B);
+
+            int i = 0;
+            sm.Configure(State.A).Ignore(Trigger.X);
+            {
+                sm.Configure(State.B).SubstateOf(State.A)
+                    .PermitIf(Trigger.X, State.C, () => i == 2);
             }
 
             sm.Fire(Trigger.X);  // This shouldn't throw an exception and we should just ignore it

--- a/test/Stateless.Tests/StateRepresentationFixture.cs
+++ b/test/Stateless.Tests/StateRepresentationFixture.cs
@@ -325,7 +325,7 @@ namespace Stateless.Tests
             Assert.False(sub.CanHandle(Trigger.X));
             Assert.False(super.CanHandle(Trigger.X));
             Assert.NotNull(result);
-            Assert.False(result?.Handler.GetGuardConditionsMet());
+            Assert.False(result?.Handler.GuardConditionsMet());
             Assert.Contains("2", result?.UnmetGuardConditions.ToArray());
             
         }
@@ -347,7 +347,7 @@ namespace Stateless.Tests
             Assert.True(sub.CanHandle(Trigger.X));
             Assert.True(super.CanHandle(Trigger.X));
             Assert.NotNull(result);     
-            Assert.True(result?.Handler.GetGuardConditionsMet());
+            Assert.True(result?.Handler.GuardConditionsMet());
             Assert.False(result?.UnmetGuardConditions.Any());
 
         }

--- a/test/Stateless.Tests/StateRepresentationFixture.cs
+++ b/test/Stateless.Tests/StateRepresentationFixture.cs
@@ -279,8 +279,8 @@ namespace Stateless.Tests
             var rep = CreateRepresentation(State.B);
 
             var falseConditions = new[] {
-                new Tuple<Func<bool>, string>(() => true, "1"),
-                new Tuple<Func<bool>, string>(() => false, "2")
+                new Tuple<Func<object[], bool>, string>((args) => true, "1"),
+                new Tuple<Func<object[], bool>, string>((args) => false, "2")
             };
 
             var transitionGuard = new StateMachine<State, Trigger>.TransitionGuard(falseConditions);
@@ -296,8 +296,8 @@ namespace Stateless.Tests
             var rep = CreateRepresentation(State.B);
 
             var trueConditions = new[] {
-                new Tuple<Func<bool>, string>(() => true, "1"),
-                new Tuple<Func<bool>, string>(() => true, "2")
+                new Tuple<Func<object[], bool>, string>(args => true, "1"),
+                new Tuple<Func<object[], bool>, string>(args => true, "2")
             };
 
             var transitionGuard = new StateMachine<State, Trigger>.TransitionGuard(trueConditions);
@@ -313,19 +313,19 @@ namespace Stateless.Tests
             CreateSuperSubstatePair(out StateMachine<State, Trigger>.StateRepresentation super, out StateMachine<State, Trigger>.StateRepresentation sub);
 
             var falseConditions = new[] {
-                new Tuple<Func<bool>, string>(() => true, "1"),
-                new Tuple<Func<bool>, string>(() => false, "2")
+                new Tuple<Func<object[], bool>, string>(args => true, "1"),
+                new Tuple<Func<object[], bool>, string>(args => false, "2")
             };
             var transitionGuard = new StateMachine<State, Trigger>.TransitionGuard(falseConditions);
             var transition = new StateMachine<State, Trigger>.TransitioningTriggerBehaviour(Trigger.X, State.C, transitionGuard);
             super.AddTriggerBehaviour(transition);
 
-            sub.TryFindHandler(Trigger.X, out StateMachine<State, Trigger>.TriggerBehaviourResult result);
+            sub.TryFindHandler(Trigger.X, new object[0], out StateMachine<State, Trigger>.TriggerBehaviourResult result);
 
             Assert.False(sub.CanHandle(Trigger.X));
             Assert.False(super.CanHandle(Trigger.X));
             Assert.NotNull(result);
-            Assert.False(result?.Handler.GuardConditionsMet);
+            Assert.False(result?.Handler.GetGuardConditionsMet());
             Assert.Contains("2", result?.UnmetGuardConditions.ToArray());
             
         }
@@ -335,19 +335,19 @@ namespace Stateless.Tests
             CreateSuperSubstatePair(out StateMachine<State, Trigger>.StateRepresentation super, out StateMachine<State, Trigger>.StateRepresentation sub);
 
             var trueConditions = new[] {
-                new Tuple<Func<bool>, string>(() => true, "1"),
-                new Tuple<Func<bool>, string>(() => true, "2")
+                new Tuple<Func<object[], bool>, string>(args => true, "1"),
+                new Tuple<Func<object[], bool>, string>(args => true, "2")
             };
             var transitionGuard = new StateMachine<State, Trigger>.TransitionGuard(trueConditions);
             var transition = new StateMachine<State, Trigger>.TransitioningTriggerBehaviour(Trigger.X, State.C, transitionGuard);
 
             super.AddTriggerBehaviour(transition);
-            sub.TryFindHandler(Trigger.X, out StateMachine<State, Trigger>.TriggerBehaviourResult result);
+            sub.TryFindHandler(Trigger.X, new object[0], out StateMachine<State, Trigger>.TriggerBehaviourResult result);
 
             Assert.True(sub.CanHandle(Trigger.X));
             Assert.True(super.CanHandle(Trigger.X));
             Assert.NotNull(result);     
-            Assert.True(result?.Handler.GuardConditionsMet);
+            Assert.True(result?.Handler.GetGuardConditionsMet());
             Assert.False(result?.UnmetGuardConditions.Any());
 
         }

--- a/test/Stateless.Tests/TriggerBehaviourFixture.cs
+++ b/test/Stateless.Tests/TriggerBehaviourFixture.cs
@@ -17,7 +17,7 @@ namespace Stateless.Tests
             Assert.Equal(Trigger.X, transitioning.Trigger);
         }
 
-        protected bool False()
+        protected bool False(params object[] args)
         {
             return false;
         }
@@ -28,10 +28,10 @@ namespace Stateless.Tests
             var transitioning = new StateMachine<State, Trigger>.TransitioningTriggerBehaviour(
                 Trigger.X, State.C, new StateMachine<State, Trigger>.TransitionGuard(False));
 
-            Assert.False(transitioning.GuardConditionsMet);
+            Assert.False(transitioning.GetGuardConditionsMet());
         }
 
-        protected bool True()
+        protected bool True(params object[] args)
         {
             return true;
         }
@@ -42,49 +42,49 @@ namespace Stateless.Tests
             var transitioning = new StateMachine<State, Trigger>.TransitioningTriggerBehaviour(
                 Trigger.X, State.C, new StateMachine<State, Trigger>.TransitionGuard(True));
 
-            Assert.True(transitioning.GuardConditionsMet);
+            Assert.True(transitioning.GetGuardConditionsMet());
         }
 
         [Fact]
         public void WhenOneOfMultipleGuardConditionsFalse_GuardConditionsMetIsFalse()
         {
             var falseGuard = new[] {
-                new Tuple<Func<bool>, string>(() => true, "1"),
-                new Tuple<Func<bool>, string>(() => true, "2")
+                new Tuple<Func<object[], bool>, string>(args => true, "1"),
+                new Tuple<Func<object[], bool>, string>(args => true, "2")
             };
 
             var transitioning = new StateMachine<State, Trigger>.TransitioningTriggerBehaviour(
                 Trigger.X, State.C, new StateMachine<State, Trigger>.TransitionGuard(falseGuard));
 
-            Assert.True(transitioning.GuardConditionsMet);
+            Assert.True(transitioning.GetGuardConditionsMet());
         }
 
         [Fact]
         public void WhenAllMultipleGuardConditionsFalse_IsGuardConditionsMetIsFalse()
         {
             var falseGuard = new[] {
-                new Tuple<Func<bool>, string>(() => false, "1"),
-                new Tuple<Func<bool>, string>(() => false, "2")
+                new Tuple<Func<object[], bool>, string>(args => false, "1"),
+                new Tuple<Func<object[], bool>, string>(args => false, "2")
             };
 
             var transitioning = new StateMachine<State, Trigger>.TransitioningTriggerBehaviour(
                 Trigger.X, State.C, new StateMachine<State, Trigger>.TransitionGuard(falseGuard));
 
-            Assert.False(transitioning.GuardConditionsMet);
+            Assert.False(transitioning.GetGuardConditionsMet());
         }
 
         [Fact]
         public void WhenAllGuardConditionsTrue_GuardConditionsMetIsTrue()
         {
             var trueGuard = new[] {
-                new Tuple<Func<bool>, string>(() => true, "1"),
-                new Tuple<Func<bool>, string>(() => true, "2")
+                new Tuple<Func<object[], bool>, string>(args => true, "1"),
+                new Tuple<Func<object[], bool>, string>(args => true, "2")
             };
 
             var transitioning = new StateMachine<State, Trigger>.TransitioningTriggerBehaviour(
                 Trigger.X, State.C, new StateMachine<State, Trigger>.TransitionGuard(trueGuard));
 
-            Assert.True(transitioning.GuardConditionsMet);
+            Assert.True(transitioning.GetGuardConditionsMet());
         }
     }
 }

--- a/test/Stateless.Tests/TriggerBehaviourFixture.cs
+++ b/test/Stateless.Tests/TriggerBehaviourFixture.cs
@@ -28,7 +28,7 @@ namespace Stateless.Tests
             var transitioning = new StateMachine<State, Trigger>.TransitioningTriggerBehaviour(
                 Trigger.X, State.C, new StateMachine<State, Trigger>.TransitionGuard(False));
 
-            Assert.False(transitioning.GetGuardConditionsMet());
+            Assert.False(transitioning.GuardConditionsMet());
         }
 
         protected bool True(params object[] args)
@@ -42,7 +42,7 @@ namespace Stateless.Tests
             var transitioning = new StateMachine<State, Trigger>.TransitioningTriggerBehaviour(
                 Trigger.X, State.C, new StateMachine<State, Trigger>.TransitionGuard(True));
 
-            Assert.True(transitioning.GetGuardConditionsMet());
+            Assert.True(transitioning.GuardConditionsMet());
         }
 
         [Fact]
@@ -56,7 +56,7 @@ namespace Stateless.Tests
             var transitioning = new StateMachine<State, Trigger>.TransitioningTriggerBehaviour(
                 Trigger.X, State.C, new StateMachine<State, Trigger>.TransitionGuard(falseGuard));
 
-            Assert.True(transitioning.GetGuardConditionsMet());
+            Assert.True(transitioning.GuardConditionsMet());
         }
 
         [Fact]
@@ -70,7 +70,7 @@ namespace Stateless.Tests
             var transitioning = new StateMachine<State, Trigger>.TransitioningTriggerBehaviour(
                 Trigger.X, State.C, new StateMachine<State, Trigger>.TransitionGuard(falseGuard));
 
-            Assert.False(transitioning.GetGuardConditionsMet());
+            Assert.False(transitioning.GuardConditionsMet());
         }
 
         [Fact]
@@ -84,7 +84,7 @@ namespace Stateless.Tests
             var transitioning = new StateMachine<State, Trigger>.TransitioningTriggerBehaviour(
                 Trigger.X, State.C, new StateMachine<State, Trigger>.TransitionGuard(trueGuard));
 
-            Assert.True(transitioning.GetGuardConditionsMet());
+            Assert.True(transitioning.GuardConditionsMet());
         }
     }
 }

--- a/test/Stateless.Tests/TriggerWithParametersFixture.cs
+++ b/test/Stateless.Tests/TriggerWithParametersFixture.cs
@@ -21,7 +21,7 @@ namespace Stateless.Tests
             var twp = new StateMachine<State, Trigger>.TriggerWithParameters<string>(Trigger.X);
             twp.ValidateParameters(new[] { "arg" });
         }
-
+        
         [Fact]
         public void ParametersArePolymorphic()
         {


### PR DESCRIPTION
Add support for guard clauses as those found in the *If() configurations to support arguments passed in via a TriggerWithParameters trigger.  Similar to how the Dynamic functions handled passed in arguments. 

Example:
```csharp
var sm = new StateMachine<State, Trigger>(State.A);
var x = sm.SetTriggerParameters<int>(Trigger.X);
sm.Configure(State.A).PermitIf(x, State.B, i => i == 2);
sm.Fire(x, 1);    // Does not transition
sm.Fire(x, 2);    // transitions to state B
```

Add the following functions to StateConfiguration:
```csharp
InternalTransitionIf<TArg0>(TriggerWithParameters<TArg0> trigger, Func<TArg0, bool> guard, Action<TArg0, Transition> internalAction)
InternalTransitionIf<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Func<TArg0, TArg1, bool> guard, Action<TArg0, TArg1, Transition> internalAction)
InternalTransitionIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Func<TArg0, TArg1, TArg2, bool> guard, Action<TArg0, TArg1, TArg2, Transition> internalAction)

PermitIf<TArg0>(TriggerWithParameters<TArg0> trigger, TState destinationState, Func<TArg0, bool> guard, string guardDescription = null)
PermitIf<TArg0>(TriggerWithParameters<TArg0> trigger, TState destinationState, params Tuple<Func<TArg0, bool>, string>[] guards)
PermitIf<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, TState destinationState, Func<TArg0, TArg1, bool> guard, string guardDescription = null)
PermitIf<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, TState destinationState, params Tuple<Func<TArg0, TArg1, bool>, string>[] guards)
PermitIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, TState destinationState, Func<TArg0, TArg1, TArg2, bool> guard, string guardDescription = null)
PermitIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, TState destinationState, params Tuple<Func<TArg0, TArg1, TArg2, bool>, string>[] guards)

PermitReentryIf<TArg0>(TriggerWithParameters<TArg0> trigger, Func<TArg0, bool> guard, string guardDescription = null)
PermitReentryIf<TArg0>(TriggerWithParameters<TArg0> trigger, params Tuple<Func<TArg0, bool>, string>[] guards)
PermitReentryIf<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Func<TArg0, TArg1, bool> guard, string guardDescription = null)
PermitReentryIf<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, params Tuple<Func<TArg0, TArg1, bool>, string>[] guards)
PermitReentryIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Func<TArg0, TArg1, TArg2, bool> guard, string guardDescription = null)
PermitReentryIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, params Tuple<Func<TArg0, TArg1, TArg2, bool>, string>[] guards)

IgnoreIf<TArg0>(TriggerWithParameters<TArg0> trigger, Func<TArg0, bool> guard, string guardDescription = null)
IgnoreIf<TArg0>(TriggerWithParameters<TArg0> trigger, params Tuple<Func<TArg0, bool>, string>[] guards)
IgnoreIf<TArg0, TArgo1>(TriggerWithParameters<TArg0, TArgo1> trigger, Func<TArg0, TArgo1, bool> guard, string guardDescription = null)
IgnoreIf<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, params Tuple<Func<TArg0, TArg1, bool>, string>[] guards)
IgnoreIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Func<TArg0, TArg1, TArg2, bool> guard, string guardDescription = null)
IgnoreIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, params Tuple<Func<TArg0, TArg1, TArg2, bool>, string>[] guards)

PermitDynamicIf<TArg0>(TriggerWithParameters<TArg0> trigger, Func<TArg0, TState> destinationStateSelector, Func<TArg0, bool> guard, string guardDescription = null)
PermitDynamicIf<TArg0>(TriggerWithParameters<TArg0> trigger, Func<TArg0, TState> destinationStateSelector, params Tuple<Func<TArg0, bool>, string>[] guards)
PermitDynamicIf<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Func<TArg0, TArg1, TState> destinationStateSelector, Func<TArg0, TArg1, bool> guard, string guardDescription = null)
PermitDynamicIf<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Func<TArg0, TArg1, TState> destinationStateSelector, Tuple<Func<TArg0, TArg1, bool>, string>[] guards)
PermitDynamicIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Func<TArg0, TArg1, TArg2, TState> destinationStateSelector, Func<TArg0, TArg1, TArg2, bool> guard, string guardDescription = null)
PermitDynamicIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Func<TArg0, TArg1, TArg2, TState> destinationStateSelector, Tuple<Func<TArg0, TArg1, TArg2, bool>, string>[] guards)

```

I needed to make changes to how guard clauses function in order to support optional arguments.  Because of that, the underlying guard clause type is now ```Func<object[], bool>``` instead of ```Func<bool>```.  Old guard clauses are still compatible, they just have a 0 arg object array passed in.  This change is backwards compatible.

