### PR TITLE
Fix Issue 228, Guard Conditions being evaluated more than once.

### DIFF
--- a/src/Stateless/StateRepresentation.cs
+++ b/src/Stateless/StateRepresentation.cs
@@ -66,7 +66,7 @@ namespace Stateless
 
                 // Guard functions executed
                 var actual = possible
-                    .Select(h => new TriggerBehaviourResult(h, h.UnmetGuardConditions));
+                    .Select(h => new TriggerBehaviourResult(h, h.UnmetGuardConditions)).ToArray();
 
                 handlerResult = TryFindLocalHandlerResult(trigger, actual, r => !r.UnmetGuardConditions.Any())
                     ?? TryFindLocalHandlerResult(trigger, actual, r => r.UnmetGuardConditions.Any());

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -468,5 +468,25 @@ namespace Stateless.Tests
             Assert.True(onExitStateBfired);
             Assert.True(onExitStateAfired);
         }
+
+        /// <summary>
+        /// Verifies guard clauses are only called one time during a transition evaluation.
+        /// </summary>
+        [Fact]
+        public void GuardClauseCalledOnlyOnce()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            int i = 0;
+
+            sm.Configure(State.A).PermitIf(Trigger.X, State.B, () =>
+            {
+                ++i;
+                return true;
+            });
+
+            sm.Fire(Trigger.X);
+
+            Assert.Equal(1, i);
+        }
     }
 }


### PR DESCRIPTION
Simple fix to ensure guard conditions are only evaluated once during a transition.