### PR TITLE
#249 fix async internal transition not firing when sync

### DIFF
--- a/src/Stateless/StateRepresentation.Async.cs
+++ b/src/Stateless/StateRepresentation.Async.cs
@@ -137,7 +137,7 @@ namespace Stateless
 
             async Task ExecuteInternalActionsAsync(Transition transition, object[] args)
             {
-                InternalTriggerBehaviour.Async internalTransition = null;
+                InternalTriggerBehaviour internalTransition = null;
 
                 // Look for actions in superstate(s) recursivly until we hit the topmost superstate, or we actually find some trigger handlers.
                 StateRepresentation aStateRep = this;
@@ -146,7 +146,7 @@ namespace Stateless
                     if (aStateRep.TryFindLocalHandler(transition.Trigger, args, out TriggerBehaviourResult result))
                     {
                         // Trigger handler(s) found in this state
-                        internalTransition = result.Handler as InternalTriggerBehaviour.Async;
+                        internalTransition = result.Handler as InternalTriggerBehaviour;
                         break;
                     }
                     // Try to look for trigger handlers in superstate (if it exists)
@@ -154,7 +154,7 @@ namespace Stateless
                 }
 
                 // Execute internal transition event handler
-                await (internalTransition?.ExecuteAsync(transition, args)).ConfigureAwait(false);
+                await (internalTransition.ExecuteAsync(transition, args)).ConfigureAwait(false);
             }
 
             internal Task InternalActionAsync(Transition transition, object[] args)

--- a/test/Stateless.Tests/InternalTransitionFixture.cs
+++ b/test/Stateless.Tests/InternalTransitionFixture.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Stateless.Tests
@@ -272,6 +273,20 @@ namespace Stateless.Tests
             sm.Fire(Trigger.Y);
 
             Assert.Equal(2, handled);
+        }
+        [Fact]
+        public async Task AsyncHandlesNonAsyndActionAsync()
+        {
+            var handled = false;
+
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+                .InternalTransition(Trigger.Y, () => handled=true);
+
+            await sm.FireAsync(Trigger.Y);
+
+            Assert.True(handled);
         }
     }
 }


### PR DESCRIPTION
Fixed by not casting to Async, both async and sync versions can call ExecuteAsync.