### PR TITLE
Fix issue 261   reentrant trigger in substate causes exit action to be executed twice

### DIFF
--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -110,7 +110,7 @@ namespace Stateless
             }
         }
 
-		/// <summary>
+        /// <summary>
         /// The currently-permissible trigger values.
         /// </summary>
         public IEnumerable<TTrigger> PermittedTriggers
@@ -120,7 +120,7 @@ namespace Stateless
                 return GetPermittedTriggers();
             }
         }
-		
+
         /// <summary>
         /// The currently-permissible trigger values.
         /// </summary>
@@ -364,9 +364,13 @@ namespace Stateless
                 State = transition.Destination;
                 var newRepresentation = GetRepresentation(transition.Destination);
 
-                // Then Exit the final superstate
-                transition = new Transition(handler.Destination, handler.Destination, trigger);
-                newRepresentation.Exit(transition);
+                if (!source.Equals(transition.Destination))
+                {
+                    // Then Exit the final superstate
+                    transition = new Transition(handler.Destination, handler.Destination, trigger);
+                    newRepresentation.Exit(transition);
+                }
+
                 _onTransitionedEvent.Invoke(new Transition(source, handler.Destination, trigger));
 
                 newRepresentation.Enter(transition, args);

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -717,6 +717,32 @@ namespace Stateless.Tests
             Assert.False(superExit);
         }
 
+        [Fact]
+        public void OnExitFiresOnlyOnceReentrySubstate()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
 
+            int exitB = 0;
+            int exitA = 0;
+            int entryB = 0;
+            int entryA = 0;
+
+            sm.Configure(State.A)
+                .SubstateOf(State.B)
+                .OnEntry(() => entryA++)
+                .PermitReentry(Trigger.X)
+                .OnExit(() => exitA++);
+
+            sm.Configure(State.B)
+                .OnEntry(() => entryB++)
+                .OnExit(() => exitB++);
+
+            sm.Fire(Trigger.X);
+
+            Assert.Equal(0, exitB);
+            Assert.Equal(0, entryB);
+            Assert.Equal(1, exitA);
+            Assert.Equal(1, entryA);
+        }
     }
 }


### PR DESCRIPTION
Adding check to determine if superstate exit action should also be executed.