### PR TITLE
Undo pull request #251

### DIFF
--- a/src/Stateless/StateConfiguration.Async.cs
+++ b/src/Stateless/StateConfiguration.Async.cs
@@ -1,8 +1,6 @@
 ﻿#if TASKS
 
 using System;
-using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace Stateless
@@ -21,10 +19,7 @@ namespace Stateless
             public StateConfiguration InternalTransitionAsyncIf(TTrigger trigger, Func<bool> guard, Func<Transition, Task> entryAction)
             {
                 if (entryAction == null) throw new ArgumentNullException(nameof(entryAction));
-                if (!entryAction.GetMethodInfo().IsDefined(typeof(AsyncStateMachineAttribute),false))
-                {
-                    throw new ArgumentException("The supplied method is not tagged 'async'", nameof(entryAction));
-                }
+
                 _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger, guard, (t, args) => entryAction(t)));
                 return this;
             }
@@ -39,10 +34,7 @@ namespace Stateless
             public StateConfiguration InternalTransitionAsyncIf(TTrigger trigger, Func<bool> guard, Func<Task> internalAction)
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
-                if (!internalAction.GetMethodInfo().IsDefined(typeof(AsyncStateMachineAttribute), false))
-                {
-                    throw new ArgumentException("The supplied method is not tagged 'async'", nameof(internalAction));
-                }
+
                 _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger, guard, (t, args) => internalAction()));
                 return this;
             }
@@ -58,10 +50,7 @@ namespace Stateless
             public StateConfiguration InternalTransitionAsyncIf<TArg0>(TTrigger trigger, Func<bool> guard, Func<Transition, Task> internalAction)
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
-                if (!internalAction.GetMethodInfo().IsDefined(typeof(AsyncStateMachineAttribute), false))
-                {
-                    throw new ArgumentException("The supplied method is not tagged 'async'", nameof(internalAction));
-                }
+
                 _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger, guard, (t, args) => internalAction(t)));
                 return this;
             }
@@ -77,10 +66,7 @@ namespace Stateless
             public StateConfiguration InternalTransitionAsyncIf<TArg0>(TriggerWithParameters<TArg0> trigger, Func<bool> guard, Func<TArg0, Transition, Task> internalAction)
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
-                if (!internalAction.GetMethodInfo().IsDefined(typeof(AsyncStateMachineAttribute), false))
-                {
-                    throw new ArgumentException("The supplied method is not tagged 'async'", nameof(internalAction));
-                }
+
                 _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger.Trigger, guard, (t, args) => internalAction(ParameterConversion.Unpack<TArg0>(args, 0), t)));
                 return this;
             }
@@ -97,10 +83,7 @@ namespace Stateless
             public StateConfiguration InternalTransitionAsyncIf<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Func<bool> guard, Func<TArg0, TArg1, Transition, Task> internalAction)
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
-                if (!internalAction.GetMethodInfo().IsDefined(typeof(AsyncStateMachineAttribute), false))
-                {
-                    throw new ArgumentException("The supplied method is not tagged 'async'", nameof(internalAction));
-                }
+
                 _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger.Trigger, guard, (t, args) => internalAction(
                     ParameterConversion.Unpack<TArg0>(args, 0),
                     ParameterConversion.Unpack<TArg1>(args, 1), t)));
@@ -120,10 +103,7 @@ namespace Stateless
             public StateConfiguration InternalTransitionAsyncIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Func<bool> guard, Func<TArg0, TArg1, TArg2, Transition, Task> internalAction)
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
-                if (!internalAction.GetMethodInfo().IsDefined(typeof(AsyncStateMachineAttribute), false))
-                {
-                    throw new ArgumentException("The supplied method is not tagged 'async'", nameof(internalAction));
-                }
+
                 _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger.Trigger, guard, (t, args) => internalAction(
                     ParameterConversion.Unpack<TArg0>(args, 0),
                     ParameterConversion.Unpack<TArg1>(args, 1),

--- a/test/Stateless.Tests/AsyncActionsFixture.cs
+++ b/test/Stateless.Tests/AsyncActionsFixture.cs
@@ -76,7 +76,7 @@ namespace Stateless.Tests
 
             var test = "";
             sm.Configure(State.A)
-              .InternalTransitionAsync(Trigger.X, async () => await Task.Run(() => test = "foo"));
+              .InternalTransitionAsync(Trigger.X, () => Task.Run(() => test = "foo"));
 
             await sm.FireAsync(Trigger.X).ConfigureAwait(false);
 
@@ -89,7 +89,7 @@ namespace Stateless.Tests
             var sm = new StateMachine<State, Trigger>(State.A);
 
             sm.Configure(State.A)
-              .InternalTransitionAsync(Trigger.X, async () => await TaskResult.Done);
+              .InternalTransitionAsync(Trigger.X, () => TaskResult.Done);
 
             Assert.Throws<InvalidOperationException>(() => sm.Fire(Trigger.X));
         }


### PR DESCRIPTION
This changeset reverts the changes made in pull request #251 which required the use of `async` within the `InternalTransitionAsync()` method. (See discussion in #251)