### PR TITLE
Hotfix/can fire trigger with parameters

### DIFF
--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -494,7 +494,7 @@ namespace Stateless
         /// <returns>True if the trigger can be fired, false otherwise.</returns>
         public bool CanFire(TTrigger trigger)
         {
-            return CurrentRepresentation.CanHandle(trigger);
+            return CurrentRepresentation.CanHandle(trigger, new object[_triggerConfiguration.TryGetValue(trigger, out var triggerConfiguration) ? triggerConfiguration.Arity : 0]);
         }
 
         /// <summary>

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -117,7 +117,7 @@ namespace Stateless
         {
             get
             {
-                return GetPermittedTriggers();
+                return CurrentRepresentation.TriggerBehaviours.Keys;
             }
         }
 
@@ -506,7 +506,7 @@ namespace Stateless
             return string.Format(
                 "StateMachine {{ State = {0}, PermittedTriggers = {{ {1} }}}}",
                 State,
-                string.Join(", ", GetPermittedTriggers().Select(t => t.ToString()).ToArray()));
+                string.Join(", ", PermittedTriggers.Select(t => t.ToString()).ToArray()));
         }
 
         /// <summary>

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -116,8 +116,11 @@ namespace Stateless
         public IEnumerable<TTrigger> PermittedTriggers
         {
             get
-            {
-                return CurrentRepresentation.TriggerBehaviours.Keys;
+            { 
+                var set = new HashSet<TTrigger>();
+                for (var state = CurrentRepresentation; state != null; state = state.Superstate)
+                    set.UnionWith(state.TriggerBehaviours.Keys);
+                return set; 
             }
         }
 

--- a/src/Stateless/TriggerWithParameters.cs
+++ b/src/Stateless/TriggerWithParameters.cs
@@ -29,6 +29,17 @@ namespace Stateless
             public TTrigger Trigger { get { return _underlyingTrigger; } }
 
             /// <summary>
+            /// Gets the number of parameters associated with the trigger
+            /// </summary>
+            internal virtual int Arity => this.GetType()
+#if NET40
+                .GetGenericArguments()
+#else
+                .GenericTypeArguments
+#endif
+                .Length;
+
+            /// <summary>
             /// Ensure that the supplied arguments are compatible with those configured for this
             /// trigger.
             /// </summary>
@@ -55,6 +66,8 @@ namespace Stateless
                 : base(underlyingTrigger, typeof(TArg0))
             {
             }
+
+            internal sealed override int Arity => 1;
         }
 
         /// <summary>
@@ -72,6 +85,7 @@ namespace Stateless
                 : base(underlyingTrigger, typeof(TArg0), typeof(TArg1))
             {
             }
+            internal sealed override int Arity => 2;
         }
 
         /// <summary>
@@ -90,6 +104,7 @@ namespace Stateless
                 : base(underlyingTrigger, typeof(TArg0), typeof(TArg1), typeof(TArg2))
             {
             }
+            internal sealed override int Arity => 3;
         }
     }
 }

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -832,7 +832,56 @@ namespace Stateless.Tests
             var sm = new StateMachine<State, Trigger>(State.A);
             sm.Configure(State.A).PermitIf(sm.SetTriggerParameters<string>(trigger), State.B, _ => true);
             Assert.Single(sm.PermittedTriggers, trigger);
-        } 
+        }
+
+        [Fact]
+        public void PermittedTriggersIncludeAllDefinedTriggers()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            sm.Configure(State.A)
+                .Permit(Trigger.X, State.B)
+                .InternalTransition(Trigger.Y, _ => { })
+                .Ignore(Trigger.Z);
+            Assert.All(new[] { Trigger.X, Trigger.Y, Trigger.Z }, trigger => Assert.Contains(trigger, sm.PermittedTriggers));
+        }
+
+        [Fact]
+        public void PermittedTriggersExcludeAllUndefinedTriggers()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            sm.Configure(State.A)
+                .Permit(Trigger.X, State.B);
+            Assert.All(new[] { Trigger.Y, Trigger.Z }, trigger => Assert.DoesNotContain(trigger, sm.PermittedTriggers));
+        }
+
+        [Fact]
+        public void PermittedTriggersIncludeAllInheritedTriggers()
+        {
+            State   superState          = State.A, 
+                    subState            = State.B, 
+                    otherState          = State.C;
+            Trigger superStateTrigger   = Trigger.X, 
+                    subStateTrigger     = Trigger.Y;
+
+            StateMachine<State, Trigger> hsm(State initialState) 
+                => new StateMachine<State, Trigger>(initialState)
+                        .Configure(superState)
+                        .Permit(superStateTrigger, otherState)
+                    .Machine
+                        .Configure(subState)
+                        .SubstateOf(superState)
+                        .Permit(subStateTrigger, otherState)
+                    .Machine;
+
+            var hsmInSuperstate = hsm(superState);
+            var hsmInSubstate = hsm(subState);
+
+            Assert.All(hsmInSuperstate.PermittedTriggers, trigger => Assert.Contains(trigger, hsmInSubstate.PermittedTriggers));
+            Assert.Contains(superStateTrigger, hsmInSubstate.PermittedTriggers);
+            Assert.Contains(superStateTrigger, hsmInSuperstate.PermittedTriggers);
+            Assert.Contains(subStateTrigger, hsmInSubstate.PermittedTriggers);
+            Assert.DoesNotContain(subStateTrigger, hsmInSuperstate.PermittedTriggers);
+        }
 
     }
 }

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -749,8 +749,15 @@ namespace Stateless.Tests
             var trigger = Trigger.X;
             var sm = new StateMachine<State, Trigger>(State.A);
             sm.Configure(State.A).Permit(trigger, State.B);
-            Assert.Single(sm.PermittedTriggers, trigger);
             Assert.True(sm.CanFire(trigger));
+        }
+        [Fact]
+        public void WhenConfigurePermittedTransitionOnTriggerWithoutParameters_ThenStateMachineCanEnumeratePermittedTriggers()
+        {
+            var trigger = Trigger.X;
+            var sm = new StateMachine<State, Trigger>(State.A);
+            sm.Configure(State.A).Permit(trigger, State.B);
+            Assert.Single(sm.PermittedTriggers, trigger);
         }
 
 
@@ -761,8 +768,16 @@ namespace Stateless.Tests
             var sm = new StateMachine<State, Trigger>(State.A);
             sm.Configure(State.A).Permit(trigger, State.B);
             sm.SetTriggerParameters<string>(trigger);
-            Assert.Single(sm.PermittedTriggers, trigger);
             Assert.True(sm.CanFire(trigger));
+        }
+        [Fact]
+        public void WhenConfigurePermittedTransitionOnTriggerWithParameters_ThenStateMachineCanEnumeratePermittedTriggers()
+        {
+            var trigger = Trigger.X;
+            var sm = new StateMachine<State, Trigger>(State.A);
+            sm.Configure(State.A).Permit(trigger, State.B);
+            sm.SetTriggerParameters<string>(trigger);
+            Assert.Single(sm.PermittedTriggers, trigger);
         }
 
         [Fact]
@@ -771,8 +786,16 @@ namespace Stateless.Tests
             var trigger = Trigger.X;
             var sm = new StateMachine<State, Trigger>(State.A);
             sm.Configure(State.A).InternalTransition(trigger, (_) => { });
-            Assert.Single(sm.PermittedTriggers, trigger);
             Assert.True(sm.CanFire(trigger));
+        }
+
+        [Fact]
+        public void WhenConfigureInternalTransitionOnTriggerWithoutParameters_ThenStateMachineCanEnumeratePermittedTriggers()
+        {
+            var trigger = Trigger.X;
+            var sm = new StateMachine<State, Trigger>(State.A);
+            sm.Configure(State.A).InternalTransition(trigger, (_) => { });
+            Assert.Single(sm.PermittedTriggers, trigger);
         }
 
 
@@ -784,8 +807,34 @@ namespace Stateless.Tests
             var trigger = Trigger.X;
             var sm = new StateMachine<State, Trigger>(State.A);
             sm.Configure(State.A).InternalTransition(sm.SetTriggerParameters<string>(trigger), (arg, _) => { });
-            Assert.Single(sm.PermittedTriggers, trigger);
             Assert.True(sm.CanFire(trigger), userMessage: $"This failing test case illustrates the problem.  {StateMachineCanFireBugSummary}");
+        }
+
+        [Fact, Trait("Bug", StateMachineCanFireBugSummary)]
+        public void WhenConfigureInternalTransitionOnTriggerWithParameters_ThenStateMachineCanEnumeratePermittedTriggers()
+        {
+            var trigger = Trigger.X;
+            var sm = new StateMachine<State, Trigger>(State.A);
+            sm.Configure(State.A).InternalTransition(sm.SetTriggerParameters<string>(trigger), (arg, _) => { });
+            Assert.Single(sm.PermittedTriggers, trigger);
+        }
+
+        [Fact, Trait("Bug", StateMachineCanFireBugSummary)]
+        public void WhenConfigureConditionallyPermittedTransitionOnTriggerWithParameters_ThenStateMachineCanFireTrigger()
+        {
+            var trigger = Trigger.X;
+            var sm = new StateMachine<State, Trigger>(State.A);
+            sm.Configure(State.A).PermitIf(sm.SetTriggerParameters<string>(trigger), State.B, _ => true);
+            Assert.True(sm.CanFire(trigger), userMessage: $"This failing test case illustrates the problem.  {StateMachineCanFireBugSummary}");
+        }
+
+        [Fact, Trait("Bug", StateMachineCanFireBugSummary)]
+        public void WhenConfigureConditionallyPermittedTransitionOnTriggerWithParameters_ThenStateMachineCanEnumeratePermittedTriggers()
+        {
+            var trigger = Trigger.X;
+            var sm = new StateMachine<State, Trigger>(State.A);
+            sm.Configure(State.A).PermitIf(sm.SetTriggerParameters<string>(trigger), State.B, _ => true);
+            Assert.Single(sm.PermittedTriggers, trigger);
         }
 
         [Fact, Trait("Bug", StateMachineCanFireBugSummary)]
@@ -799,7 +848,21 @@ namespace Stateless.Tests
             Assert.StartsWith("   at Stateless.ParameterConversion.Unpack(Object[] args, Type argType, Int32 index)", problem1.StackTrace);
             ArgumentException problem2 = Assert.Throws<ArgumentException>(() => sm.CanFire(trigger));
             Assert.Equal(problem2.Message, "An argument of type System.String is required in position 0.");
-            Assert.StartsWith("   at Stateless.ParameterConversion.Unpack(Object[] args, Type argType, Int32 index)", problem2.StackTrace); 
+            Assert.StartsWith("   at Stateless.ParameterConversion.Unpack(Object[] args, Type argType, Int32 index)", problem2.StackTrace);
+        }
+
+        [Fact, Trait("Bug", StateMachineCanFireBugSummary)]
+        public void WhenConfigureConditionallyPermittedTransitionOnTriggerWithParameters_ThenCanFireCausesArgumentException()
+        {
+            var trigger = Trigger.X;
+            var sm = new StateMachine<State, Trigger>(State.A);
+            sm.Configure(State.A).PermitIf(sm.SetTriggerParameters<string>(trigger), State.B, _ => true);
+            ArgumentException problem1 = Assert.Throws<ArgumentException>(() => sm.PermittedTriggers.Single());
+            Assert.Equal(problem1.Message, "An argument of type System.String is required in position 0.");
+            Assert.StartsWith("   at Stateless.ParameterConversion.Unpack(Object[] args, Type argType, Int32 index)", problem1.StackTrace);
+            ArgumentException problem2 = Assert.Throws<ArgumentException>(() => sm.CanFire(trigger));
+            Assert.Equal(problem2.Message, "An argument of type System.String is required in position 0.");
+            Assert.StartsWith("   at Stateless.ParameterConversion.Unpack(Object[] args, Type argType, Int32 index)", problem2.StackTrace);
         }
 
     }

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -797,20 +797,17 @@ namespace Stateless.Tests
             sm.Configure(State.A).InternalTransition(trigger, (_) => { });
             Assert.Single(sm.PermittedTriggers, trigger);
         }
-
-
-        private const string StateMachineCanFireBugSummary = "StateMachine.CanFire exhibits unexpected and inconsistent behavior when its argument is a trigger with parameters and an internal transition is registered.";
-
-        [Fact, Trait("Bug", StateMachineCanFireBugSummary)]
+         
+        [Fact]
         public void WhenConfigureInternalTransitionOnTriggerWithParameters_ThenStateMachineCanFireTrigger()
         {
             var trigger = Trigger.X;
             var sm = new StateMachine<State, Trigger>(State.A);
             sm.Configure(State.A).InternalTransition(sm.SetTriggerParameters<string>(trigger), (arg, _) => { });
-            Assert.True(sm.CanFire(trigger), userMessage: $"This failing test case illustrates the problem.  {StateMachineCanFireBugSummary}");
+            Assert.True(sm.CanFire(trigger));
         }
 
-        [Fact, Trait("Bug", StateMachineCanFireBugSummary)]
+        [Fact]
         public void WhenConfigureInternalTransitionOnTriggerWithParameters_ThenStateMachineCanEnumeratePermittedTriggers()
         {
             var trigger = Trigger.X;
@@ -819,51 +816,23 @@ namespace Stateless.Tests
             Assert.Single(sm.PermittedTriggers, trigger);
         }
 
-        [Fact, Trait("Bug", StateMachineCanFireBugSummary)]
+        [Fact]
         public void WhenConfigureConditionallyPermittedTransitionOnTriggerWithParameters_ThenStateMachineCanFireTrigger()
         {
             var trigger = Trigger.X;
             var sm = new StateMachine<State, Trigger>(State.A);
             sm.Configure(State.A).PermitIf(sm.SetTriggerParameters<string>(trigger), State.B, _ => true);
-            Assert.True(sm.CanFire(trigger), userMessage: $"This failing test case illustrates the problem.  {StateMachineCanFireBugSummary}");
+            Assert.True(sm.CanFire(trigger));
         }
 
-        [Fact, Trait("Bug", StateMachineCanFireBugSummary)]
+        [Fact]
         public void WhenConfigureConditionallyPermittedTransitionOnTriggerWithParameters_ThenStateMachineCanEnumeratePermittedTriggers()
         {
             var trigger = Trigger.X;
             var sm = new StateMachine<State, Trigger>(State.A);
             sm.Configure(State.A).PermitIf(sm.SetTriggerParameters<string>(trigger), State.B, _ => true);
             Assert.Single(sm.PermittedTriggers, trigger);
-        }
-
-        [Fact, Trait("Bug", StateMachineCanFireBugSummary)]
-        public void WhenConfigureInternalTransitionOnTriggerWithParameters_ThenCanFireCausesArgumentException()
-        {
-            var trigger = Trigger.X;
-            var sm = new StateMachine<State, Trigger>(State.A);
-            sm.Configure(State.A).InternalTransition(sm.SetTriggerParameters<string>(trigger), (arg, _) => { });
-            ArgumentException problem1 = Assert.Throws<ArgumentException>(() => sm.PermittedTriggers.Single());
-            Assert.Equal(problem1.Message, "An argument of type System.String is required in position 0.");
-            Assert.StartsWith("   at Stateless.ParameterConversion.Unpack(Object[] args, Type argType, Int32 index)", problem1.StackTrace);
-            ArgumentException problem2 = Assert.Throws<ArgumentException>(() => sm.CanFire(trigger));
-            Assert.Equal(problem2.Message, "An argument of type System.String is required in position 0.");
-            Assert.StartsWith("   at Stateless.ParameterConversion.Unpack(Object[] args, Type argType, Int32 index)", problem2.StackTrace);
-        }
-
-        [Fact, Trait("Bug", StateMachineCanFireBugSummary)]
-        public void WhenConfigureConditionallyPermittedTransitionOnTriggerWithParameters_ThenCanFireCausesArgumentException()
-        {
-            var trigger = Trigger.X;
-            var sm = new StateMachine<State, Trigger>(State.A);
-            sm.Configure(State.A).PermitIf(sm.SetTriggerParameters<string>(trigger), State.B, _ => true);
-            ArgumentException problem1 = Assert.Throws<ArgumentException>(() => sm.PermittedTriggers.Single());
-            Assert.Equal(problem1.Message, "An argument of type System.String is required in position 0.");
-            Assert.StartsWith("   at Stateless.ParameterConversion.Unpack(Object[] args, Type argType, Int32 index)", problem1.StackTrace);
-            ArgumentException problem2 = Assert.Throws<ArgumentException>(() => sm.CanFire(trigger));
-            Assert.Equal(problem2.Message, "An argument of type System.String is required in position 0.");
-            Assert.StartsWith("   at Stateless.ParameterConversion.Unpack(Object[] args, Type argType, Int32 index)", problem2.StackTrace);
-        }
+        } 
 
     }
 }


### PR DESCRIPTION
Implemented a minimal patch to address bugs with StateMachine.CanFire and StateMachine.PermittedTriggers under certain conditions,  

- Related Issues:
  - https://github.com/dotnet-state-machine/stateless/issues/272
  - https://github.com/dotnet-state-machine/stateless/issues/275

Notes:
- StateMachine.CanFire exhibits unexpected and inconsistent behavior when (1) its argument is a trigger with parameters and (2) an internal transition is registered.
- Added additional test cases to demonstrate scope of the problem.  Rather than simply affecting internal transitions, all transition configurations that depend upon conditional guard clauses are impacted.  The reason that non-conditional internal transition configurations are affected is that their implementation delegates to the conditional method with a condition that is always true.
- Fix for `StateMachine.CanFire`: The problematic validation fails on parameter length.  CanFire initializes an array of the appropriate length before invoking the underlying StateRepresentation method
- Fix for `StateMachine.PermittedTriggers`/`StateMachine.ToString()`: Changed the implementation of the StateMachine.PermittedTriggers property.  This resolves the exception that was being thrown.  It does not address StateMachine.GetPermittedTriggers(object[]) or any issues with the underlying StateRepresentation class.  StateMachine.ToString() depends on GetPermittedTriggers(), which remains either broken or unspecified in some cases.  It will still throw unexpected errors for triggers with parameters, which means that StateMachine.ToString() would do the same.  The assumption justifying this commit is that the reduced consistency between StateMachine.PermittedTriggers and StateMachine.GetPermittedTriggers() is less harmful than StateMachine.CanFire() and StateMachine.ToString() violating their contracts.