### PR TITLE
Fixes #292 multiple calls of OnEntry when having nested InitialTransitions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ project.lock.json
 artifacts/
 TestResult.xml
 *.orig
+/.localhistory/*

--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -222,7 +222,12 @@ namespace Stateless
                     {
                         var initialTransition = new Transition(source, newRepresentation.InitialTransitionTarget, trigger);
                         newRepresentation = GetRepresentation(newRepresentation.InitialTransitionTarget);
-                        await newRepresentation.EnterAsync(initialTransition, args);
+
+                        if (!newRepresentation.GetSubstates().Any()) 
+                        {
+                            await newRepresentation.EnterAsync(initialTransition, args);
+                        }
+
                         State = newRepresentation.UnderlyingState;
                     }
                     //Alert all listeners of state transition

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -430,7 +430,10 @@ namespace Stateless
                 {
                     var initialTransition = new Transition(transition.Source, newRepresentation.InitialTransitionTarget, transition.Trigger);
                     newRepresentation = GetRepresentation(newRepresentation.InitialTransitionTarget);
-                    newRepresentation.Enter(initialTransition, args);
+
+                    if (!newRepresentation.GetSubstates().Any())
+                        newRepresentation.Enter(initialTransition, args);
+
                     State = newRepresentation.UnderlyingState;
                 }
                 //Alert all listeners of state transition

--- a/src/Stateless/Stateless.csproj
+++ b/src/Stateless/Stateless.csproj
@@ -23,7 +23,8 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
-    <Version>4.2.2-pr</Version>
+    <Version>4.2.3-pr</Version>
+    <FileVersion>4.2.3.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">

--- a/src/Stateless/Stateless.csproj
+++ b/src/Stateless/Stateless.csproj
@@ -23,7 +23,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateNeutralResourcesLanguageAttribute>false</GenerateNeutralResourcesLanguageAttribute>
-    <Version>4.2.1</Version>
+    <Version>4.2.2-pr</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">

--- a/test/Stateless.Tests/InitialTransitionFixture.cs
+++ b/test/Stateless.Tests/InitialTransitionFixture.cs
@@ -44,8 +44,6 @@ namespace Stateless.Tests
             sm.Fire(Trigger.X);
             Assert.Equal(State.D, sm.State);
         }
-
-
         [Fact]
         public void SubStateOfSubstateOnEntryCountAndOrder() 
         {
@@ -73,7 +71,6 @@ namespace Stateless.Tests
             sm.Fire(Trigger.X);
             Assert.Equal("BCD", onEntryCount);
         }
-
         [Fact]
         public void DoesNotEnterSubStateofSubstate()
         {


### PR DESCRIPTION
Fixes #292 for 'normal' StateMachine. Unfortunately I have no real idea how the 'async' version works, so I only added code in the 'normal' part and I added a test case to test the behavior.

All other tests still pass.

Would be happy if this helps to fix the problem :).

Best regards,
ahorn