### PR TITLE
Make visualization API extensible.

### DIFF
--- a/src/Stateless/Graph/Decision.cs
+++ b/src/Stateless/Graph/Decision.cs
@@ -5,11 +5,19 @@ namespace Stateless.Graph
     /// <summary>
     /// Used to keep track of the decision point of a dynamic transition
     /// </summary>
-    class Decision : State
+    public class Decision : State
     {
+        /// <summary>
+        /// Gets the underlying method description of the invoked method.
+        /// </summary>
         public InvocationInfo Method { get; private set; }
 
-        internal Decision(InvocationInfo method, int num)
+        /// <summary>
+        /// Creates a new instance of <see cref="Decision"/>.
+        /// </summary>
+        /// <param name="method">The name of the invoked method.</param>
+        /// <param name="num">The decision count.</param>
+        public Decision(InvocationInfo method, int num)
             : base("Decision" + num.ToString())
         {
             Method = method;

--- a/src/Stateless/Graph/GraphStyleBase.cs
+++ b/src/Stateless/Graph/GraphStyleBase.cs
@@ -8,7 +8,7 @@ namespace Stateless.Graph
     /// Style definition for StateGraph.
     /// Provides formatting of individual items in a state graph.
     /// </summary>
-    public abstract class IGraphStyle
+    public abstract class GraphStyleBase
     {
         /// <summary>
         /// Get the text that must be present at the top of a state graph file.
@@ -16,7 +16,7 @@ namespace Stateless.Graph
         /// digraph {
         /// </summary>
         /// <returns>Prefix text</returns>
-        abstract internal string GetPrefix();
+        public abstract string GetPrefix();
 
         /// <summary>
         /// Returns the formatted text for a single state.
@@ -26,7 +26,7 @@ namespace Stateless.Graph
         /// </summary>
         /// <param name="state">The state to generate text for</param>
         /// <returns>Description of the state in the desired format</returns>
-        abstract internal string FormatOneState(State state);
+        public abstract string FormatOneState(State state);
 
         /// <summary>
         /// Returns the formatted text for a single superstate and its substates.
@@ -34,7 +34,7 @@ namespace Stateless.Graph
         /// </summary>
         /// <param name="stateInfo">The superstate to generate text for</param>
         /// <returns>Description of the superstate, and all its substates, in the desired format</returns>
-        abstract internal string FormatOneCluster(SuperState stateInfo);
+        public abstract string FormatOneCluster(SuperState stateInfo);
 
         /// <summary>
         /// Returns the formatted text for a single decision node.
@@ -46,7 +46,7 @@ namespace Stateless.Graph
         /// <param name="nodeName">Name of the node</param>
         /// <param name="label">Label for the node</param>
         /// <returns></returns>
-        abstract internal string FormatOneDecisionNode(string nodeName, string label);
+        public abstract string FormatOneDecisionNode(string nodeName, string label);
 
         /// <summary>
         /// Returns the formatted text for all the transitions found in the state graph.
@@ -55,7 +55,7 @@ namespace Stateless.Graph
         /// </summary>
         /// <param name="transitions">List of all transitions in the state graph</param>
         /// <returns>Description of all transitions, in the desired format</returns>
-        virtual internal List<string> FormatAllTransitions(List<Transition> transitions)
+        public virtual List<string> FormatAllTransitions(List<Transition> transitions)
         {
             List<string> lines = new List<string>();
 
@@ -119,7 +119,7 @@ namespace Stateless.Graph
         /// <param name="destinationNodeName"></param>
         /// <param name="guards">List of guards (if any)</param>
         /// <returns></returns>
-        virtual internal string FormatOneTransition(string sourceNodeName, string trigger, IEnumerable<string> actions, string destinationNodeName, IEnumerable<string> guards)
+        public virtual string FormatOneTransition(string sourceNodeName, string trigger, IEnumerable<string> actions, string destinationNodeName, IEnumerable<string> guards)
         {
             throw new InvalidOperationException("If you use IGraphStyle.FormatAllTransitions() you must implement an override of FormatOneTransition()");
         }

--- a/src/Stateless/Graph/State.cs
+++ b/src/Stateless/Graph/State.cs
@@ -44,7 +44,11 @@ namespace Stateless.Graph
         /// </summary>
         public List<string> ExitActions { get; private set; } = new List<string>();
 
-        internal State(StateInfo stateInfo)
+        /// <summary>
+        /// Constructs a new instance of State.
+        /// </summary>
+        /// <param name="stateInfo">The state to be represented.</param>
+        public State(StateInfo stateInfo)
         {
             NodeName = stateInfo.UnderlyingState.ToString();
             StateName = stateInfo.UnderlyingState.ToString();
@@ -60,7 +64,11 @@ namespace Stateless.Graph
                 ExitActions.Add(exitAction.Description);
         }
 
-        internal State(string nodeName)
+        /// <summary>
+        /// Constructs a new instance of State.
+        /// </summary>
+        /// <param name="nodeName">The node name.</param>
+        public State(string nodeName)
         {
             NodeName = nodeName;
             StateName = null;

--- a/src/Stateless/Graph/StateGraph.cs
+++ b/src/Stateless/Graph/StateGraph.cs
@@ -9,7 +9,7 @@ namespace Stateless.Graph
     /// graph structure, in preparation for feeding it to a diagram
     /// generator 
     /// </summary>
-    class StateGraph
+    public class StateGraph
     {
         /// <summary>
         /// List of all states in the graph, indexed by the string representation of the underlying State object.
@@ -27,6 +27,10 @@ namespace Stateless.Graph
         /// </summary>
         public List<Decision> Decisions { get; private set; } = new List<Decision>();
 
+        /// <summary>
+        /// Creates a new instance of <see cref="StateGraph"/>.
+        /// </summary>
+        /// <param name="machineInfo">An object which exposes the states, transitions, and actions of this machine.</param>
         public StateGraph(StateMachineInfo machineInfo)
         {
             // Start with top-level superstates
@@ -47,7 +51,7 @@ namespace Stateless.Graph
         /// </summary>
         /// <param name="style"></param>
         /// <returns></returns>
-        public string ToGraph(IGraphStyle style)
+        public string ToGraph(GraphStyleBase style)
         {
             string dirgraphText = style.GetPrefix().Replace("\n", System.Environment.NewLine);
 

--- a/src/Stateless/Graph/SuperState.cs
+++ b/src/Stateless/Graph/SuperState.cs
@@ -12,7 +12,11 @@ namespace Stateless.Graph
         /// </summary>
         public List<State> SubStates { get; } = new List<State>();
 
-        internal SuperState(Reflection.StateInfo stateInfo)
+        /// <summary>
+        /// Constructs a new instance of SuperState.
+        /// </summary>
+        /// <param name="stateInfo">The super state to be represented.</param>
+        public SuperState(Reflection.StateInfo stateInfo)
             : base(stateInfo)
         {
 

--- a/src/Stateless/Graph/Transition.cs
+++ b/src/Stateless/Graph/Transition.cs
@@ -41,7 +41,10 @@ namespace Stateless.Graph
         }
     }
 
-    class FixedTransition : Transition
+    /// <summary>
+    /// Represents a fixed transition.
+    /// </summary>
+    public class FixedTransition : Transition
     {
         /// <summary>
         /// The state where this transition finishes
@@ -53,6 +56,13 @@ namespace Stateless.Graph
         /// </summary>
         public IEnumerable<InvocationInfo> Guards { get; private set; }
 
+        /// <summary>
+        /// Creates a new instance of <see cref="FixedTransition"/>.
+        /// </summary>
+        /// <param name="sourceState">The source state.</param>
+        /// <param name="destinationState">The destination state.</param>
+        /// <param name="trigger">The trigger associated with this transition.</param>
+        /// <param name="guards">The guard conditions associated with this transition.</param>
         public FixedTransition(State sourceState, State destinationState, TriggerInfo trigger, IEnumerable<InvocationInfo> guards)
             : base(sourceState, trigger)
         {
@@ -61,7 +71,10 @@ namespace Stateless.Graph
         }
     }
 
-    class DynamicTransition : Transition
+    /// <summary>
+    /// Represents a dynamic transition.
+    /// </summary>
+    public class DynamicTransition : Transition
     {
         /// <summary>
         /// The state where this transition finishes
@@ -73,6 +86,13 @@ namespace Stateless.Graph
         /// </summary>
         public string Criterion { get; private set; }
 
+        /// <summary>
+        /// Creates a new instance of <see cref="DynamicTransition"/>.
+        /// </summary>
+        /// <param name="sourceState">The source state.</param>
+        /// <param name="destinationState">The destination state.</param>
+        /// <param name="trigger">The trigger associated with this transition.</param>
+        /// <param name="criterion">The reason the destination state was chosen.</param>
         public DynamicTransition(State sourceState, State destinationState, TriggerInfo trigger, string criterion)
             : base(sourceState, trigger)
         {
@@ -81,10 +101,23 @@ namespace Stateless.Graph
         }
     }
 
-    class StayTransition : Transition
+    /// <summary>
+    /// Represents a transition from a state to itself.
+    /// </summary>
+    public class StayTransition : Transition
     {
+        /// <summary>
+        /// The guard conditions associated with this transition.
+        /// </summary>
         public IEnumerable<InvocationInfo> Guards { get; private set; }
 
+        /// <summary>
+        /// Creates a new instance of <see cref="StayTransition"/>.
+        /// </summary>
+        /// <param name="sourceState">The source state.</param>
+        /// <param name="trigger">The trigger associated with this transition.</param>
+        /// <param name="guards">The guard conditions associated with this transition.</param>
+        /// <param name="executeEntryExitActions">Sets whether the entry and exit actions are executed when the transition is enacted.</param>
         public StayTransition(State sourceState, TriggerInfo trigger, IEnumerable<InvocationInfo> guards, bool executeEntryExitActions)
             : base(sourceState, trigger)
         {

--- a/src/Stateless/Graph/UmlDotGraphStyle.cs
+++ b/src/Stateless/Graph/UmlDotGraphStyle.cs
@@ -8,11 +8,11 @@ namespace Stateless.Graph
     /// <summary>
     /// Generate DOT graphs in basic UML style
     /// </summary>
-    public class UmlDotGraphStyle : IGraphStyle
+    public class UmlDotGraphStyle : GraphStyleBase
     {
         /// <summary>Get the text that starts a new graph</summary>
         /// <returns></returns>
-        override internal string GetPrefix()
+        public override string GetPrefix()
         {
             return "digraph {\n"
                       + "compound=true;\n"
@@ -20,7 +20,13 @@ namespace Stateless.Graph
                       + "rankdir=\"LR\"\n";
         }
 
-        internal override string FormatOneCluster(SuperState stateInfo)
+        /// <summary>
+        /// Returns the formatted text for a single superstate and its substates.
+        /// For example, for DOT files this would be a subgraph containing nodes for all the substates.
+        /// </summary>
+        /// <param name="stateInfo">The superstate to generate text for</param>
+        /// <returns>Description of the superstate, and all its substates, in the desired format</returns>
+        public override string FormatOneCluster(SuperState stateInfo)
         {
             string stateRepresentationString = "";
             var sourceName = stateInfo.StateName;
@@ -54,7 +60,7 @@ namespace Stateless.Graph
         /// </summary>
         /// <param name="state">The state to generate text for</param>
         /// <returns></returns>
-        override internal string FormatOneState(State state)
+        public override string FormatOneState(State state)
         {
             if ((state.EntryActions.Count == 0) && (state.ExitActions.Count == 0))
                 return state.StateName + " [label=\"" + state.StateName + "\"];\n";
@@ -81,7 +87,7 @@ namespace Stateless.Graph
         /// <param name="destinationNodeName"></param>
         /// <param name="guards"></param>
         /// <returns></returns>
-        override internal string FormatOneTransition(string sourceNodeName, string trigger, IEnumerable<string> actions, string destinationNodeName, IEnumerable<string> guards)
+        public override string FormatOneTransition(string sourceNodeName, string trigger, IEnumerable<string> actions, string destinationNodeName, IEnumerable<string> guards)
         {
             string label = trigger ?? "";
 
@@ -107,7 +113,7 @@ namespace Stateless.Graph
         /// <param name="nodeName">Name of the node</param>
         /// <param name="label">Label for the node</param>
         /// <returns></returns>
-        override internal string FormatOneDecisionNode(string nodeName, string label)
+        public override string FormatOneDecisionNode(string nodeName, string label)
         {
             return nodeName + " [shape = \"diamond\", label = \"" + label + "\"];\n";
         }

--- a/src/Stateless/Reflection/DynamicTransitionInfo.cs
+++ b/src/Stateless/Reflection/DynamicTransitionInfo.cs
@@ -58,10 +58,26 @@ namespace Stateless.Reflection
     /// </summary>
     public class DynamicTransitionInfo : TransitionInfo
     {
-        internal InvocationInfo DestinationStateSelectorDescription { get; private set; }
-        internal DynamicStateInfos PossibleDestinationStates { get; private set; }
+        /// <summary>
+        /// Gets method informtion for the destination state selector.
+        /// </summary>
+        public InvocationInfo DestinationStateSelectorDescription { get; private set; }
 
-        internal static DynamicTransitionInfo Create<TTrigger>(TTrigger trigger, IEnumerable<InvocationInfo> guards,
+        /// <summary>
+        /// Gets the possible destination states.
+        /// </summary>
+        public DynamicStateInfos PossibleDestinationStates { get; private set; }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="DynamicTransitionInfo"/>.
+        /// </summary>
+        /// <typeparam name="TTrigger">The trigger type.</typeparam>
+        /// <param name="trigger">The trigger associated with this transition.</param>
+        /// <param name="guards">The guard conditions associated with this transition.</param>
+        /// <param name="selector">The destination selector associated with this transition.</param>
+        /// <param name="possibleStates">The possible destination states.</param>
+        /// <returns></returns>
+        public static DynamicTransitionInfo Create<TTrigger>(TTrigger trigger, IEnumerable<InvocationInfo> guards,
             InvocationInfo selector, DynamicStateInfos possibleStates)
         {
             var transition = new DynamicTransitionInfo

--- a/src/Stateless/Reflection/InvocationInfo.cs
+++ b/src/Stateless/Reflection/InvocationInfo.cs
@@ -12,7 +12,7 @@ namespace Stateless.Reflection
         /// <summary>
         /// Is the method synchronous or asynchronous?
         /// </summary>
-        internal enum Timing
+        public enum Timing
         {
             /// <summary>Method is synchronous</summary>
             Synchronous,
@@ -27,7 +27,13 @@ namespace Stateless.Reflection
             return new InvocationInfo(method?.TryGetMethodName(), description, timing);
         }
 
-        InvocationInfo(string methodName, string description, Timing timing)      // description can be null if user didn't specify a description
+        /// <summary>
+        /// Creates a new instance of <see cref="InvocationInfo"/>.
+        /// </summary>
+        /// <param name="methodName">The name of the invoked method.</param>
+        /// <param name="description">A description of the invoked method.</param>
+        /// <param name="timing">Sets a value indicating whether the method is invoked asynchronously.</param>
+        public InvocationInfo(string methodName, string description, Timing timing)      // description can be null if user didn't specify a description
         {
             MethodName = methodName;
             _description = description;
@@ -43,7 +49,7 @@ namespace Stateless.Reflection
         /// <summary>
         /// Text returned for compiler-generated functions where the caller has not specified a description
         /// </summary>
-        static public string DefaultFunctionDescription { get; set; } = "Function";
+        public static string DefaultFunctionDescription { get; set; } = "Function";
 
         /// <summary>
         /// A description of the invoked method.  Returns:


### PR DESCRIPTION
This PR is to address Issues #210 and #290 by changing several type declarations from `internal` to `public` so that the graphing classes are more extensible.

Additionally, the `abstract` class `IGraphStyle` has been renamed to `GraphStyleBase` to make it consistent with the [.NET Framework Design Guidelines](https://docs.microsoft.com/en-us/dotnet/standard/design-guidelines/names-of-classes-structs-and-interfaces). Finally a few declaration modifiers have been reordered to make them consistent within the solution (e.g. `override public ...` ->`public override ...`).

Review comments & feedback welcomed!