### PR TITLE
Brought back guard description when guard prevents transition

### DIFF
--- a/src/Stateless/StateRepresentation.cs
+++ b/src/Stateless/StateRepresentation.cs
@@ -43,7 +43,7 @@ namespace Stateless
                     (Superstate != null && Superstate.TryFindHandler(trigger, args, out handler)));
             }
 
-            bool TryFindLocalHandler(TTrigger trigger, object[] args, out TriggerBehaviourResult handlerResult)
+            private bool TryFindLocalHandler(TTrigger trigger, object[] args, out TriggerBehaviourResult handlerResult)
             {
                 // Get list of candidate trigger handlers
                 if (!TriggerBehaviours.TryGetValue(trigger, out ICollection<TriggerBehaviour> possible))
@@ -51,36 +51,40 @@ namespace Stateless
                     handlerResult = null;
                     return false;
                 }
-
-                // Remove those that have unmet guard conditions
+               
                 // Guard functions are executed here
                 var actual = possible
                     .Select(h => new TriggerBehaviourResult(h, h.UnmetGuardConditions(args)))
-                    .Where(g => g.UnmetGuardConditions.Count == 0)
                     .ToArray();
 
                 // Find a handler for the trigger
-                handlerResult = TryFindLocalHandlerResult(trigger, actual, r => !r.UnmetGuardConditions.Any())
-                    ?? TryFindLocalHandlerResult(trigger, actual, r => r.UnmetGuardConditions.Any());
+                handlerResult = TryFindLocalHandlerResult(trigger, actual)
+                    ?? TryFindLocalHandlerResultWithUnmetGuardConditions(actual);
 
-                if (handlerResult == null) return false;
+                if (handlerResult == null)
+                    return false;
 
                 return !handlerResult.UnmetGuardConditions.Any();
             }
 
-            TriggerBehaviourResult TryFindLocalHandlerResult(TTrigger trigger, IEnumerable<TriggerBehaviourResult> results, Func<TriggerBehaviourResult, bool> filter)
+            private TriggerBehaviourResult TryFindLocalHandlerResult(TTrigger trigger, IEnumerable<TriggerBehaviourResult> results)
             {
                 var actual = results
-                    .Where(filter);
+                    .Where(r => !r.UnmetGuardConditions.Any())
+                    .ToList();
 
-                if (actual.Count() > 1)
-                    throw new InvalidOperationException(
-                        string.Format(StateRepresentationResources.MultipleTransitionsPermitted,
-                        trigger, _state));
+                if (actual.Count <= 1)
+                    return actual.FirstOrDefault();
 
-                return actual
-                    .FirstOrDefault();
+                var message = string.Format(StateRepresentationResources.MultipleTransitionsPermitted, trigger, _state);
+                throw new InvalidOperationException(message);
             }
+
+            private static TriggerBehaviourResult TryFindLocalHandlerResultWithUnmetGuardConditions(IEnumerable<TriggerBehaviourResult> results)
+            {
+               return results.FirstOrDefault(r => r.UnmetGuardConditions.Any());
+            }
+
             public void AddActivateAction(Action action, Reflection.InvocationInfo activateActionDescription)
             {
                 ActivateActions.Add(new ActivateActionBehaviour.Sync(_state, action, activateActionDescription));

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -259,7 +259,7 @@ namespace Stateless.Tests
             var sm = new StateMachine<State, Trigger>(State.A);
             sm.Configure(State.A).PermitIf(Trigger.X, State.B, () => false, guardDescription);
             var exception = Assert.Throws<InvalidOperationException>(() => sm.Fire(Trigger.X));
-            Assert.Equal(typeof(InvalidOperationException), exception.GetType());
+            Assert.Equal(exception.Message, "Trigger 'X' is valid for transition from state 'A' but a guard conditions are not met. Guard descriptions: 'test'.");
         }
 
         [Fact]
@@ -271,7 +271,7 @@ namespace Stateless.Tests
                 new Tuple<Func<bool>, string>(() => false, "test2"));
 
             var exception = Assert.Throws<InvalidOperationException>(() => sm.Fire(Trigger.X));
-            Assert.Equal(typeof(InvalidOperationException), exception.GetType());
+            Assert.Equal(exception.Message, "Trigger 'X' is valid for transition from state 'A' but a guard conditions are not met. Guard descriptions: 'test1, test2'.");
         }
 
         [Fact]
@@ -673,6 +673,7 @@ namespace Stateless.Tests
 
             Assert.Equal(1, i);
         }
+
         [Fact]
         public void NoExceptionWhenPermitIfHasMultipleExclusiveGuardsBothFalse()
         {


### PR DESCRIPTION
Doesn't break NoExceptionWhenPermitIfHasMultipleExclusiveGuardsBothFalse test.

Would appreciate @HenningNT comment that this doesn't cause regression.