### PR TITLE
Check if we are transitioning to superstate when using FireAsync

### DIFF
--- a/src/Stateless/StateRepresentation.Async.cs
+++ b/src/Stateless/StateRepresentation.Async.cs
@@ -114,8 +114,21 @@ namespace Stateless
 
                     if (_superstate != null)
                     {
-                        transition = new Transition(_superstate.UnderlyingState, transition.Destination, transition.Trigger);
-                        return await _superstate.ExitAsync(transition).ConfigureAwait(false);
+                        // Check if destination is within the state list
+                        if (IsIncludedIn(transition.Destination))
+                        {
+                            // Destination state is within the list, exit first superstate only if it is NOT the the first
+                            if (!_superstate.UnderlyingState.Equals(transition.Destination))
+                            {
+                                return await _superstate.ExitAsync(transition).ConfigureAwait(false);
+                            }
+                        }
+                        else
+                        {
+                            return await _superstate.ExitAsync(transition).ConfigureAwait(false);
+                        }
+
+                        //transition = new Transition(_superstate.UnderlyingState, transition.Destination, transition.Trigger);
                     }
                 }
                 return transition;

--- a/test/Stateless.Tests/AsyncActionsFixture.cs
+++ b/test/Stateless.Tests/AsyncActionsFixture.cs
@@ -261,6 +261,31 @@ namespace Stateless.Tests
         }
 
         [Fact]
+        public async void TransitionToSuperstateDoesNotExitSuperstate()
+        {
+            StateMachine<State, Trigger> sm = new StateMachine<State, Trigger>(State.B);
+
+            bool superExit = false;
+            bool superEntry = false;
+            bool subExit = false;
+
+            sm.Configure(State.A)
+                .OnEntryAsync(t => Task.Run(() => superEntry = true))
+                .OnExitAsync(t => Task.Run(() => superExit = true));
+
+            sm.Configure(State.B)
+                .SubstateOf(State.A)
+                .Permit(Trigger.Y, State.A)
+                .OnExitAsync(t => Task.Run(() => subExit = true));
+
+            await sm.FireAsync(Trigger.Y);
+
+            Assert.True(subExit);
+            Assert.False(superEntry);
+            Assert.False(superExit);
+        }
+
+        [Fact]
         public async void IgnoredTriggerMustBeIgnoredAsync()
         {
             bool nullRefExcThrown = false;


### PR DESCRIPTION
Fix for Issue #306  

Replicate logic to Async code so we do not re-transition to superstate when leaving substate



