### PR TITLE
Initial migration to netcore 2 & net47; all tests pass

### DIFF
--- a/common.props
+++ b/common.props
@@ -1,0 +1,14 @@
+<Project>
+
+ <!-- Assembly version & attribute controls -->
+  <PropertyGroup>
+    <VersionPrefix>5.0</VersionPrefix>
+
+<!--
+    <GenerateAssemblyConfigurationAttribute>true</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>true</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>true</GenerateAssemblyProductAttribute>
+-->
+  </PropertyGroup>
+
+</Project>

--- a/example/BugTrackerExample/BugTrackerExample.csproj
+++ b/example/BugTrackerExample/BugTrackerExample.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net47</TargetFrameworks>
     <AssemblyName>BugTrackerExample</AssemblyName>
     <OutputType>Exe</OutputType>
-    <PackageId>BugTrackerExample</PackageId>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
+    <IsPackable>false</IsPackable>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/example/JsonExample/JsonExample.csproj
+++ b/example/JsonExample/JsonExample.csproj
@@ -1,8 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.0;net47</TargetFrameworks>
+    <AssemblyName>JsonExample</AssemblyName>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/example/OnOffExample/OnOffExample.csproj
+++ b/example/OnOffExample/OnOffExample.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net47</TargetFrameworks>
     <AssemblyName>OnOffExample</AssemblyName>
     <OutputType>Exe</OutputType>
-    <PackageId>OnOffExample</PackageId>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
+    <IsPackable>false</IsPackable>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/example/TelephoneCallExample/TelephoneCallExample.csproj
+++ b/example/TelephoneCallExample/TelephoneCallExample.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net47</TargetFrameworks>
     <AssemblyName>TelephoneCallExample</AssemblyName>
     <OutputType>Exe</OutputType>
-    <PackageId>TelephoneCallExample</PackageId>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
+    <IsPackable>false</IsPackable>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/src/Stateless/Stateless.csproj
+++ b/src/Stateless/Stateless.csproj
@@ -1,12 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="../../common.props" />
+
   <PropertyGroup>
     <Description>Create state machines and lightweight state machine-based workflows directly in .NET code</Description>
     <AssemblyTitle>Stateless</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>4.2.0</VersionPrefix>
     <Authors>Stateless Contributors</Authors>
-    <TargetFrameworks>netstandard1.0;net45;net40</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net47</TargetFrameworks>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Stateless</AssemblyName>
@@ -26,11 +28,11 @@
     <Version>4.2.1</Version>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);PORTABLE_REFLECTION;TASKS</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net47' ">
     <DefineConstants>$(DefineConstants);TASKS</DefineConstants>
   </PropertyGroup>
 

--- a/test/Stateless.Tests/ActiveStatesFixture.cs
+++ b/test/Stateless.Tests/ActiveStatesFixture.cs
@@ -50,7 +50,7 @@ namespace Stateless.Tests
             actualOrdering.Clear();
             sm.Activate();
 
-            Assert.Equal(0, actualOrdering.Count);
+            Assert.Empty(actualOrdering);
         }
 
         [Fact]
@@ -99,7 +99,7 @@ namespace Stateless.Tests
             actualOrdering.Clear();
             sm.Activate();
 
-            Assert.Equal(0, actualOrdering.Count);
+            Assert.Empty(actualOrdering);
         }
 
         [Fact]

--- a/test/Stateless.Tests/AsyncActionsFixture.cs
+++ b/test/Stateless.Tests/AsyncActionsFixture.cs
@@ -193,7 +193,7 @@ namespace Stateless.Tests
 
             await sm.ActivateAsync().ConfigureAwait(false);
 
-            Assert.Equal(true, activated); // Should await action
+            Assert.True(activated); // Should await action
         }
 
         [Fact]
@@ -208,7 +208,7 @@ namespace Stateless.Tests
             await sm.ActivateAsync().ConfigureAwait(false);
             await sm.DeactivateAsync().ConfigureAwait(false);
 
-            Assert.Equal(true, deactivated); // Should await action
+            Assert.True(deactivated); // Should await action
         }
 
         [Fact]

--- a/test/Stateless.Tests/InitialTransitionFixture.cs
+++ b/test/Stateless.Tests/InitialTransitionFixture.cs
@@ -126,7 +126,7 @@ namespace Stateless.Tests
         {
             var sm = new StateMachine<State, Trigger>(State.A);
 
-            Assert.Throws(typeof(ArgumentException), () =>
+            Assert.Throws<ArgumentException>( () =>
                 // This configuration would create an infinite loop
                 sm.Configure(State.A)
                     .InitialTransition(State.A) );
@@ -142,7 +142,7 @@ namespace Stateless.Tests
             sm.Configure(State.B)
                 .InitialTransition(State.A); // Invalid configuration, State a is a superstate
 
-            Assert.Throws(typeof(InvalidOperationException), () =>
+            Assert.Throws<InvalidOperationException>( () =>
                 sm.Fire(Trigger.X) );
         }
 
@@ -156,7 +156,7 @@ namespace Stateless.Tests
             sm.Configure(State.B)
                 .InitialTransition(State.A);
 
-            await Assert.ThrowsAsync (typeof(InvalidOperationException), async () =>
+            await Assert.ThrowsAsync<InvalidOperationException>( async () =>
                 await sm.FireAsync(Trigger.X) );
         }
 
@@ -170,7 +170,7 @@ namespace Stateless.Tests
             sm.Configure(State.B)
                 .InitialTransition(State.C);
 
-            Assert.Throws(typeof(InvalidOperationException), () =>
+            Assert.Throws<InvalidOperationException>( () =>
                 sm.Configure(State.B)
                 .InitialTransition(State.A) );
         }

--- a/test/Stateless.Tests/InternalTransitionFixture.cs
+++ b/test/Stateless.Tests/InternalTransitionFixture.cs
@@ -211,9 +211,9 @@ namespace Stateless.Tests
             sm.Configure(State.A)
                 .InternalTransitionIf(Trigger.X, u => isPermitted, t => { });
 
-            Assert.Equal(1, sm.GetPermittedTriggers().ToArray().Length);
+            Assert.Single(sm.GetPermittedTriggers());
             isPermitted = false;
-            Assert.Equal(0, sm.GetPermittedTriggers().ToArray().Length);
+            Assert.Empty(sm.GetPermittedTriggers());
         }
 
         [Fact]

--- a/test/Stateless.Tests/ReflectionFixture.cs
+++ b/test/Stateless.Tests/ReflectionFixture.cs
@@ -108,19 +108,19 @@ namespace Stateless.Tests
 
             StateMachineInfo inf = sm.GetInfo();
 
-            Assert.Equal(inf.TriggerType, typeof(Trigger));
-            Assert.Equal(inf.States.Count(), 2);
+            Assert.Equal(typeof(Trigger), inf.TriggerType);
+            Assert.Equal(2, inf.States.Count());
             var binding = inf.States.Single(s => (State)s.UnderlyingState == State.A);
 
             Assert.True(binding.UnderlyingState is State);
             Assert.Equal(State.A, (State)binding.UnderlyingState);
             //
-            Assert.Equal(0, binding.Substates.Count());
-            Assert.Equal(null, binding.Superstate);
-            Assert.Equal(0, binding.EntryActions.Count());
-            Assert.Equal(0, binding.ExitActions.Count());
+            Assert.Empty(binding.Substates);
+            Assert.Null(binding.Superstate);
+            Assert.Empty(binding.EntryActions);
+            Assert.Empty(binding.ExitActions);
             //
-            Assert.Equal(1, binding.FixedTransitions.Count());
+            Assert.Single(binding.FixedTransitions);
             foreach (FixedTransitionInfo trans in binding.FixedTransitions)
             {
                 Assert.True(trans.Trigger.UnderlyingTrigger is Trigger);
@@ -128,10 +128,10 @@ namespace Stateless.Tests
                 //
                 Assert.True(trans.DestinationState.UnderlyingState is State);
                 Assert.Equal(State.B, (State)trans.DestinationState.UnderlyingState);
-                Assert.Equal(0, trans.GuardConditionsMethodDescriptions.Count());
+                Assert.Empty(trans.GuardConditionsMethodDescriptions);
             }
-            Assert.Equal(0, binding.IgnoredTriggers.Count());
-            Assert.Equal(0, binding.DynamicTransitions.Count());
+            Assert.Empty(binding.IgnoredTriggers);
+            Assert.Empty(binding.DynamicTransitions);
         }
 
         [Fact]
@@ -146,17 +146,17 @@ namespace Stateless.Tests
             StateMachineInfo inf = sm.GetInfo();
 
             Assert.True(inf.StateType == typeof(State));
-            Assert.Equal(inf.TriggerType, typeof(Trigger));
-            Assert.Equal(inf.States.Count(), 3);
+            Assert.Equal(typeof(Trigger), inf.TriggerType);
+            Assert.Equal(3, inf.States.Count());
             var binding = inf.States.Single(s => (State)s.UnderlyingState == State.A);
 
             Assert.True(binding.UnderlyingState is State);
             Assert.Equal(State.A, (State)binding.UnderlyingState); // Binding state value mismatch
             //
-            Assert.Equal(0, binding.Substates.Count()); //  Binding substate count mismatch"
-            Assert.Equal(null, binding.Superstate);
-            Assert.Equal(0, binding.EntryActions.Count()); //  Binding entry actions count mismatch
-            Assert.Equal(0, binding.ExitActions.Count());
+            Assert.Empty(binding.Substates); //  Binding substate count mismatch"
+            Assert.Null(binding.Superstate);
+            Assert.Empty(binding.EntryActions); //  Binding entry actions count mismatch
+            Assert.Empty(binding.ExitActions);
             //
             Assert.Equal(2, binding.FixedTransitions.Count()); // Transition count mismatch
             //
@@ -167,7 +167,7 @@ namespace Stateless.Tests
                 Assert.True(trans.Trigger.UnderlyingTrigger is Trigger);
                 //
                 Assert.True(trans.DestinationState.UnderlyingState is State);
-                Assert.Equal(0, trans.GuardConditionsMethodDescriptions.Count());
+                Assert.Empty(trans.GuardConditionsMethodDescriptions);
                 //
                 // Can't make assumptions about which trigger/destination comes first in the list
                 if ((Trigger)trans.Trigger.UnderlyingTrigger == Trigger.X)
@@ -187,8 +187,8 @@ namespace Stateless.Tests
             }
             Assert.True(haveXB && haveYC);
             //
-            Assert.Equal(0, binding.IgnoredTriggers.Count());
-            Assert.Equal(0, binding.DynamicTransitions.Count());
+            Assert.Empty(binding.IgnoredTriggers);
+            Assert.Empty(binding.DynamicTransitions);
         }
 
         [Fact]
@@ -204,19 +204,19 @@ namespace Stateless.Tests
             StateMachineInfo inf = sm.GetInfo();
 
             Assert.True(inf.StateType == typeof(State));
-            Assert.Equal(inf.TriggerType, typeof(Trigger));
-            Assert.Equal(inf.States.Count(), 2);
+            Assert.Equal(typeof(Trigger), inf.TriggerType);
+            Assert.Equal(2, inf.States.Count());
             var binding = inf.States.Single(s => (State)s.UnderlyingState == State.A);
 
             Assert.True(binding.UnderlyingState is State);
             Assert.Equal(State.A, (State)binding.UnderlyingState);
             //
-            Assert.Equal(0, binding.Substates.Count());
-            Assert.Equal(null, binding.Superstate);
-            Assert.Equal(0, binding.EntryActions.Count());
-            Assert.Equal(0, binding.ExitActions.Count());
+            Assert.Empty(binding.Substates);
+            Assert.Null(binding.Superstate);
+            Assert.Empty(binding.EntryActions);
+            Assert.Empty(binding.ExitActions);
             //
-            Assert.Equal(1, binding.FixedTransitions.Count());
+            Assert.Single(binding.FixedTransitions);
             foreach (FixedTransitionInfo trans in binding.FixedTransitions)
             {
                 Assert.True(trans.Trigger.UnderlyingTrigger is Trigger);
@@ -225,10 +225,10 @@ namespace Stateless.Tests
                 Assert.True(trans.DestinationState.UnderlyingState is State);
                 Assert.Equal(State.B, (State)trans.DestinationState.UnderlyingState);
                 //
-                Assert.NotEqual(0, trans.GuardConditionsMethodDescriptions.Count());
+                Assert.NotEmpty(trans.GuardConditionsMethodDescriptions);
             }
-            Assert.Equal(0, binding.IgnoredTriggers.Count());
-            Assert.Equal(0, binding.DynamicTransitions.Count());
+            Assert.Empty(binding.IgnoredTriggers);
+            Assert.Empty(binding.DynamicTransitions);
         }
 
         [Fact]
@@ -244,19 +244,19 @@ namespace Stateless.Tests
             StateMachineInfo inf = sm.GetInfo();
 
             Assert.True(inf.StateType == typeof(State));
-            Assert.Equal(inf.TriggerType, typeof(Trigger));
-            Assert.Equal(inf.States.Count(), 2);
+            Assert.Equal(typeof(Trigger), inf.TriggerType);
+            Assert.Equal(2, inf.States.Count());
             var binding = inf.States.Single(s => (State)s.UnderlyingState == State.A);
 
             Assert.True(binding.UnderlyingState is State);
             Assert.Equal(State.A, (State)binding.UnderlyingState);
             //
-            Assert.Equal(0, binding.Substates.Count());
-            Assert.Equal(null, binding.Superstate);
-            Assert.Equal(0, binding.EntryActions.Count());
-            Assert.Equal(0, binding.ExitActions.Count());
+            Assert.Empty(binding.Substates);
+            Assert.Null(binding.Superstate);
+            Assert.Empty(binding.EntryActions);
+            Assert.Empty(binding.ExitActions);
             //
-            Assert.Equal(1, binding.FixedTransitions.Count());
+            Assert.Single(binding.FixedTransitions);
             foreach (FixedTransitionInfo trans in binding.FixedTransitions)
             {
                 Assert.True(trans.Trigger.UnderlyingTrigger is Trigger);
@@ -265,11 +265,11 @@ namespace Stateless.Tests
                 Assert.True(trans.DestinationState.UnderlyingState is State);
                 Assert.Equal(State.B, (State)trans.DestinationState.UnderlyingState);
                 //
-                Assert.Equal(1, trans.GuardConditionsMethodDescriptions.Count());
+                Assert.Single(trans.GuardConditionsMethodDescriptions);
                 Assert.Equal("description", trans.GuardConditionsMethodDescriptions.First().Description);
             }
-            Assert.Equal(0, binding.IgnoredTriggers.Count());
-            Assert.Equal(0, binding.DynamicTransitions.Count());
+            Assert.Empty(binding.IgnoredTriggers);
+            Assert.Empty(binding.DynamicTransitions);
         }
 
         [Fact]
@@ -283,19 +283,19 @@ namespace Stateless.Tests
             StateMachineInfo inf = sm.GetInfo();
 
             Assert.True(inf.StateType == typeof(State));
-            Assert.Equal(inf.TriggerType, typeof(Trigger));
-            Assert.Equal(inf.States.Count(), 2);
+            Assert.Equal(typeof(Trigger), inf.TriggerType);
+            Assert.Equal(2, inf.States.Count());
             var binding = inf.States.Single(s => (State)s.UnderlyingState == State.A);
 
             Assert.True(binding.UnderlyingState is State);
             Assert.Equal(State.A, (State)binding.UnderlyingState);
             //
-            Assert.Equal(0, binding.Substates.Count());
-            Assert.Equal(null, binding.Superstate);
-            Assert.Equal(0, binding.EntryActions.Count());
-            Assert.Equal(0, binding.ExitActions.Count());
+            Assert.Empty(binding.Substates);
+            Assert.Null(binding.Superstate);
+            Assert.Empty(binding.EntryActions);
+            Assert.Empty(binding.ExitActions);
             //
-            Assert.Equal(1, binding.FixedTransitions.Count());
+            Assert.Single(binding.FixedTransitions);
             foreach (FixedTransitionInfo trans in binding.FixedTransitions)
             {
                 Assert.True(trans.Trigger.UnderlyingTrigger is Trigger);
@@ -304,11 +304,11 @@ namespace Stateless.Tests
                 Assert.True(trans.DestinationState.UnderlyingState is State);
                 Assert.Equal(State.B, (State)trans.DestinationState.UnderlyingState);
                 //
-                Assert.Equal(1, trans.GuardConditionsMethodDescriptions.Count());
+                Assert.Single(trans.GuardConditionsMethodDescriptions);
                 Assert.Equal("IsTrue", trans.GuardConditionsMethodDescriptions.First().Description);
             }
-            Assert.Equal(0, binding.IgnoredTriggers.Count());
-            Assert.Equal(0, binding.DynamicTransitions.Count());
+            Assert.Empty(binding.IgnoredTriggers);
+            Assert.Empty(binding.DynamicTransitions);
         }
 
         [Fact]
@@ -322,19 +322,19 @@ namespace Stateless.Tests
             StateMachineInfo inf = sm.GetInfo();
 
             Assert.True(inf.StateType == typeof(State));
-            Assert.Equal(inf.TriggerType, typeof(Trigger));
-            Assert.Equal(inf.States.Count(), 2);
+            Assert.Equal(typeof(Trigger), inf.TriggerType);
+            Assert.Equal(2, inf.States.Count());
             var binding = inf.States.Single(s => (State)s.UnderlyingState == State.A);
 
             Assert.True(binding.UnderlyingState is State);
             Assert.Equal(State.A, (State)binding.UnderlyingState);
             //
-            Assert.Equal(0, binding.Substates.Count());
-            Assert.Equal(null, binding.Superstate);
-            Assert.Equal(0, binding.EntryActions.Count());
-            Assert.Equal(0, binding.ExitActions.Count());
+            Assert.Empty(binding.Substates);
+            Assert.Null(binding.Superstate);
+            Assert.Empty(binding.EntryActions);
+            Assert.Empty(binding.ExitActions);
             //
-            Assert.Equal(1, binding.FixedTransitions.Count());
+            Assert.Single(binding.FixedTransitions);
             foreach (FixedTransitionInfo trans in binding.FixedTransitions)
             {
                 Assert.True(trans.Trigger.UnderlyingTrigger is Trigger);
@@ -343,11 +343,11 @@ namespace Stateless.Tests
                 Assert.True(trans.DestinationState.UnderlyingState is State);
                 Assert.Equal(State.B, (State)trans.DestinationState.UnderlyingState);
                 //
-                Assert.Equal(1, trans.GuardConditionsMethodDescriptions.Count());
+                Assert.Single(trans.GuardConditionsMethodDescriptions);
                 Assert.Equal("description", trans.GuardConditionsMethodDescriptions.First().Description);
             }
-            Assert.Equal(0, binding.IgnoredTriggers.Count());
-            Assert.Equal(0, binding.DynamicTransitions.Count());
+            Assert.Empty(binding.IgnoredTriggers);
+            Assert.Empty(binding.DynamicTransitions);
         }
 
         [Fact]
@@ -360,26 +360,26 @@ namespace Stateless.Tests
             StateMachineInfo inf = sm.GetInfo();
 
             Assert.True(inf.StateType == typeof(State));
-            Assert.Equal(inf.TriggerType, typeof(Trigger));
-            Assert.Equal(inf.States.Count(), 1);
+            Assert.Equal(typeof(Trigger), inf.TriggerType);
+            Assert.Single(inf.States);
             var binding = inf.States.Single(s => (State)s.UnderlyingState == State.A);
 
             Assert.True(binding.UnderlyingState is State);
             Assert.Equal(State.A, (State)binding.UnderlyingState);
             //
-            Assert.Equal(0, binding.Substates.Count());
-            Assert.Equal(null, binding.Superstate);
-            Assert.Equal(0, binding.EntryActions.Count());
-            Assert.Equal(0, binding.ExitActions.Count());
+            Assert.Empty(binding.Substates);
+            Assert.Null(binding.Superstate);
+            Assert.Empty(binding.EntryActions);
+            Assert.Empty(binding.ExitActions);
             //
-            Assert.Equal(0, binding.FixedTransitions.Count()); // Binding transition count mismatch
-            Assert.Equal(0, binding.IgnoredTriggers.Count());
-            Assert.Equal(1, binding.DynamicTransitions.Count()); // Dynamic transition count mismatch
+            Assert.Empty(binding.FixedTransitions); // Binding transition count mismatch
+            Assert.Empty(binding.IgnoredTriggers);
+            Assert.Single(binding.DynamicTransitions); // Dynamic transition count mismatch
             foreach (DynamicTransitionInfo trans in binding.DynamicTransitions)
             {
                 Assert.True(trans.Trigger.UnderlyingTrigger is Trigger);
                 Assert.Equal(Trigger.X, (Trigger)trans.Trigger.UnderlyingTrigger);
-                Assert.Equal(0, trans.GuardConditionsMethodDescriptions.Count());
+                Assert.Empty(trans.GuardConditionsMethodDescriptions);
             }
         }
 
@@ -394,26 +394,26 @@ namespace Stateless.Tests
             StateMachineInfo inf = sm.GetInfo();
 
             Assert.True(inf.StateType == typeof(State));
-            Assert.Equal(inf.TriggerType, typeof(Trigger));
-            Assert.Equal(inf.States.Count(), 1);
+            Assert.Equal(typeof(Trigger), inf.TriggerType);
+            Assert.Single(inf.States);
             var binding = inf.States.Single(s => (State)s.UnderlyingState == State.A);
 
             Assert.True(binding.UnderlyingState is State);
             Assert.Equal(State.A, (State)binding.UnderlyingState);
             //
-            Assert.Equal(0, binding.Substates.Count());
-            Assert.Equal(null, binding.Superstate);
-            Assert.Equal(0, binding.EntryActions.Count());
-            Assert.Equal(0, binding.ExitActions.Count());
+            Assert.Empty(binding.Substates);
+            Assert.Null(binding.Superstate);
+            Assert.Empty(binding.EntryActions);
+            Assert.Empty(binding.ExitActions);
             //
-            Assert.Equal(0, binding.FixedTransitions.Count()); // Binding transition count mismatch"
-            Assert.Equal(0, binding.IgnoredTriggers.Count());
-            Assert.Equal(1, binding.DynamicTransitions.Count()); // Dynamic transition count mismatch
+            Assert.Empty(binding.FixedTransitions); // Binding transition count mismatch"
+            Assert.Empty(binding.IgnoredTriggers);
+            Assert.Single(binding.DynamicTransitions); // Dynamic transition count mismatch
             foreach (DynamicTransitionInfo trans in binding.DynamicTransitions)
             {
                 Assert.True(trans.Trigger.UnderlyingTrigger is Trigger);
                 Assert.Equal(Trigger.X, (Trigger)trans.Trigger.UnderlyingTrigger);
-                Assert.Equal(0, trans.GuardConditionsMethodDescriptions.Count());
+                Assert.Empty(trans.GuardConditionsMethodDescriptions);
             }
         }
 
@@ -428,24 +428,24 @@ namespace Stateless.Tests
             StateMachineInfo inf = sm.GetInfo();
 
             Assert.True(inf.StateType == typeof(State));
-            Assert.Equal(inf.States.Count(), 1);
+            Assert.Single(inf.States);
             var binding = inf.States.Single(s => (State)s.UnderlyingState == State.A);
 
             Assert.True(binding.UnderlyingState is State);
             Assert.Equal(State.A, (State)binding.UnderlyingState);
             //
-            Assert.Equal(0, binding.Substates.Count());
-            Assert.Equal(null, binding.Superstate);
-            Assert.Equal(1, binding.EntryActions.Count());
+            Assert.Empty(binding.Substates);
+            Assert.Null(binding.Superstate);
+            Assert.Single(binding.EntryActions);
             foreach (ActionInfo entryAction in binding.EntryActions)
             {
                 Assert.Equal("enteredA", entryAction.Method.Description);
             }
-            Assert.Equal(0, binding.ExitActions.Count());
+            Assert.Empty(binding.ExitActions);
             //
-            Assert.Equal(0, binding.FixedTransitions.Count()); // Binding count mismatch
-            Assert.Equal(0, binding.IgnoredTriggers.Count());
-            Assert.Equal(0, binding.DynamicTransitions.Count()); // Dynamic transition count mismatch
+            Assert.Empty(binding.FixedTransitions); // Binding count mismatch
+            Assert.Empty(binding.IgnoredTriggers);
+            Assert.Empty(binding.DynamicTransitions); // Dynamic transition count mismatch
         }
 
         [Fact]
@@ -459,23 +459,23 @@ namespace Stateless.Tests
             StateMachineInfo inf = sm.GetInfo();
 
             Assert.True(inf.StateType == typeof(State));
-            Assert.Equal(inf.States.Count(), 1);
+            Assert.Single(inf.States);
             var binding = inf.States.Single(s => (State)s.UnderlyingState == State.A);
 
             Assert.True(binding.UnderlyingState is State);
             Assert.Equal(State.A, (State)binding.UnderlyingState);
             //
-            Assert.Equal(0, binding.Substates.Count());
-            Assert.Equal(null, binding.Superstate);
+            Assert.Empty(binding.Substates);
+            Assert.Null(binding.Superstate);
             //
-            Assert.Equal(1, binding.EntryActions.Count());
+            Assert.Single(binding.EntryActions);
             foreach (ActionInfo entryAction in binding.EntryActions)
                 Assert.Equal("enteredA", entryAction.Method.Description);
-            Assert.Equal(0, binding.ExitActions.Count());
+            Assert.Empty(binding.ExitActions);
             //
-            Assert.Equal(0, binding.FixedTransitions.Count()); // Binding count mismatch
-            Assert.Equal(0, binding.IgnoredTriggers.Count());
-            Assert.Equal(0, binding.DynamicTransitions.Count()); // Dynamic transition count mismatch
+            Assert.Empty(binding.FixedTransitions); // Binding count mismatch
+            Assert.Empty(binding.IgnoredTriggers);
+            Assert.Empty(binding.DynamicTransitions); // Dynamic transition count mismatch
         }
 
         [Fact]
@@ -489,23 +489,23 @@ namespace Stateless.Tests
             StateMachineInfo inf = sm.GetInfo();
 
             Assert.True(inf.StateType == typeof(State));
-            Assert.Equal(inf.States.Count(), 1);
+            Assert.Single(inf.States);
             var binding = inf.States.Single(s => (State)s.UnderlyingState == State.A);
 
             Assert.True(binding.UnderlyingState is State);
             Assert.Equal(State.A, (State)binding.UnderlyingState);
             //
-            Assert.Equal(0, binding.Substates.Count());
-            Assert.Equal(null, binding.Superstate);
+            Assert.Empty(binding.Substates);
+            Assert.Null(binding.Superstate);
             //
-            Assert.Equal(0, binding.EntryActions.Count());
-            Assert.Equal(1, binding.ExitActions.Count());
+            Assert.Empty(binding.EntryActions);
+            Assert.Single(binding.ExitActions);
             foreach (InvocationInfo exitAction in binding.ExitActions)
                 Assert.Equal("exitA", exitAction.Description);
             //
-            Assert.Equal(0, binding.FixedTransitions.Count()); // Binding count mismatch
-            Assert.Equal(0, binding.IgnoredTriggers.Count());
-            Assert.Equal(0, binding.DynamicTransitions.Count()); // Dynamic transition count mismatch
+            Assert.Empty(binding.FixedTransitions); // Binding count mismatch
+            Assert.Empty(binding.IgnoredTriggers);
+            Assert.Empty(binding.DynamicTransitions); // Dynamic transition count mismatch
         }
 
         [Fact]
@@ -519,23 +519,23 @@ namespace Stateless.Tests
             StateMachineInfo inf = sm.GetInfo();
 
             Assert.True(inf.StateType == typeof(State));
-            Assert.Equal(inf.States.Count(), 1);
+            Assert.Single(inf.States);
             var binding = inf.States.Single(s => (State)s.UnderlyingState == State.A);
 
             Assert.True(binding.UnderlyingState is State);
             Assert.Equal(State.A, (State)binding.UnderlyingState);
             //
-            Assert.Equal(0, binding.Substates.Count());
-            Assert.Equal(null, binding.Superstate);
+            Assert.Empty(binding.Substates);
+            Assert.Null(binding.Superstate);
             //
-            Assert.Equal(0, binding.EntryActions.Count());
-            Assert.Equal(1, binding.ExitActions.Count());
+            Assert.Empty(binding.EntryActions);
+            Assert.Single(binding.ExitActions);
             foreach (InvocationInfo entryAction in binding.ExitActions)
                 Assert.Equal("exitA", entryAction.Description);
             //
-            Assert.Equal(0, binding.FixedTransitions.Count()); // Binding count mismatch
-            Assert.Equal(0, binding.IgnoredTriggers.Count());
-            Assert.Equal(0, binding.DynamicTransitions.Count()); // Dynamic transition count mismatch
+            Assert.Empty(binding.FixedTransitions); // Binding count mismatch
+            Assert.Empty(binding.IgnoredTriggers);
+            Assert.Empty(binding.DynamicTransitions); // Dynamic transition count mismatch
         }
 
         [Fact]
@@ -550,14 +550,14 @@ namespace Stateless.Tests
             StateMachineInfo inf = sm.GetInfo();
 
             Assert.True(inf.StateType == typeof(State));
-            Assert.Equal(inf.TriggerType, typeof(Trigger));
-            Assert.Equal(inf.States.Count(), 2);
+            Assert.Equal(typeof(Trigger), inf.TriggerType);
+            Assert.Equal(2, inf.States.Count());
             var binding = inf.States.Single(s => (State)s.UnderlyingState == State.A);
 
             Assert.True(binding.UnderlyingState is State);
             Assert.Equal(State.A, (State)binding.UnderlyingState);
             //
-            Assert.Equal(1, binding.FixedTransitions.Count()); // Transition count mismatch"
+            Assert.Single(binding.FixedTransitions); // Transition count mismatch"
             foreach (FixedTransitionInfo trans in binding.FixedTransitions)
             {
                 Assert.True(trans.Trigger.UnderlyingTrigger is Trigger);
@@ -565,26 +565,26 @@ namespace Stateless.Tests
                 //
                 Assert.True(trans.DestinationState.UnderlyingState is State);
                 Assert.Equal(State.B, (State)trans.DestinationState.UnderlyingState);
-                Assert.Equal(0, trans.GuardConditionsMethodDescriptions.Count());
+                Assert.Empty(trans.GuardConditionsMethodDescriptions);
             }
             //
-            Assert.Equal(1, binding.IgnoredTriggers.Count()); //  Ignored triggers count mismatch
+            Assert.Single(binding.IgnoredTriggers); //  Ignored triggers count mismatch
             foreach (IgnoredTransitionInfo ignore in binding.IgnoredTriggers)
             {
                 Assert.True(ignore.Trigger.UnderlyingTrigger is Trigger);
                 Assert.Equal(Trigger.Y, (Trigger)ignore.Trigger.UnderlyingTrigger); // Ignored trigger value mismatch
             }
             //
-            Assert.Equal(0, binding.Substates.Count());
-            Assert.Equal(null, binding.Superstate);
-            Assert.Equal(0, binding.EntryActions.Count());
-            Assert.Equal(0, binding.ExitActions.Count());
-            Assert.Equal(0, binding.DynamicTransitions.Count()); // Dynamic transition count mismatch
+            Assert.Empty(binding.Substates);
+            Assert.Null(binding.Superstate);
+            Assert.Empty(binding.EntryActions);
+            Assert.Empty(binding.ExitActions);
+            Assert.Empty(binding.DynamicTransitions); // Dynamic transition count mismatch
         }
 
         void VerifyMethodNames(IEnumerable<InvocationInfo> methods, string prefix, string body, State state, InvocationInfo.Timing timing)
         {
-            Assert.Equal(1, methods.Count());
+            Assert.Single(methods);
             InvocationInfo method = methods.First();
 
             if (state == State.A)
@@ -845,9 +845,9 @@ namespace Stateless.Tests
 
             foreach (StateInfo stateInfo in inf.States)
             {
-                Assert.Equal(1, stateInfo.Transitions.Count());
+                Assert.Single(stateInfo.Transitions);
                 TransitionInfo transInfo = stateInfo.Transitions.First();
-                Assert.Equal(1, transInfo.GuardConditionsMethodDescriptions.Count());
+                Assert.Single(transInfo.GuardConditionsMethodDescriptions);
                 VerifyMethodNames(transInfo.GuardConditionsMethodDescriptions, "", "Permit", (State)stateInfo.UnderlyingState, InvocationInfo.Timing.Synchronous);
             }
 
@@ -869,9 +869,9 @@ namespace Stateless.Tests
 
             foreach (StateInfo stateInfo in inf.States)
             {
-                Assert.Equal(1, stateInfo.Transitions.Count());
+                Assert.Single(stateInfo.Transitions);
                 TransitionInfo transInfo = stateInfo.Transitions.First();
-                Assert.Equal(1, transInfo.GuardConditionsMethodDescriptions.Count());
+                Assert.Single(transInfo.GuardConditionsMethodDescriptions);
                 VerifyMethodNames(transInfo.GuardConditionsMethodDescriptions, "", "Permit", (State)stateInfo.UnderlyingState, InvocationInfo.Timing.Synchronous);
             }
 

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -114,9 +114,9 @@ namespace Stateless.Tests
 
             var permitted = sm.GetPermittedTriggers();
 
-            Assert.True(permitted.Contains(Trigger.X));
-            Assert.True(permitted.Contains(Trigger.Y));
-            Assert.False(permitted.Contains(Trigger.Z));
+            Assert.Contains(Trigger.X, permitted);
+            Assert.Contains(Trigger.Y, permitted);
+            Assert.DoesNotContain(Trigger.Z, permitted);
         }
 
         [Fact]
@@ -132,7 +132,7 @@ namespace Stateless.Tests
                 .Permit(Trigger.X, State.B);
 
             var permitted = sm.GetPermittedTriggers();
-            Assert.Equal(1, permitted.Count());
+            Assert.Single(permitted);
             Assert.Equal(Trigger.X, permitted.First());
         }
 
@@ -144,7 +144,7 @@ namespace Stateless.Tests
             sm.Configure(State.B)
                 .PermitIf(Trigger.X, State.A, () => false);
 
-            Assert.Equal(0, sm.GetPermittedTriggers().Count());
+            Assert.Empty(sm.GetPermittedTriggers());
         }
 
         [Fact]
@@ -157,7 +157,7 @@ namespace Stateless.Tests
                     new Tuple<Func<bool>, string>(() => true, "1"),
                     new Tuple<Func<bool>, string>(() => false, "2"));
 
-            Assert.Equal(0, sm.GetPermittedTriggers().Count());
+            Assert.Empty(sm.GetPermittedTriggers());
         }
 
         [Fact]
@@ -246,7 +246,7 @@ namespace Stateless.Tests
         {
             var sm = new StateMachine<State, Trigger>(State.A);
             var exception = Assert.Throws<InvalidOperationException>(() => sm.Fire(Trigger.X));
-            Assert.Equal(exception.Message, "No valid leaving transitions are permitted from state 'A' for trigger 'X'. Consider ignoring the trigger.");
+            Assert.Equal("No valid leaving transitions are permitted from state 'A' for trigger 'X'. Consider ignoring the trigger.", exception.Message);
         }
 
         [Fact]
@@ -259,7 +259,7 @@ namespace Stateless.Tests
             var sm = new StateMachine<State, Trigger>(State.A);
             sm.Configure(State.A).PermitIf(Trigger.X, State.B, () => false, guardDescription);
             var exception = Assert.Throws<InvalidOperationException>(() => sm.Fire(Trigger.X));
-            Assert.Equal(exception.Message, "Trigger 'X' is valid for transition from state 'A' but a guard conditions are not met. Guard descriptions: 'test'.");
+            Assert.Equal("Trigger 'X' is valid for transition from state 'A' but a guard conditions are not met. Guard descriptions: 'test'.", exception.Message);
         }
 
         [Fact]
@@ -271,7 +271,7 @@ namespace Stateless.Tests
                 new Tuple<Func<bool>, string>(() => false, "test2"));
 
             var exception = Assert.Throws<InvalidOperationException>(() => sm.Fire(Trigger.X));
-            Assert.Equal(exception.Message, "Trigger 'X' is valid for transition from state 'A' but a guard conditions are not met. Guard descriptions: 'test1, test2'.");
+            Assert.Equal("Trigger 'X' is valid for transition from state 'A' but a guard conditions are not met. Guard descriptions: 'test1, test2'.", exception.Message);
         }
 
         [Fact]
@@ -371,7 +371,7 @@ namespace Stateless.Tests
         {
             var sm = new StateMachine<State, Trigger>(State.A);
 
-            Assert.Throws(typeof(ArgumentException),  () => { sm.Configure(State.A).SubstateOf(State.A); });
+            Assert.Throws<ArgumentException>( () => { sm.Configure(State.A).SubstateOf(State.A); });
         }
 
         [Fact]
@@ -380,7 +380,7 @@ namespace Stateless.Tests
             var sm = new StateMachine<State, Trigger>(State.A);
             sm.Configure(State.B).SubstateOf(State.A);
 
-            Assert.Throws(typeof(ArgumentException), () => { sm.Configure(State.A).SubstateOf(State.B); });
+            Assert.Throws<ArgumentException>( () => { sm.Configure(State.A).SubstateOf(State.B); });
         }
 
         [Fact]
@@ -390,7 +390,7 @@ namespace Stateless.Tests
             sm.Configure(State.B).SubstateOf(State.A);
             sm.Configure(State.C).SubstateOf(State.B);
 
-            Assert.Throws(typeof(ArgumentException), () => { sm.Configure(State.A).SubstateOf(State.C); });
+            Assert.Throws<ArgumentException>( () => { sm.Configure(State.A).SubstateOf(State.C); });
         }
 
         [Fact]
@@ -403,7 +403,7 @@ namespace Stateless.Tests
             sm.Configure(State.C);
             sm.Configure(State.A).SubstateOf(State.C);
 
-            Assert.Throws(typeof(ArgumentException), () => { sm.Configure(State.C).SubstateOf(State.B); });
+            Assert.Throws<ArgumentException>( () => { sm.Configure(State.C).SubstateOf(State.B); });
         }
 
         [Fact]
@@ -463,7 +463,7 @@ namespace Stateless.Tests
 
             sm.Fire(Trigger.X);
 
-            Assert.Equal(State.B, sm.State);
+            Assert.True(State.B == sm.State);
             Assert.True(onEntryStateBfired);
             Assert.True(onExitStateBfired);
             Assert.True(onExitStateAfired);
@@ -477,7 +477,7 @@ namespace Stateless.Tests
             sm.Configure(State.A).PermitIf(x, State.B, i => i == 2);
             sm.Fire(x, 2);
 
-            Assert.Equal(sm.State, State.B);
+            Assert.True(sm.State == State.B);
         }
 
         [Fact]
@@ -500,7 +500,7 @@ namespace Stateless.Tests
             sm.Configure(State.A).PermitIf(x, State.B, positiveGuard, negativeGuard);
             sm.Fire(x, 2);
 
-            Assert.Equal(sm.State, State.B);
+            Assert.True(sm.State == State.B);
         }
 
         [Fact]
@@ -523,7 +523,7 @@ namespace Stateless.Tests
             var x = sm.SetTriggerParameters<string, int>(Trigger.X);
             sm.Configure(State.A).PermitIf(x, State.B, (s, i) => s == "3" && i == 3);
             sm.Fire(x, "3", 3);
-            Assert.Equal(sm.State, State.B);
+            Assert.True(sm.State == State.B);
         }
 
         [Fact]
@@ -532,7 +532,7 @@ namespace Stateless.Tests
             var sm = new StateMachine<State, Trigger>(State.A);
             var x = sm.SetTriggerParameters<string, int>(Trigger.X);
             sm.Configure(State.A).PermitIf(x, State.B, (s, i) => s == "3" && i == 3);
-            Assert.Equal(sm.State, State.A);
+            Assert.True(sm.State == State.A);
 
             Assert.Throws<InvalidOperationException>(() => sm.Fire(x, "2", 2));
             Assert.Throws<InvalidOperationException>(() => sm.Fire(x, "3", 2));
@@ -548,7 +548,7 @@ namespace Stateless.Tests
                 .PermitIf(x, State.B, i => i == 3)
                 .PermitIf(x, State.C, i => i == 2);
             sm.Fire(x, 3);
-            Assert.Equal(sm.State, State.B);
+            Assert.True(sm.State == State.B);
         }
 
         [Fact]
@@ -571,7 +571,7 @@ namespace Stateless.Tests
                 .PermitDynamicIf(x, i => i == 3 ? State.B : State.C, i => i == 3 || i == 5)
                 .PermitDynamicIf(x, i => i == 2 ? State.C : State.D, i => i == 2 || i == 4);
             sm.Fire(x, 3);
-            Assert.Equal(sm.State, State.B);
+            Assert.True(sm.State == State.B);
         }
 
         [Fact]
@@ -595,7 +595,7 @@ namespace Stateless.Tests
                 sm.Configure(State.B).SubstateOf(State.A).PermitIf(x, State.C, i => i == 2);
             }
             sm.Fire(x, 3);
-            Assert.Equal(sm.State, State.D);
+            Assert.True(sm.State == State.D);
         }
 
         [Fact]
@@ -608,7 +608,7 @@ namespace Stateless.Tests
                 sm.Configure(State.B).SubstateOf(State.A).PermitIf(x, State.C, i => i == 2);
             }
             sm.Fire(x, 2);
-            Assert.Equal(sm.State, State.C);
+            Assert.True(sm.State == State.C);
         }
 
         [Fact]
@@ -619,7 +619,7 @@ namespace Stateless.Tests
             sm.Configure(State.A)
                 .PermitReentryIf(x, i => i == 3 );
             sm.Fire(x, 3);
-            Assert.Equal(sm.State, State.A);
+            Assert.True(sm.State == State.A);
         }
 
         [Fact]
@@ -641,7 +641,7 @@ namespace Stateless.Tests
             sm.Configure(State.A).IgnoreIf(x, i => i == 3);
             sm.Fire(x, 3);
 
-            Assert.Equal(sm.State, State.A);
+            Assert.True(sm.State == State.A);
         }
 
         [Fact]
@@ -688,7 +688,7 @@ namespace Stateless.Tests
             sm.Fire(Trigger.X);  // THROWS EXCEPTION
 
             Assert.True(onUnhandledTriggerWasCalled, "OnUnhandledTrigger was called");
-            Assert.Equal(sm.State, State.A);
+            Assert.True(sm.State == State.A);
         }
 
         [Fact]

--- a/test/Stateless.Tests/Stateless.Tests.csproj
+++ b/test/Stateless.Tests/Stateless.Tests.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="../../common.props" />
+
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net47</TargetFrameworks>
     <DefineConstants>$(DefineConstants);TASKS</DefineConstants>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>Stateless.Tests</AssemblyName>
@@ -9,9 +11,15 @@
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Stateless.Tests</PackageId>
+    <IsPackable>false</IsPackable>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);portable-net45+win8</PackageTargetFallback>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.0.4</RuntimeFrameworkVersion>
+
+<!-- REVIEW: need to keep? 
+    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(PackageTargetFallback);portable-net45+win8</PackageTargetFallback>
+    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0</RuntimeFrameworkVersion>
+-->
+
+<!-- REVIEW: remove Generate props? -->
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -27,9 +35,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />
+    <PackageReference Include="xunit" Version="2.*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I need a FSM for a a project, and need NetCore 2 in order to run on Linux & Windows.  I've done the migration to netstandard 2 and netfx 4.7 (compilation errors with 4.6.x).  Would you like to merge this PR and publish updated NuGet?  If not, let me know and we'll consider publishing separately.