### PR TITLE
update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ await stateMachine.FireAsync(Trigger.Assigned);
 
 ## Building
 
-Stateless runs on .NET 4.0+ and practically all modern .NET platforms by targeting .NET Standard 1.0. Visual Studio 2017 is required to build the solution.
+Stateless runs on .NET 4.0+ and practically all modern .NET platforms by targeting .NET Standard 1.0 and .NET Standard2.0. Visual Studio 2017 or later is required to build the solution.
 
 
 ## Project Goals


### PR DESCRIPTION
Add note that stateless Targets .NET Standard 2.0, too. Furthermore I built stateless with VS 2019, no problem.