### PR TITLE
A basic attempt at adding Trigger parameters to the OnTransitioned

### DIFF
--- a/example/TelephoneCallExample/PhoneCall.cs
+++ b/example/TelephoneCallExample/PhoneCall.cs
@@ -68,7 +68,7 @@ namespace TelephoneCallExample
                 .Permit(Trigger.TakenOffHold, State.Connected)
                 .Permit(Trigger.PhoneHurledAgainstWall, State.PhoneDestroyed);
 
-            _machine.OnTransitioned(t => Console.WriteLine($"OnTransitioned: {t.Source} -> {t.Destination} via {t.Trigger}({string.Join(", ",  t.Parameters ?? new object[0])})"));
+            _machine.OnTransitioned(t => Console.WriteLine($"OnTransitioned: {t.Source} -> {t.Destination} via {t.Trigger}({string.Join(", ",  t.Parameters)})"));
         }
 
         void OnSetVolume(int volume)

--- a/example/TelephoneCallExample/PhoneCall.cs
+++ b/example/TelephoneCallExample/PhoneCall.cs
@@ -67,6 +67,8 @@ namespace TelephoneCallExample
                 .SubstateOf(State.Connected)
                 .Permit(Trigger.TakenOffHold, State.Connected)
                 .Permit(Trigger.PhoneHurledAgainstWall, State.PhoneDestroyed);
+
+            _machine.OnTransitioned(t => Console.WriteLine($"OnTransitioned: {t.Source} -> {t.Destination} via {t.Trigger}({string.Join(", ",  t.Parameters ?? new object[0])})"));
         }
 
         void OnSetVolume(int volume)

--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -182,7 +182,7 @@ namespace Stateless
             if (result.Handler is ReentryTriggerBehaviour handler)
             {
                 // Handle transition, and set new state
-                var transition = new Transition(source, handler.Destination, trigger);
+                var transition = new Transition(source, handler.Destination, trigger, args);
                 transition = await representativeState.ExitAsync(transition);
                 State = transition.Destination;
                 var newRepresentation = GetRepresentation(transition.Destination);
@@ -190,18 +190,18 @@ namespace Stateless
                 if (!source.Equals(transition.Destination))
                 {
                     // Then Exit the final superstate
-                    transition = new Transition(handler.Destination, handler.Destination, trigger);
+                    transition = new Transition(handler.Destination, handler.Destination, trigger, args);
                     await newRepresentation.ExitAsync(transition);
                 }
 
-                await _onTransitionedEvent.InvokeAsync(new Transition(source, handler.Destination, trigger));
+                await _onTransitionedEvent.InvokeAsync(new Transition(source, handler.Destination, trigger, args));
 
                 await newRepresentation.EnterAsync(transition, args);
             }
             // Check if it is an internal transition, or a transition from one state to another.
             else if (result.Handler.ResultsInTransitionFrom(source, args, out var destination))
             {
-                var transition = new Transition(source, destination, trigger);
+                var transition = new Transition(source, destination, trigger, args);
 
                 transition = await representativeState.ExitAsync(transition).ConfigureAwait(false);
 
@@ -220,25 +220,25 @@ namespace Stateless
                     // Check if state has substate(s), and if an initial transition(s) has been set up.
                     while (newRepresentation.GetSubstates().Any() && newRepresentation.HasInitialTransition)
                     {
-                        var initialTransition = new Transition(source, newRepresentation.InitialTransitionTarget, trigger);
+                        var initialTransition = new Transition(source, newRepresentation.InitialTransitionTarget, trigger, args);
                         newRepresentation = GetRepresentation(newRepresentation.InitialTransitionTarget);
                         await newRepresentation.EnterAsync(initialTransition, args);
                         State = newRepresentation.UnderlyingState;
                     }
                     //Alert all listeners of state transition
-                    await _onTransitionedEvent.InvokeAsync(new Transition(source, destination, trigger));
+                    await _onTransitionedEvent.InvokeAsync(new Transition(source, destination, trigger, args));
                 }
                 else
                 {
                     //Alert all listeners of state transition
-                    await _onTransitionedEvent.InvokeAsync(new Transition(source, destination, trigger));
+                    await _onTransitionedEvent.InvokeAsync(new Transition(source, destination, trigger, args));
 
                     await newRepresentation.EnterAsync(transition, args);
                 }
             }
             else
             {
-                var transition = new Transition(source, destination, trigger);
+                var transition = new Transition(source, destination, trigger, args);
 
                 await CurrentRepresentation.InternalActionAsync(transition, args).ConfigureAwait(false);
             }

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -366,7 +366,7 @@ namespace Stateless
                 case ReentryTriggerBehaviour handler:
                 {
                     // Handle transition, and set new state
-                    var transition = new Transition(source, handler.Destination, trigger);
+                    var transition = new Transition(source, handler.Destination, trigger, args);
                     HandleReentryTrigger(args, representativeState, transition);
                     break;
                 }
@@ -374,7 +374,7 @@ namespace Stateless
                 case TransitioningTriggerBehaviour _ when (result.Handler.ResultsInTransitionFrom(source, args, out destination)):
                 {
                     // Handle transition, and set new state
-                    var transition = new Transition(source, destination, trigger);
+                    var transition = new Transition(source, destination, trigger, args);
                     HandleTransitioningTrigger(args, representativeState, transition);
 
                     break;
@@ -382,7 +382,7 @@ namespace Stateless
                 case InternalTriggerBehaviour _:
                 {
                     // Internal transitions does not update the current state, but must execute the associated action.
-                    var transition = new Transition(source, source, trigger);
+                    var transition = new Transition(source, source, trigger, args);
                     CurrentRepresentation.InternalAction(transition, args);
                     break;
                 }
@@ -400,7 +400,7 @@ namespace Stateless
             if (!transition.Source.Equals(transition.Destination))
             {
                 // Then Exit the final superstate
-                transition = new Transition(transition.Destination, transition.Destination, transition.Trigger);
+                transition = new Transition(transition.Destination, transition.Destination, transition.Trigger, args);
                 newRepresentation.Exit(transition);
 
                 _onTransitionedEvent.Invoke(transition);
@@ -442,7 +442,7 @@ namespace Stateless
                     throw new InvalidOperationException($"The target ({representation.InitialTransitionTarget}) for the initial transition is not a substate.");
                 }
 
-                var initialTransition = new Transition(transition.Source, representation.InitialTransitionTarget, transition.Trigger);
+                var initialTransition = new Transition(transition.Source, representation.InitialTransitionTarget, transition.Trigger, args);
                 representation = GetRepresentation(representation.InitialTransitionTarget);
                 representation = EnterState(representation, initialTransition, args);
             }

--- a/src/Stateless/Transition.cs
+++ b/src/Stateless/Transition.cs
@@ -13,11 +13,13 @@
             /// <param name="source">The state transitioned from.</param>
             /// <param name="destination">The state transitioned to.</param>
             /// <param name="trigger">The trigger that caused the transition.</param>
-            public Transition(TState source, TState destination, TTrigger trigger)
+            /// <param name="parameters">The optional trigger parameters</param>
+            public Transition(TState source, TState destination, TTrigger trigger, object[] parameters = null)
             {
                 Source = source;
                 Destination = destination;
                 Trigger = trigger;
+                Parameters = parameters;
             }
 
             /// <summary>
@@ -39,6 +41,11 @@
             /// True if the transition is a re-entry, i.e. the identity transition.
             /// </summary>
             public bool IsReentry => Source.Equals(Destination);
+
+            /// <summary>
+            /// The trigger parameters
+            /// </summary>
+            public object[] Parameters { get; }
         }
     }
 }

--- a/src/Stateless/Transition.cs
+++ b/src/Stateless/Transition.cs
@@ -19,7 +19,7 @@
                 Source = source;
                 Destination = destination;
                 Trigger = trigger;
-                Parameters = parameters;
+                Parameters = parameters ?? new object[0];
             }
 
             /// <summary>
@@ -45,6 +45,9 @@
             /// <summary>
             /// The trigger parameters
             /// </summary>
+            /// <remarks>
+            /// Never null. For a parameterless trigger the value will be an empty array.
+            /// </remarks>
             public object[] Parameters { get; }
         }
     }

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -339,6 +339,7 @@ namespace Stateless.Tests
             Assert.Equal(Trigger.X, transition.Trigger);
             Assert.Equal(State.B, transition.Source);
             Assert.Equal(State.A, transition.Destination);
+            Assert.Equal(new object[0], transition.Parameters);
         }
 
         [Fact]
@@ -364,6 +365,56 @@ namespace Stateless.Tests
             {
                 Assert.Equal(expectedOrdering[i], actualOrdering[i]);
             }
+        }
+
+        [Fact]
+        public void WhenATransitionOccurs_WithAParameterizedTrigger_TheOnTransitionEventFires()
+        {
+            var sm = new StateMachine<State, Trigger>(State.B);
+            var triggerX = sm.SetTriggerParameters<string>(Trigger.X);
+
+            sm.Configure(State.B)
+                .Permit(Trigger.X, State.A);
+
+            StateMachine<State, Trigger>.Transition transition = null;
+            sm.OnTransitioned(t => transition = t);
+
+            string parameter = "the parameter";
+            sm.Fire(triggerX, parameter);
+
+            Assert.NotNull(transition);
+            Assert.Equal(Trigger.X, transition.Trigger);
+            Assert.Equal(State.B, transition.Source);
+            Assert.Equal(State.A, transition.Destination);
+            Assert.Equal(1, transition.Parameters.Count());
+            Assert.Equal(parameter, transition.Parameters[0]);
+        }
+
+        [Fact]
+        public void WhenATransitionOccurs_WithAParameterizedTrigger_WithMultipleParameters_TheOnTransitionEventFires()
+        {
+            var sm = new StateMachine<State, Trigger>(State.B);
+            var triggerX = sm.SetTriggerParameters<string, int, bool>(Trigger.X);
+
+            sm.Configure(State.B)
+                .Permit(Trigger.X, State.A);
+
+            StateMachine<State, Trigger>.Transition transition = null;
+            sm.OnTransitioned(t => transition = t);
+
+            string firstParameter = "the parameter";
+            int secondParameter = 99;
+            bool thirdParameter = true;
+            sm.Fire(triggerX, firstParameter, secondParameter, thirdParameter);
+
+            Assert.NotNull(transition);
+            Assert.Equal(Trigger.X, transition.Trigger);
+            Assert.Equal(State.B, transition.Source);
+            Assert.Equal(State.A, transition.Destination);
+            Assert.Equal(3, transition.Parameters.Count());
+            Assert.Equal(firstParameter, transition.Parameters[0]);
+            Assert.Equal(secondParameter, transition.Parameters[1]);
+            Assert.Equal(thirdParameter, transition.Parameters[2]);
         }
 
         [Fact]


### PR DESCRIPTION
This was a very quick, basic attempt to add Trigger parameters to the OnTransitioned
event.

This was requested in  #346 and something I was interested in as well.
This change is more of a proof of concept to see if the maintainers consider
this type of an approach acceptable. If so, I would add tests and ensure that
if the parameters are not specified they are stored as an empty array on the
Transition object.