### PR TITLE
Invert _firingMode.Equals(FiringMode.Immediate)

### DIFF
--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -439,7 +439,7 @@ namespace Stateless
             // Enter the new state
             representation.Enter(transition, args);
 
-            if (_firingMode.Equals(FiringMode.Immediate) && !State.Equals(transition.Destination))
+            if (FiringMode.Immediate.Equals(_firingMode) && !State.Equals(transition.Destination))
             {
                 // This can happen if triggers are fired in OnEntry
                 // Must update current representation with updated State


### PR DESCRIPTION
I'm looking to use this library in a SaaS environment (MS Dynamics 365 plugin) that runs in partial trust mode under .NET Framework 4.6, and was getting this exception when calling Fire(trigger): `System.Security.VerificationException : Operation could destabilize the runtime`

To reproduce locally -- several tests will fail in current VS2019, add `[assembly: AllowPartiallyTrustedCallers]` in AssemblyInfo.cs

I narrowed it down to this particular line: `if(_firingMode.Equals(FiringMode.Immediate) ...)`

For reasons that escape me, inverting the Equals fixes the problem. Presumably Equals is now being called on an explicit type/value, but I couldn't manage to find the root cause in a repro (generics, boxing, nullability...?)

If I stumble upon other related issues, I might add to this PR.