### PR TITLE
Expose internal transitions

### DIFF
--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -236,6 +236,9 @@ namespace Stateless
             {
                 var transition = new Transition(source, destination, trigger, args);
 
+                // Alert all listeners of state transition
+                await _onTransitionedInternalEvent.InvokeAsync(transition);
+
                 await CurrentRepresentation.InternalActionAsync(transition, args).ConfigureAwait(false);
             }
         }


### PR DESCRIPTION
TODO:
- [ ] Discuss implementation
- [ ] Agree on API's  
- [ ] Add unit tests

# Motivation
In one of my projects I use System.Reactive to drive parts of the state machine. I find InternalTransitions useful for a bunch of discrete steps you'd like fine-grained control on, but that do not represent a super state. I noticed in the current implementation these transitions are not exposed to the OnTransitioned handler, which I find reasonable as they do not represent a transition. 

However, it would be useful to expose them in a way so that you could use RX to drive the state machine using internal transitions as well as normal transitions. 

# Design Choices
- Instead of reusing the current `OnTransitioned` method, I think it would be appropriate in this case to add a new api, `OnTransitionedInternal` which is seperate. The reasoning is this sort of change would change the behavior, and break downstream dependencies, which warrants a different API/Event handler all together. 

Alternatively, we could add a new constructor parameter, and check a flag to include internal transitions in the original event. However, I feel the current implementation of the constructor is simple and I am hesitant to add more bloat to the constructor. And as for the original intent, RX.Net can easily merge such streams if someone for example needed all events in a single stream.
