### PR TITLE
Dev

### DIFF
--- a/src/Stateless/StateConfiguration.cs
+++ b/src/Stateless/StateConfiguration.cs
@@ -1345,6 +1345,20 @@ namespace Stateless
             /// </summary>
             /// <param name="trigger">The accepted trigger.</param>
             /// <param name="destinationStateSelector">Function to calculate the state
+            /// that the trigger will cause a transition to.</param>            
+            /// <returns>The reciever.</returns>
+            /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
+            public StateConfiguration PermitDynamicIf<TArg0>(TriggerWithParameters<TArg0> trigger, Func<TArg0, TState> destinationStateSelector)
+            {
+                return PermitDynamicIf<TArg0>(trigger, destinationStateSelector, null, new Tuple<Func<bool>, string>[0]);
+            }
+
+            /// <summary>
+            /// Accept the specified trigger and transition to the destination state, calculated
+            /// dynamically by the supplied function.
+            /// </summary>
+            /// <param name="trigger">The accepted trigger.</param>
+            /// <param name="destinationStateSelector">Function to calculate the state
             /// that the trigger will cause a transition to.</param>
             /// <param name="possibleDestinationStates">Optional list of possible target states.</param>
             /// <param name="guards">Functions and their descriptions that must return true in order for the

--- a/test/Stateless.Tests/TriggerWithParametersFixture.cs
+++ b/test/Stateless.Tests/TriggerWithParametersFixture.cs
@@ -46,5 +46,18 @@ namespace Stateless.Tests
             var twp = new StateMachine<State, Trigger>.TriggerWithParameters<string, string>(Trigger.X);
             Assert.Throws<ArgumentException>(() => twp.ValidateParameters(new[] { "a", "b", "c" }));
         }
+
+        /// <summary>
+        /// issue #380 - default params on PermitIfDynamic lead to ambiguity at compile time... explicits work properly.
+        /// </summary>
+        [Fact]
+        public void StateParameterIsNotAmbiguous()
+        {
+            var fsm = new StateMachine<State, Trigger>(State.A);
+            StateMachine<State, Trigger>.TriggerWithParameters<State> pressTrigger = fsm.SetTriggerParameters<State>(Trigger.X);
+
+            fsm.Configure(State.A)
+                .PermitDynamicIf(pressTrigger, state => state);
+        }
     }
 }


### PR DESCRIPTION
issue #380 resolution:
 - add Method signature with no optional parameters
 - new method calls into specified overload in issue comments using explicit types builds empty Tuple<Func<bool>, string>[] to satisfy params Tuple<Func<bool>, string>[] defaults