### PR TITLE
Add OnTransitionCompleted event which fires after OnTransitioned

### DIFF
--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -197,6 +197,8 @@ namespace Stateless
                 await _onTransitionedEvent.InvokeAsync(new Transition(source, handler.Destination, trigger, args));
 
                 await newRepresentation.EnterAsync(transition, args);
+
+                await _onTransitionCompletedEvent.InvokeAsync(new Transition(source, handler.Destination, trigger, args));
             }
             // Check if it is an internal transition, or a transition from one state to another.
             else if (result.Handler.ResultsInTransitionFrom(source, args, out var destination))
@@ -231,6 +233,8 @@ namespace Stateless
                         State = newRepresentation.UnderlyingState;
                     }
                 }
+
+                await _onTransitionCompletedEvent.InvokeAsync(transition);
             }
             else
             {
@@ -272,6 +276,19 @@ namespace Stateless
         {
             if (onTransitionAction == null) throw new ArgumentNullException(nameof(onTransitionAction));
             _onTransitionedEvent.Register(onTransitionAction);
+        }
+
+        /// <summary>
+        /// Registers a callback that will be invoked every time the statemachine
+        /// transitions from one state into another and all the OnEntryFrom etc methods
+        /// have been invoked
+        /// </summary>
+        /// <param name="onTransitionAction">The asynchronous action to execute, accepting the details
+        /// of the transition.</param>
+        public void OnTransitionCompletedAsync(Func<Transition, Task> onTransitionAction)
+        {
+            if (onTransitionAction == null) throw new ArgumentNullException(nameof(onTransitionAction));
+            _onTransitionCompletedEvent.Register(onTransitionAction);
         }
     }
 }

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -439,7 +439,6 @@ namespace Stateless
                 State = representation.UnderlyingState;
             }
 
-
             _onTransitionCompletedEvent.Invoke(transition);
         }
 

--- a/test/Stateless.Tests/ActiveStatesFixture.cs
+++ b/test/Stateless.Tests/ActiveStatesFixture.cs
@@ -23,6 +23,7 @@ namespace Stateless.Tests
 
             // should not be called for activation
             sm.OnTransitioned(t => actualOrdering.Add("OnTransitioned"));
+            sm.OnTransitionCompleted(t => actualOrdering.Add("OnTransitionCompleted"));
 
             sm.Activate();
 
@@ -67,6 +68,7 @@ namespace Stateless.Tests
 
             // should not be called for activation
             sm.OnTransitioned(t => actualOrdering.Add("OnTransitioned"));
+            sm.OnTransitionCompleted(t => actualOrdering.Add("OnTransitionCompleted"));
 
             sm.Activate();
             sm.Deactivate();
@@ -110,10 +112,12 @@ namespace Stateless.Tests
                 "ExitedA",
                 "OnTransitioned",
                 "EnteredB",
+                "OnTransitionCompleted",
 
                 "ExitedB",
                 "OnTransitioned",
                 "EnteredA",
+                "OnTransitionCompleted",
 
             };
 
@@ -134,6 +138,7 @@ namespace Stateless.Tests
               .Permit(Trigger.Y, State.A);
 
             sm.OnTransitioned(t => actualOrdering.Add("OnTransitioned"));
+            sm.OnTransitionCompleted(t => actualOrdering.Add("OnTransitionCompleted"));
 
             sm.Activate();
             sm.Fire(Trigger.X);

--- a/test/Stateless.Tests/InitialTransitionFixture.cs
+++ b/test/Stateless.Tests/InitialTransitionFixture.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Stateless.Tests
@@ -265,6 +267,73 @@ namespace Stateless.Tests
             sm.Fire(Trigger.X);
 
             Assert.Equal("BCD", onEntryCount);
+        }
+
+        [Fact]
+        public void TransitionEvents_OrderingWithInitialTransition()
+        {
+            var expectedOrdering = new List<string> { "OnExitA", "OnTransitioned", "OnEntryB", "OnEntryC", "OnTransitionCompleted" };
+            var actualOrdering = new List<string>();
+
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+                .Permit(Trigger.X, State.B)
+                .OnExit(() => actualOrdering.Add("OnExitA"));
+
+            sm.Configure(State.B)
+                .InitialTransition(State.C)
+                .OnEntry(() => actualOrdering.Add("OnEntryB"));
+
+            sm.Configure(State.C)
+                .SubstateOf(State.B)
+                .OnEntry(() => actualOrdering.Add("OnEntryC"));
+
+            sm.OnTransitioned(t => actualOrdering.Add("OnTransitioned"));
+            sm.OnTransitionCompleted(t => actualOrdering.Add("OnTransitionCompleted"));
+
+            sm.Fire(Trigger.X);
+            Assert.Equal(State.C, sm.State);
+
+            Assert.Equal(expectedOrdering.Count, actualOrdering.Count);
+            for (int i = 0; i < expectedOrdering.Count; i++)
+            {
+                Assert.Equal(expectedOrdering[i], actualOrdering[i]);
+            }
+        }
+
+        [Fact]
+        public async void AsyncTransitionEvents_OrderingWithInitialTransition()
+        {
+            var expectedOrdering = new List<string> { "OnExitA", "OnTransitioned", "OnEntryB", "OnEntryC", "OnTransitionCompleted" };
+            var actualOrdering = new List<string>();
+
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+                .Permit(Trigger.X, State.B)
+                .OnExit(() => actualOrdering.Add("OnExitA"));
+
+            sm.Configure(State.B)
+                .InitialTransition(State.C)
+                .OnEntry(() => actualOrdering.Add("OnEntryB"));
+
+            sm.Configure(State.C)
+                .SubstateOf(State.B)
+                .OnEntry(() => actualOrdering.Add("OnEntryC"));
+
+            sm.OnTransitionedAsync(t => Task.Run(() => actualOrdering.Add("OnTransitioned")));
+            sm.OnTransitionCompletedAsync(t => Task.Run(() => actualOrdering.Add("OnTransitionCompleted")));
+
+            // await so that the async call completes before asserting anything
+            await sm.FireAsync(Trigger.X);
+            Assert.Equal(State.C, sm.State);
+
+            Assert.Equal(expectedOrdering.Count, actualOrdering.Count);
+            for (int i = 0; i < expectedOrdering.Count; i++)
+            {
+                Assert.Equal(expectedOrdering[i], actualOrdering[i]);
+            }
         }
     }
 }

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -377,10 +377,10 @@ namespace Stateless.Tests
         /// The expected ordering is OnExit, OnTransitioned, OnEntry, OnTransitionCompleted
         /// </summary>
         [Fact]
-        public void TheOnTransitionedEventFiresBeforeTheOnEntryEventAndOnTransitionedCompletedFiresAfterwards()
+        public void TheOnTransitionedEventFiresBeforeTheOnEntryEventAndOnTransitionCompletedFiresAfterwards()
         {
             var sm = new StateMachine<State, Trigger>(State.B);
-            var expectedOrdering = new List<string> { "OnExit", "OnTransitioned", "OnEntry", "OnTransitionedCompleted" };
+            var expectedOrdering = new List<string> { "OnExit", "OnTransitioned", "OnEntry", "OnTransitionCompleted" };
             var actualOrdering = new List<string>();
 
             sm.Configure(State.B)
@@ -391,7 +391,7 @@ namespace Stateless.Tests
                 .OnEntry(() => actualOrdering.Add("OnEntry"));
 
             sm.OnTransitioned(t => actualOrdering.Add("OnTransitioned"));
-            sm.OnTransitionCompleted(t => actualOrdering.Add("OnTransitionedCompleted"));
+            sm.OnTransitionCompleted(t => actualOrdering.Add("OnTransitionCompleted"));
 
             sm.Fire(Trigger.X);
 

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -357,7 +357,7 @@ namespace Stateless.Tests
         public void TheOnTransitionEventFiresBeforeTheOnEntryEvent()
         {
             var sm = new StateMachine<State, Trigger>(State.B);
-            var expectedOrdering = new List<string> { "OnExit", "OnTransitioned", "OnEntry" };
+            var expectedOrdering = new List<string> { "OnExit", "OnTransitioned", "OnEntry", "OnTransitionedCompleted" };
             var actualOrdering = new List<string>();
 
             sm.Configure(State.B)
@@ -368,6 +368,7 @@ namespace Stateless.Tests
                 .OnEntry(() => actualOrdering.Add("OnEntry"));
 
             sm.OnTransitioned(t => actualOrdering.Add("OnTransitioned"));
+            sm.OnTransitionCompleted(t => actualOrdering.Add("OnTransitionedCompleted"));
 
             sm.Fire(Trigger.X);
 

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -485,7 +485,7 @@ namespace Stateless.Tests
                 .Permit(Trigger.X, State.A);
 
             StateMachine<State, Trigger>.Transition transition = null;
-            sm.OnTransitioned(t => transition = t);
+            sm.OnTransitionCompleted(t => transition = t);
 
             string firstParameter = "the parameter";
             int secondParameter = 99;

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -334,7 +334,7 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        public void WhenATransitionOccurs_TheOnTransitionEventFires()
+        public void WhenATransitionOccurs_TheOnTransitionedEventFires()
         {
             var sm = new StateMachine<State, Trigger>(State.B);
 
@@ -354,7 +354,30 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        public void TheOnTransitionEventFiresBeforeTheOnEntryEvent()
+        public void WhenATransitionOccurs_TheOnTransitionCompletedEventFires()
+        {
+            var sm = new StateMachine<State, Trigger>(State.B);
+
+            sm.Configure(State.B)
+                .Permit(Trigger.X, State.A);
+
+            StateMachine<State, Trigger>.Transition transition = null;
+            sm.OnTransitionCompleted(t => transition = t);
+
+            sm.Fire(Trigger.X);
+
+            Assert.NotNull(transition);
+            Assert.Equal(Trigger.X, transition.Trigger);
+            Assert.Equal(State.B, transition.Source);
+            Assert.Equal(State.A, transition.Destination);
+            Assert.Equal(new object[0], transition.Parameters);
+        }
+
+        /// <summary>
+        /// The expected ordering is OnExit, OnTransitioned, OnEntry, OnTransitionCompleted
+        /// </summary>
+        [Fact]
+        public void TheOnTransitionedEventFiresBeforeTheOnEntryEventAndOnTransitionedCompletedFiresAfterwards()
         {
             var sm = new StateMachine<State, Trigger>(State.B);
             var expectedOrdering = new List<string> { "OnExit", "OnTransitioned", "OnEntry", "OnTransitionedCompleted" };
@@ -380,7 +403,7 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        public void WhenATransitionOccurs_WithAParameterizedTrigger_TheOnTransitionEventFires()
+        public void WhenATransitionOccurs_WithAParameterizedTrigger_TheOnTransitionedEventFires()
         {
             var sm = new StateMachine<State, Trigger>(State.B);
             var triggerX = sm.SetTriggerParameters<string>(Trigger.X);
@@ -403,7 +426,57 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        public void WhenATransitionOccurs_WithAParameterizedTrigger_WithMultipleParameters_TheOnTransitionEventFires()
+        public void WhenATransitionOccurs_WithAParameterizedTrigger_TheOnTransitionCompletedEventFires()
+        {
+            var sm = new StateMachine<State, Trigger>(State.B);
+            var triggerX = sm.SetTriggerParameters<string>(Trigger.X);
+
+            sm.Configure(State.B)
+                .Permit(Trigger.X, State.A);
+
+            StateMachine<State, Trigger>.Transition transition = null;
+            sm.OnTransitionCompleted(t => transition = t);
+
+            string parameter = "the parameter";
+            sm.Fire(triggerX, parameter);
+
+            Assert.NotNull(transition);
+            Assert.Equal(Trigger.X, transition.Trigger);
+            Assert.Equal(State.B, transition.Source);
+            Assert.Equal(State.A, transition.Destination);
+            Assert.Equal(1, transition.Parameters.Count());
+            Assert.Equal(parameter, transition.Parameters[0]);
+        }
+
+        [Fact]
+        public void WhenATransitionOccurs_WithAParameterizedTrigger_WithMultipleParameters_TheOnTransitionedEventFires()
+        {
+            var sm = new StateMachine<State, Trigger>(State.B);
+            var triggerX = sm.SetTriggerParameters<string, int, bool>(Trigger.X);
+
+            sm.Configure(State.B)
+                .Permit(Trigger.X, State.A);
+
+            StateMachine<State, Trigger>.Transition transition = null;
+            sm.OnTransitioned(t => transition = t);
+
+            string firstParameter = "the parameter";
+            int secondParameter = 99;
+            bool thirdParameter = true;
+            sm.Fire(triggerX, firstParameter, secondParameter, thirdParameter);
+
+            Assert.NotNull(transition);
+            Assert.Equal(Trigger.X, transition.Trigger);
+            Assert.Equal(State.B, transition.Source);
+            Assert.Equal(State.A, transition.Destination);
+            Assert.Equal(3, transition.Parameters.Count());
+            Assert.Equal(firstParameter, transition.Parameters[0]);
+            Assert.Equal(secondParameter, transition.Parameters[1]);
+            Assert.Equal(thirdParameter, transition.Parameters[2]);
+        }
+
+        [Fact]
+        public void WhenATransitionOccurs_WithAParameterizedTrigger_WithMultipleParameters_TheOnTransitionCompletedEventFires()
         {
             var sm = new StateMachine<State, Trigger>(State.B);
             var triggerX = sm.SetTriggerParameters<string, int, bool>(Trigger.X);


### PR DESCRIPTION
This is a quick proof of concept for implementing a OnTransitioned event
which is fired after the OnEntryFrom actions have been invoked.

Tests + Async path still todo - I want to check that the maintainer thinks this is worthwhile first
I have described my reasoning for this PR in #394 