### PR TITLE
Fix for unmet guard collection not being set by OnUnhandledTrigger 

### DIFF
--- a/src/Stateless/StateRepresentation.cs
+++ b/src/Stateless/StateRepresentation.cs
@@ -38,8 +38,16 @@ namespace Stateless
 
             public bool TryFindHandler(TTrigger trigger, object[] args, out TriggerBehaviourResult handler)
             {
-                return (TryFindLocalHandler(trigger, args, out handler) ||
-                    (Superstate != null && Superstate.TryFindHandler(trigger, args, out handler)));
+                TriggerBehaviourResult localHandler = null;
+                TriggerBehaviourResult superStateHandler = null;
+
+                bool handlerFound = (TryFindLocalHandler(trigger, args, out localHandler) ||
+                                    (Superstate != null && Superstate.TryFindHandler(trigger, args, out superStateHandler)));
+
+                // If no handler for super state, replace by local handler (see issue #398)
+                handler = superStateHandler ?? localHandler;
+
+                return handlerFound;
             }
 
             private bool TryFindLocalHandler(TTrigger trigger, object[] args, out TriggerBehaviourResult handlerResult)

--- a/test/Stateless.Tests/StateRepresentationFixture.cs
+++ b/test/Stateless.Tests/StateRepresentationFixture.cs
@@ -361,5 +361,25 @@ namespace Stateless.Tests
         {
             return new StateMachine<State, Trigger>.StateRepresentation(state);
         }
+
+        // Issue #398 - Set guard description if substate transition fails
+        [Fact]
+        public void SetGuardDescriptionWhenSubstateGuardFails()
+        {
+            const string expectedGuardDescription = "Guard failed";
+            ICollection<string> guardDescriptions = null;
+
+            var fsm = new StateMachine<State, Trigger>(State.B);
+            fsm.OnUnhandledTrigger((state, trigger, descriptions) => guardDescriptions = descriptions);
+
+            fsm.Configure(State.B).SubstateOf(State.A).PermitIf(Trigger.X, State.C, () => false, expectedGuardDescription);
+
+            fsm.Fire(Trigger.X);
+
+            Assert.Equal(fsm.State, State.B);
+            Assert.True(guardDescriptions != null);
+            Assert.Equal(guardDescriptions.Count, 1);
+            Assert.Equal(guardDescriptions.First(), expectedGuardDescription);
+        }
     }
 }


### PR DESCRIPTION
As described in #398, unmet guard description collection is not set by OnUnhandledTrigger if substate transition guard fails.  

This happens because _handler_ parameter in _TryFindHandler_ method is always set to super state handler.  