### PR TITLE
Added OnTransitioned event for initial transition

### DIFF
--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -229,6 +229,10 @@ namespace Stateless
                     {
                         var initialTransition = new InitialTransition(source, newRepresentation.InitialTransitionTarget, trigger, args);
                         newRepresentation = GetRepresentation(newRepresentation.InitialTransitionTarget);
+
+                        // Alert all listeners of initial state transition
+                        await _onTransitionedEvent.InvokeAsync(transition);
+
                         await newRepresentation.EnterAsync(initialTransition, args);
                         State = newRepresentation.UnderlyingState;
                     }

--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -238,7 +238,7 @@ namespace Stateless
                     }
                 }
 
-                await _onTransitionCompletedEvent.InvokeAsync(transition);
+                await _onTransitionCompletedEvent.InvokeAsync(new Transition(transition.Source, State, transition.Trigger, transition.Parameters));
             }
             else
             {

--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -231,7 +231,7 @@ namespace Stateless
                         newRepresentation = GetRepresentation(newRepresentation.InitialTransitionTarget);
 
                         // Alert all listeners of initial state transition
-                        await _onTransitionedEvent.InvokeAsync(transition);
+                        await _onTransitionedEvent.InvokeAsync(new Transition(transition.Destination, initialTransition.Destination, transition.Trigger, transition.Parameters));
 
                         await newRepresentation.EnterAsync(initialTransition, args);
                         State = newRepresentation.UnderlyingState;

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -499,7 +499,7 @@ namespace Stateless
                 representation = GetRepresentation(representation.InitialTransitionTarget);
 
                 // Alert all listeners of initial state transition
-                _onTransitionedEvent.Invoke(initialTransition);
+                _onTransitionedEvent.Invoke(new Transition(transition.Destination, initialTransition.Destination, transition.Trigger, transition.Parameters));
                 representation = EnterState(representation, initialTransition, args);
             }
 

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -497,6 +497,9 @@ namespace Stateless
 
                 var initialTransition = new InitialTransition(transition.Source, representation.InitialTransitionTarget, transition.Trigger, args);
                 representation = GetRepresentation(representation.InitialTransitionTarget);
+
+                // Alert all listeners of initial state transition
+                _onTransitionedEvent.Invoke(initialTransition);
                 representation = EnterState(representation, initialTransition, args);
             }
 

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -469,7 +469,7 @@ namespace Stateless
                 State = representation.UnderlyingState;
             }
 
-            _onTransitionCompletedEvent.Invoke(transition);
+            _onTransitionCompletedEvent.Invoke(new Transition(transition.Source, State, transition.Trigger, transition.Parameters));
         }
 
         private StateRepresentation EnterState(StateRepresentation representation, Transition transition, object [] args)

--- a/test/Stateless.Tests/InitialTransitionFixture.cs
+++ b/test/Stateless.Tests/InitialTransitionFixture.cs
@@ -272,7 +272,7 @@ namespace Stateless.Tests
         [Fact]
         public void TransitionEvents_OrderingWithInitialTransition()
         {
-            var expectedOrdering = new List<string> { "OnExitA", "OnTransitioned", "OnEntryB", "OnEntryC", "OnTransitionCompleted" };
+            var expectedOrdering = new List<string> { "OnExitA", "OnTransitioned", "OnEntryB", "OnTransitioned", "OnEntryC", "OnTransitionCompleted" };
             var actualOrdering = new List<string>();
 
             var sm = new StateMachine<State, Trigger>(State.A);
@@ -305,7 +305,7 @@ namespace Stateless.Tests
         [Fact]
         public async void AsyncTransitionEvents_OrderingWithInitialTransition()
         {
-            var expectedOrdering = new List<string> { "OnExitA", "OnTransitioned", "OnEntryB", "OnEntryC", "OnTransitionCompleted" };
+            var expectedOrdering = new List<string> { "OnExitA", "OnTransitioned", "OnEntryB", "OnTransitioned", "OnEntryC", "OnTransitionCompleted" };
             var actualOrdering = new List<string>();
 
             var sm = new StateMachine<State, Trigger>(State.A);

--- a/test/Stateless.Tests/InitialTransitionFixture.cs
+++ b/test/Stateless.Tests/InitialTransitionFixture.cs
@@ -272,7 +272,7 @@ namespace Stateless.Tests
         [Fact]
         public void TransitionEvents_OrderingWithInitialTransition()
         {
-            var expectedOrdering = new List<string> { "OnExitA", "OnTransitioned", "OnEntryB", "OnTransitioned", "OnEntryC", "OnTransitionCompleted" };
+            var expectedOrdering = new List<string> { "OnExitA", "OnTransitionedAB", "OnEntryB", "OnTransitionedBC", "OnEntryC", "OnTransitionCompletedAC" };
             var actualOrdering = new List<string>();
 
             var sm = new StateMachine<State, Trigger>(State.A);
@@ -289,8 +289,8 @@ namespace Stateless.Tests
                 .SubstateOf(State.B)
                 .OnEntry(() => actualOrdering.Add("OnEntryC"));
 
-            sm.OnTransitioned(t => actualOrdering.Add("OnTransitioned"));
-            sm.OnTransitionCompleted(t => actualOrdering.Add("OnTransitionCompleted"));
+            sm.OnTransitioned(t => actualOrdering.Add($"OnTransitioned{t.Source}{t.Destination}"));
+            sm.OnTransitionCompleted(t => actualOrdering.Add($"OnTransitionCompleted{t.Source}{t.Destination}"));
 
             sm.Fire(Trigger.X);
             Assert.Equal(State.C, sm.State);
@@ -305,7 +305,7 @@ namespace Stateless.Tests
         [Fact]
         public async void AsyncTransitionEvents_OrderingWithInitialTransition()
         {
-            var expectedOrdering = new List<string> { "OnExitA", "OnTransitioned", "OnEntryB", "OnTransitioned", "OnEntryC", "OnTransitionCompleted" };
+            var expectedOrdering = new List<string> { "OnExitA", "OnTransitionedAB", "OnEntryB", "OnTransitionedBC", "OnEntryC", "OnTransitionCompletedAC" };
             var actualOrdering = new List<string>();
 
             var sm = new StateMachine<State, Trigger>(State.A);
@@ -322,8 +322,8 @@ namespace Stateless.Tests
                 .SubstateOf(State.B)
                 .OnEntry(() => actualOrdering.Add("OnEntryC"));
 
-            sm.OnTransitionedAsync(t => Task.Run(() => actualOrdering.Add("OnTransitioned")));
-            sm.OnTransitionCompletedAsync(t => Task.Run(() => actualOrdering.Add("OnTransitionCompleted")));
+            sm.OnTransitionedAsync(t => Task.Run(() => actualOrdering.Add($"OnTransitioned{t.Source}{t.Destination}")));
+            sm.OnTransitionCompletedAsync(t => Task.Run(() => actualOrdering.Add($"OnTransitionCompleted{t.Source}{t.Destination}")));
 
             // await so that the async call completes before asserting anything
             await sm.FireAsync(Trigger.X);


### PR DESCRIPTION
Initial fix for issue #413. Here I assumed that the correct output is:
```
OnTransitioned = A->B
OnTransitioned = B->C
Final state = C
```