### PR TITLE
Fix StateInfo.Transitions NullReferenceException for states without transitions

### DIFF
--- a/src/Stateless/Reflection/StateInfo.cs
+++ b/src/Stateless/Reflection/StateInfo.cs
@@ -143,7 +143,7 @@ namespace Stateless.Reflection
         /// <summary> 
         /// Transitions defined for this state.
         /// </summary>
-        public IEnumerable<TransitionInfo> Transitions { get { return FixedTransitions.Concat<TransitionInfo>(DynamicTransitions); } }
+        public IEnumerable<TransitionInfo> Transitions { get { return (FixedTransitions ?? Enumerable.Empty<FixedTransitionInfo>()).Concat<TransitionInfo>(DynamicTransitions ?? Enumerable.Empty<DynamicTransitionInfo>()); } }
 
         /// <summary>
         /// Transitions defined for this state.


### PR DESCRIPTION
This returns `Enumerable.Empty<TransitionInfo>()` if both are `null` and still works if either of the `IEnumerable`'s are `null`. When both are not `null` behaviour is unchanged.

Closes #440