### PR TITLE
Added CanFire overload to return unmet guard descriptions

### DIFF
--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -551,6 +551,18 @@ namespace Stateless
         }
 
         /// <summary>
+        /// Returns true if <paramref name="trigger"/> can be fired
+        /// in the current state.
+        /// </summary>
+        /// <param name="trigger">Trigger to test.</param>
+        /// <param name="unmetGuards">Guard descriptions of unmet guards. If given trigger is not configured for current state, this will be null.</param>
+        /// <returns>True if the trigger can be fired, false otherwise.</returns>
+        public bool CanFire(TTrigger trigger, out ICollection<string> unmetGuards)
+        {
+            return CurrentRepresentation.CanHandle(trigger, new object[] { }, out unmetGuards);
+        }
+
+        /// <summary>
         /// A human-readable representation of the state machine.
         /// </summary>
         /// <returns>A description of the current state and permitted triggers.</returns>

--- a/src/Stateless/StateRepresentation.cs
+++ b/src/Stateless/StateRepresentation.cs
@@ -36,6 +36,13 @@ namespace Stateless
                 return TryFindHandler(trigger, args, out TriggerBehaviourResult _);
             }
 
+            public bool CanHandle(TTrigger trigger, object[] args, out ICollection<string> unmetGuards)
+            {
+                bool handlerFound = TryFindHandler(trigger, args, out TriggerBehaviourResult result);
+                unmetGuards = result?.UnmetGuardConditions;
+                return handlerFound;
+            }
+
             public bool TryFindHandler(TTrigger trigger, object[] args, out TriggerBehaviourResult handler)
             {
                 TriggerBehaviourResult superStateHandler = null;

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -1019,5 +1019,52 @@ namespace Stateless.Tests
             Assert.DoesNotContain(subStateTrigger, hsmInSuperstate.PermittedTriggers);
         }
 
+        [Fact]
+        public void CanFire_GetUnmetGuardDescriptionsIfGuardFails()
+        {
+            const string guardDescription = "Guard failed";
+            var sm = new StateMachine<State, Trigger>(State.A);
+            sm.Configure(State.A)
+              .PermitIf(Trigger.X, State.B, ()=> false, guardDescription);
+
+            bool result = sm.CanFire(Trigger.X, out ICollection<string> unmetGuards);
+
+            Assert.False(result);
+            Assert.True(unmetGuards?.Count == 1);
+            Assert.Contains(guardDescription, unmetGuards);
+        }
+
+        [Fact]
+        public void CanFire_GetNullUnmetGuardDescriptionsIfInvalidTrigger()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            bool result = sm.CanFire(Trigger.X, out ICollection<string> unmetGuards);
+
+            Assert.False(result);
+            Assert.Null(unmetGuards);
+        }
+
+        [Fact]
+        public void CanFire_GetEmptyUnmetGuardDescriptionsIfValidTrigger()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            sm.Configure(State.A).Permit(Trigger.X, State.B);
+            bool result = sm.CanFire(Trigger.X, out ICollection<string> unmetGuards);
+
+            Assert.True(result);
+            Assert.True(unmetGuards?.Count == 0);
+        }
+
+        [Fact]
+        public void CanFire_GetEmptyUnmetGuardDescriptionsIfGuardPasses()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            sm.Configure(State.A).PermitIf(Trigger.X, State.B, () => true, "Guard passed");
+            bool result = sm.CanFire(Trigger.X, out ICollection<string> unmetGuards);
+
+            Assert.True(result);
+            Assert.True(unmetGuards?.Count == 0);
+        }
+
     }
 }


### PR DESCRIPTION
Currently, unmet guard descriptions are accessible only via `OnUnhandledTrigger` action override _after_ the trigger is fired. I've come across multiple cases where it would be useful to check if any guard is unmet _before_ firing the trigger.  I've added an overload to `CanFire` method to get the unmet descriptions in case a guard fails. 