### PR TITLE
add Try... pattern to ParameterConversion, modify Guard wrapping with…

### DIFF
--- a/src/Stateless/ParameterConversion.cs
+++ b/src/Stateless/ParameterConversion.cs
@@ -23,12 +23,63 @@ namespace Stateless
 
             return arg;
         }
+        
+        public static bool TryUnpack(object[] args, Type argType, int index, out object result)
+        {
+            if (args == null)
+            {
+                result = null;
+                return false;
+            }
+
+            if (args.Length == 0)
+            {
+                result = null;
+                return false;
+            }
+
+            if (args.Length <= index)
+            {
+                result = null;
+                return false;
+            }
+
+            var arg = args[index];
+
+            if (arg != null && !argType.IsAssignableFrom(arg.GetType()))
+            {
+                result = null;
+                return false;
+            }
+
+            result = arg;
+            return true;
+        }
 
         public static TArg Unpack<TArg>(object[] args, int index)
         {
             if (args.Length == 0) return default;
 
             return (TArg)Unpack(args, typeof(TArg), index);
+        }
+        
+        public static bool TryUnpack<TArg>(object[] args, int index, out TArg result)
+        {
+            if (args.Length == 0)
+            {
+                result = default;
+                return true;
+            }
+
+            object rawResult;
+            if (!TryUnpack(args, typeof(TArg), index, out rawResult))
+            {
+                result = default;
+                return false;
+            }
+
+            result = (TArg) rawResult;
+            return true;
         }
 
         public static void Validate(object[] args, Type[] expected)

--- a/src/Stateless/TransitionGuard.cs
+++ b/src/Stateless/TransitionGuard.cs
@@ -16,22 +16,24 @@ namespace Stateless
 
             public static Func<object[], bool> ToPackedGuard<TArg0>(Func<TArg0, bool> guard)
             {
-                return args => guard(ParameterConversion.Unpack<TArg0>(args, 0));
+                return args => ParameterConversion.TryUnpack<TArg0>(args, 0, out var arg) && guard(arg);
             }
 
             public static Func<object[], bool> ToPackedGuard<TArg0, TArg1>(Func<TArg0, TArg1, bool> guard)
             {
-                return args => guard(
-                    ParameterConversion.Unpack<TArg0>(args, 0), 
-                    ParameterConversion.Unpack<TArg1>(args, 1));
+                return args => 
+                    ParameterConversion.TryUnpack<TArg0>(args, 0, out var arg0)
+                    && ParameterConversion.TryUnpack<TArg1>(args, 1, out var arg1)
+                    && guard(arg0, arg1);
             }
 
             public static Func<object[], bool> ToPackedGuard<TArg0, TArg1, TArg2>(Func<TArg0, TArg1, TArg2, bool> guard)
             {
-                return args => guard(
-                    ParameterConversion.Unpack<TArg0>(args, 0),
-                    ParameterConversion.Unpack<TArg1>(args, 1),
-                    ParameterConversion.Unpack<TArg2>(args, 2));
+                return args =>
+                    ParameterConversion.TryUnpack<TArg0>(args, 0, out var arg0)
+                    && ParameterConversion.TryUnpack<TArg1>(args, 1, out var arg1)
+                    && ParameterConversion.TryUnpack<TArg2>(args, 2, out var arg2)
+                    && guard(arg0, arg1, arg2);
             }
 
             public static Tuple<Func<object[], bool>, string>[] ToPackedGuards<TArg0>(Tuple<Func<TArg0, bool>, string>[] guards)


### PR DESCRIPTION
in order to issue https://github.com/dotnet-state-machine/stateless/issues/450 i changed guard behavior:
now guard use safe Try pattern which return false if argument does not satisfy type requirements
