### PR TITLE
Make code async-first 

### DIFF
--- a/src/Stateless/ActivateActionBehaviour.cs
+++ b/src/Stateless/ActivateActionBehaviour.cs
@@ -24,7 +24,7 @@ namespace Stateless
 
             internal Reflection.InvocationInfo Description { get; }
 
-            public virtual Task Execute()
+            public virtual Task ExecuteAsync()
             {
                 return _callback.InvokeAsync();
             }

--- a/src/Stateless/ActivateActionBehaviour.cs
+++ b/src/Stateless/ActivateActionBehaviour.cs
@@ -5,9 +5,16 @@ namespace Stateless
 {
     public partial class StateMachine<TState, TTrigger>
     {
-        internal abstract class ActivateActionBehaviour
+        internal class ActivateActionBehaviour
         {
             readonly TState _state;
+            private readonly EventCallback _callback;
+
+            public ActivateActionBehaviour(TState state, EventCallback action, Reflection.InvocationInfo actionDescription)
+                : this(state, actionDescription)
+            {
+                _callback = action;
+            }
 
             protected ActivateActionBehaviour(TState state, Reflection.InvocationInfo actionDescription)
             {
@@ -17,52 +24,9 @@ namespace Stateless
 
             internal Reflection.InvocationInfo Description { get; }
 
-            public abstract void Execute();
-            public abstract Task ExecuteAsync();
-
-            public class Sync : ActivateActionBehaviour
+            public virtual Task Execute()
             {
-                readonly Action _action;
-
-                public Sync(TState state, Action action, Reflection.InvocationInfo actionDescription)
-                    : base(state, actionDescription)
-                {
-                    _action = action;
-                }
-
-                public override void Execute()
-                {
-                    _action();
-                }
-
-                public override Task ExecuteAsync()
-                {
-                    Execute();
-                    return TaskResult.Done;
-                }
-            }
-
-            public class Async : ActivateActionBehaviour
-            {
-                readonly Func<Task> _action;
-
-                public Async(TState state, Func<Task> action, Reflection.InvocationInfo actionDescription)
-                    : base(state, actionDescription)
-                {
-                    _action = action;
-                }
-
-                public override void Execute()
-                {
-                    throw new InvalidOperationException(
-                        $"Cannot execute asynchronous action specified in OnActivateAsync for '{_state}' state. " +
-                         "Use asynchronous version of Activate [ActivateAsync]");
-                }
-
-                public override Task ExecuteAsync()
-                {
-                    return _action();
-                }
+                return _callback.InvokeAsync();
             }
         }
     }

--- a/src/Stateless/DeactivateActionBehaviour.cs
+++ b/src/Stateless/DeactivateActionBehaviour.cs
@@ -24,7 +24,7 @@ namespace Stateless
 
             internal Reflection.InvocationInfo Description { get; }
 
-            public virtual Task Execute()
+            public virtual Task ExecuteAsync()
             {
                 return _callback.InvokeAsync();
             }

--- a/src/Stateless/EntryActionBehaviour.cs
+++ b/src/Stateless/EntryActionBehaviour.cs
@@ -42,7 +42,7 @@ namespace Stateless
                     if (transition.Trigger.Equals(Trigger))
                         return base.Execute(transition, args);
 
-                    return Task.CompletedTask;
+                    return TaskResult.Done;
                 }
             }
         }

--- a/src/Stateless/EntryActionBehaviour.cs
+++ b/src/Stateless/EntryActionBehaviour.cs
@@ -5,8 +5,16 @@ namespace Stateless
 {
     public partial class StateMachine<TState, TTrigger>
     {
-        internal abstract class EntryActionBehavior
+        internal class EntryActionBehavior
         {
+            private readonly EventCallback<Transition, object[]> _callback;
+
+            public EntryActionBehavior(EventCallback<Transition, object[]> action, Reflection.InvocationInfo description)
+                : this(description)
+            {
+                _callback = action;
+            }
+
             protected EntryActionBehavior(Reflection.InvocationInfo description)
             {
                 Description = description;
@@ -14,72 +22,27 @@ namespace Stateless
 
             public Reflection.InvocationInfo Description { get; }
 
-            public abstract void Execute(Transition transition, object[] args);
-            public abstract Task ExecuteAsync(Transition transition, object[] args);
-
-            public class Sync : EntryActionBehavior
+            public virtual Task Execute(Transition transition, object[] args)
             {
-                readonly Action<Transition, object[]> _action;
-
-                public Sync(Action<Transition, object[]> action, Reflection.InvocationInfo description) : base(description)
-                {
-                    _action = action;
-                }
-
-                public override void Execute(Transition transition, object[] args)
-                {
-                    _action(transition, args);
-                }
-
-                public override Task ExecuteAsync(Transition transition, object[] args)
-                {
-                    Execute(transition, args);
-                    return TaskResult.Done;
-                }
+                return _callback.InvokeAsync(transition, args);
             }
 
-            public class SyncFrom<TTriggerType> : Sync
+            public class From<TTriggerType> : EntryActionBehavior
             {
                 internal TTriggerType Trigger { get; private set; }
 
-                public SyncFrom(TTriggerType trigger, Action<Transition, object[]> action, Reflection.InvocationInfo description)
+                public From(TTriggerType trigger, EventCallback<Transition, object[]> action, Reflection.InvocationInfo description)
                     : base(action, description)
                 {
                     Trigger = trigger;
                 }
 
-                public override void Execute(Transition transition, object[] args)
+                public override Task Execute(Transition transition, object[] args)
                 {
                     if (transition.Trigger.Equals(Trigger))
-                        base.Execute(transition, args);
-                }
+                        return base.Execute(transition, args);
 
-                public override Task ExecuteAsync(Transition transition, object[] args)
-                {
-                    Execute(transition, args);
-                    return TaskResult.Done;
-                }
-            }
-
-            public class Async : EntryActionBehavior
-            {
-                readonly Func<Transition, object[], Task> _action;
-
-                public Async(Func<Transition, object[], Task> action, Reflection.InvocationInfo description) : base(description)
-                {
-                    _action = action;
-                }
-
-                public override void Execute(Transition transition, object[] args)
-                {
-                    throw new InvalidOperationException(
-                        $"Cannot execute asynchronous action specified in OnEntry event for '{transition.Destination}' state. " +
-                         "Use asynchronous version of Fire [FireAsync]");
-                }
-
-                public override Task ExecuteAsync(Transition transition, object[] args)
-                {
-                    return _action(transition, args);
+                    return Task.CompletedTask;
                 }
             }
         }

--- a/src/Stateless/EntryActionBehaviour.cs
+++ b/src/Stateless/EntryActionBehaviour.cs
@@ -22,7 +22,7 @@ namespace Stateless
 
             public Reflection.InvocationInfo Description { get; }
 
-            public virtual Task Execute(Transition transition, object[] args)
+            public virtual Task ExecuteAsync(Transition transition, object[] args)
             {
                 return _callback.InvokeAsync(transition, args);
             }
@@ -37,10 +37,10 @@ namespace Stateless
                     Trigger = trigger;
                 }
 
-                public override Task Execute(Transition transition, object[] args)
+                public override Task ExecuteAsync(Transition transition, object[] args)
                 {
                     if (transition.Trigger.Equals(Trigger))
-                        return base.Execute(transition, args);
+                        return base.ExecuteAsync(transition, args);
 
                     return TaskResult.Done;
                 }

--- a/src/Stateless/EventCallback.cs
+++ b/src/Stateless/EventCallback.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace Stateless
+{
+    internal class EventCallback
+    {
+        protected readonly MulticastDelegate Delegate;
+
+        public EventCallback(MulticastDelegate @delegate)
+        {
+            Delegate = @delegate;
+        }
+
+        public Task InvokeAsync()
+        {
+            switch (Delegate)
+            {
+                case Action action:
+                    action();
+                    return Task.CompletedTask;
+
+                case Func<Task> func:
+                    return func();
+
+                default:
+                    return DynamicInvokeAsync();
+            }
+        }
+
+        public Task InvokeAsync(params object[] args)
+        {
+            return DynamicInvokeAsync(args);
+        }
+
+        protected Task DynamicInvokeAsync(params object[] args)
+        {
+            switch (Delegate)
+            {
+                case null:
+                    return Task.CompletedTask;
+
+                default:
+                    try
+                    {
+                        return Delegate.DynamicInvoke(args) as Task ?? Task.CompletedTask;
+                    }
+                    catch (TargetInvocationException e)
+                    {
+                        // Since we fell into the DynamicInvoke case, any exception will be wrapped
+                        // in a TIE. We can expect this to be thrown synchronously, so it's low overhead
+                        // to unwrap it.
+                        return Task.FromException(e.InnerException);
+                    }
+            }
+        }
+    }
+
+    internal class EventCallback<T> : EventCallback
+    {
+        public EventCallback(MulticastDelegate @delegate) : base(@delegate)
+        {
+        }
+
+        public Task InvokeAsync(T arg)
+        {
+            switch (Delegate)
+            {
+                case Action<T> action:
+                    action(arg);
+                    return Task.CompletedTask;
+
+                case Func<T, Task> func:
+                    return func(arg);
+
+                default:
+                    return DynamicInvokeAsync(arg);
+            }
+        }
+    }
+
+    internal class EventCallback<T1, T2> : EventCallback
+    {
+        public EventCallback(MulticastDelegate @delegate) : base(@delegate)
+        {
+        }
+
+        public Task InvokeAsync(T1 arg1, T2 arg2)
+        {
+            switch (Delegate)
+            {
+                case Action<T1, T2> action:
+                    action(arg1, arg2);
+                    return Task.CompletedTask;
+
+                case Func<T1, T2, Task> func:
+                    return func(arg1, arg2);
+
+                default:
+                    return DynamicInvokeAsync(arg1, arg2);
+            }
+        }
+    }
+
+    internal class EventCallback<T1, T2, T3> : EventCallback
+    {
+        public EventCallback(MulticastDelegate @delegate) : base(@delegate)
+        {
+        }
+
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3)
+        {
+            switch (Delegate)
+            {
+                case Action<T1, T2, T3> action:
+                    action(arg1, arg2, arg3);
+                    return Task.CompletedTask;
+
+                case Func<T1, T2, T3, Task> func:
+                    return func(arg1, arg2, arg3);
+
+                default:
+                    return DynamicInvokeAsync(arg1, arg2, arg3);
+            }
+        }
+    }
+
+    internal class EventCallback<T1, T2, T3, T4> : EventCallback
+    {
+        public EventCallback(MulticastDelegate @delegate) : base(@delegate)
+        {
+        }
+
+        public Task InvokeAsync(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        {
+            switch (Delegate)
+            {
+                case Action<T1, T2, T3, T4> action:
+                    action(arg1, arg2, arg3, arg4);
+                    return Task.CompletedTask;
+
+                case Func<T1, T2, T3, T4, Task> func:
+                    return func(arg1, arg2, arg3, arg4);
+
+                default:
+                    return DynamicInvokeAsync(arg1, arg2, arg3, arg4);
+            }
+        }
+    }
+}

--- a/src/Stateless/EventCallback.cs
+++ b/src/Stateless/EventCallback.cs
@@ -19,7 +19,7 @@ namespace Stateless
             {
                 case Action action:
                     action();
-                    return Task.CompletedTask;
+                    return TaskResult.Done;
 
                 case Func<Task> func:
                     return func();
@@ -39,12 +39,12 @@ namespace Stateless
             switch (Delegate)
             {
                 case null:
-                    return Task.CompletedTask;
+                    return TaskResult.Done;
 
                 default:
                     try
                     {
-                        return Delegate.DynamicInvoke(args) as Task ?? Task.CompletedTask;
+                        return Delegate.DynamicInvoke(args) as Task ?? TaskResult.Done;
                     }
                     catch (TargetInvocationException e)
                     {
@@ -69,7 +69,7 @@ namespace Stateless
             {
                 case Action<T> action:
                     action(arg);
-                    return Task.CompletedTask;
+                    return TaskResult.Done;
 
                 case Func<T, Task> func:
                     return func(arg);
@@ -92,7 +92,7 @@ namespace Stateless
             {
                 case Action<T1, T2> action:
                     action(arg1, arg2);
-                    return Task.CompletedTask;
+                    return TaskResult.Done;
 
                 case Func<T1, T2, Task> func:
                     return func(arg1, arg2);
@@ -115,7 +115,7 @@ namespace Stateless
             {
                 case Action<T1, T2, T3> action:
                     action(arg1, arg2, arg3);
-                    return Task.CompletedTask;
+                    return TaskResult.Done;
 
                 case Func<T1, T2, T3, Task> func:
                     return func(arg1, arg2, arg3);
@@ -138,7 +138,7 @@ namespace Stateless
             {
                 case Action<T1, T2, T3, T4> action:
                     action(arg1, arg2, arg3, arg4);
-                    return Task.CompletedTask;
+                    return TaskResult.Done;
 
                 case Func<T1, T2, T3, T4, Task> func:
                     return func(arg1, arg2, arg3, arg4);

--- a/src/Stateless/EventCallback.cs
+++ b/src/Stateless/EventCallback.cs
@@ -51,7 +51,7 @@ namespace Stateless
                         // Since we fell into the DynamicInvoke case, any exception will be wrapped
                         // in a TIE. We can expect this to be thrown synchronously, so it's low overhead
                         // to unwrap it.
-                        return Task.FromException(e.InnerException);
+                        return TaskResult.FromException(e.InnerException);
                     }
             }
         }

--- a/src/Stateless/EventCallbackFactory.cs
+++ b/src/Stateless/EventCallbackFactory.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Stateless
+{
+    internal static class EventCallbackFactory
+    {
+        public static EventCallback Create(Action callback)
+        {
+            return new EventCallback(callback);
+        }
+
+        public static EventCallback Create(Func<Task> callback)
+        {
+            return new EventCallback(callback);
+        }
+
+        public static EventCallback<T> Create<T>(Action<T> callback)
+        {
+            return new EventCallback<T>(callback);
+        }
+
+        public static EventCallback<T> Create<T>(Func<T, Task> callback)
+        {
+            return new EventCallback<T>(callback);
+        }
+
+        public static EventCallback<T1, T2> Create<T1, T2>(Action<T1, T2> callback)
+        {
+            return new EventCallback<T1, T2>(callback);
+        }
+
+        public static EventCallback<T1, T2> Create<T1, T2>(Func<T1, T2, Task> callback)
+        {
+            return new EventCallback<T1, T2>(callback);
+        }
+
+        public static EventCallback<T1, T2, T3> Create<T1, T2, T3>(Action<T1, T2, T3> callback)
+        {
+            return new EventCallback<T1, T2, T3>(callback);
+        }
+
+        public static EventCallback<T1, T2, T3> Create<T1, T2, T3>(Func<T1, T2, T3, Task> callback)
+        {
+            return new EventCallback<T1, T2, T3>(callback);
+        }
+
+        public static EventCallback<T1, T2, T3, T4> Create<T1, T2, T3, T4>(Action<T1, T2, T3, T4> callback)
+        {
+            return new EventCallback<T1, T2, T3, T4>(callback);
+        }
+
+        public static EventCallback<T1, T2, T3, T4> Create<T1, T2, T3, T4>(Func<T1, T2, T3, T4, Task> callback)
+        {
+            return new EventCallback<T1, T2, T3, T4>(callback);
+        }
+    }
+}

--- a/src/Stateless/ExitActionBehaviour.cs
+++ b/src/Stateless/ExitActionBehaviour.cs
@@ -5,10 +5,15 @@ namespace Stateless
 {
     public partial class StateMachine<TState, TTrigger>
     {
-        internal abstract class ExitActionBehavior
+        internal class ExitActionBehavior
         {
-            public abstract void Execute(Transition transition);
-            public abstract Task ExecuteAsync(Transition transition);
+            private readonly EventCallback<Transition> _callback;
+
+            public ExitActionBehavior(EventCallback<Transition> action, Reflection.InvocationInfo actionDescription)
+                : this(actionDescription)
+            {
+                _callback = action;
+            }
 
             protected ExitActionBehavior(Reflection.InvocationInfo actionDescription)
             {
@@ -17,47 +22,9 @@ namespace Stateless
 
             internal Reflection.InvocationInfo Description { get; }
 
-            public class Sync : ExitActionBehavior
+            public virtual Task Execute(Transition transition)
             {
-                readonly Action<Transition> _action;
-
-                public Sync(Action<Transition> action, Reflection.InvocationInfo actionDescription) : base(actionDescription)
-                {
-                    _action = action;
-                }
-
-                public override void Execute(Transition transition)
-                {
-                    _action(transition);
-                }
-
-                public override Task ExecuteAsync(Transition transition)
-                {
-                    Execute(transition);
-                    return TaskResult.Done;
-                }
-            }
-
-            public class Async : ExitActionBehavior
-            {
-                readonly Func<Transition, Task> _action;
-
-                public Async(Func<Transition, Task> action, Reflection.InvocationInfo actionDescription) : base(actionDescription)
-                {
-                    _action = action;
-                }
-
-                public override void Execute(Transition transition)
-                {
-                    throw new InvalidOperationException(
-                        $"Cannot execute asynchronous action specified in OnExit event for '{transition.Source}' state. " +
-                         "Use asynchronous version of Fire [FireAsync]");
-                }
-
-                public override Task ExecuteAsync(Transition transition)
-                {
-                    return _action(transition);
-                }
+                return _callback.InvokeAsync(transition);
             }
         }
     }

--- a/src/Stateless/ExitActionBehaviour.cs
+++ b/src/Stateless/ExitActionBehaviour.cs
@@ -22,7 +22,7 @@ namespace Stateless
 
             internal Reflection.InvocationInfo Description { get; }
 
-            public virtual Task Execute(Transition transition)
+            public virtual Task ExecuteAsync(Transition transition)
             {
                 return _callback.InvokeAsync(transition);
             }

--- a/src/Stateless/InternalTriggerBehaviour.cs
+++ b/src/Stateless/InternalTriggerBehaviour.cs
@@ -5,14 +5,26 @@ namespace Stateless
 {
     public partial class StateMachine<TState, TTrigger>
     {
-        internal abstract class InternalTriggerBehaviour : TriggerBehaviour
+        internal class InternalTriggerBehaviour : TriggerBehaviour
         {
+            private readonly EventCallback<Transition, object[]> _callback;
+
+            public InternalTriggerBehaviour(TTrigger trigger, Func<object[], bool> guard, EventCallback<Transition, object[]> internalAction, string guardDescription = null)
+                : this(trigger, new TransitionGuard(guard, guardDescription))
+            {
+                _callback = internalAction;
+            }
+
+            // FIXME: inconsistent with synchronous version of StateConfiguration
+            public InternalTriggerBehaviour(TTrigger trigger, Func<bool> guard, EventCallback<Transition, object[]> internalAction, string guardDescription = null)
+                : this(trigger, new TransitionGuard(guard, guardDescription))
+            {
+                _callback = internalAction;
+            }
+
             protected InternalTriggerBehaviour(TTrigger trigger, TransitionGuard guard) : base(trigger, guard)
             {
             }
-
-            public abstract void Execute(Transition transition, object[] args);
-            public abstract Task ExecuteAsync(Transition transition, object[] args);
 
             public override bool ResultsInTransitionFrom(TState source, object[] args, out TState destination)
             {
@@ -20,51 +32,10 @@ namespace Stateless
                 return false;
             }
 
-
-            public class Sync: InternalTriggerBehaviour
+            public virtual Task Execute(Transition transition, object[] args)
             {
-                public Action<Transition, object[]> InternalAction { get; }
-
-                public Sync(TTrigger trigger, Func<object[], bool> guard, Action<Transition, object[]> internalAction, string guardDescription = null) : base(trigger, new TransitionGuard(guard, guardDescription))
-                {
-                    InternalAction = internalAction;
-                }
-                public override void Execute(Transition transition, object[] args)
-                {
-                    InternalAction(transition, args);
-                }
-
-                public override Task ExecuteAsync(Transition transition, object[] args)
-                {
-                    Execute(transition, args);
-                    return TaskResult.Done;
-                }
+                return _callback.InvokeAsync(transition, args);
             }
-
-            public class Async : InternalTriggerBehaviour
-            {
-                readonly Func<Transition, object[], Task> InternalAction;
-
-                public Async(TTrigger trigger, Func<bool> guard,Func<Transition, object[], Task> internalAction, string guardDescription = null) : base(trigger, new TransitionGuard(guard, guardDescription))
-                {
-                    InternalAction = internalAction;
-                }
-
-                public override void Execute(Transition transition, object[] args)
-                {
-                    throw new InvalidOperationException(
-                        $"Cannot execute asynchronous action specified in OnEntry event for '{transition.Destination}' state. " +
-                         "Use asynchronous version of Fire [FireAsync]");
-                }
-
-                public override Task ExecuteAsync(Transition transition, object[] args)
-                {
-                    return InternalAction(transition, args);
-                }
-
-            }
-
-
         }
     }
 }

--- a/src/Stateless/InternalTriggerBehaviour.cs
+++ b/src/Stateless/InternalTriggerBehaviour.cs
@@ -32,7 +32,7 @@ namespace Stateless
                 return false;
             }
 
-            public virtual Task Execute(Transition transition, object[] args)
+            public virtual Task ExecuteAsync(Transition transition, object[] args)
             {
                 return _callback.InvokeAsync(transition, args);
             }

--- a/src/Stateless/OnTransitionedEvent.cs
+++ b/src/Stateless/OnTransitionedEvent.cs
@@ -15,19 +15,11 @@ namespace Stateless
                 _callbacks = new List<EventCallback<Transition>>();
             }
 
-            public void Invoke(Transition transition)
-            {
-                foreach (var callback in _callbacks)
-                    callback.InvokeAsync(transition).GetAwaiter().GetResult();
-            }
-
-#if TASKS
             public async Task InvokeAsync(Transition transition)
             {
                 foreach (var callback in _callbacks)
                     await callback.InvokeAsync(transition).ConfigureAwait(false);
             }
-#endif
 
             public void Register(Action<Transition> action)
             {

--- a/src/Stateless/Reflection/ActionInfo.cs
+++ b/src/Stateless/Reflection/ActionInfo.cs
@@ -17,14 +17,14 @@
 
         internal static ActionInfo Create<TState, TTrigger>(StateMachine<TState, TTrigger>.EntryActionBehavior entryAction)
         {
-            StateMachine<TState, TTrigger>.EntryActionBehavior.SyncFrom<TTrigger> syncFrom = entryAction as StateMachine<TState, TTrigger>.EntryActionBehavior.SyncFrom<TTrigger>;
+            StateMachine<TState, TTrigger>.EntryActionBehavior.From<TTrigger> syncFrom = entryAction as StateMachine<TState, TTrigger>.EntryActionBehavior.From<TTrigger>;
 
             if (syncFrom != null)
                 return new ActionInfo(entryAction.Description, syncFrom.Trigger.ToString());
             else
                 return new ActionInfo(entryAction.Description, null);
         }
-        
+
         /// <summary>
         /// Constructor
         /// </summary>

--- a/src/Stateless/StateConfiguration.Async.cs
+++ b/src/Stateless/StateConfiguration.Async.cs
@@ -20,7 +20,7 @@ namespace Stateless
             {
                 if (entryAction == null) throw new ArgumentNullException(nameof(entryAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger, guard, (t, args) => entryAction(t)));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, guard, EventCallbackFactory.Create<Transition, object[]>((t, args) => entryAction(t))));
                 return this;
             }
 
@@ -35,7 +35,7 @@ namespace Stateless
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger, guard, (t, args) => internalAction()));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, guard, EventCallbackFactory.Create<Transition, object[]>((t, args) => internalAction())));
                 return this;
             }
 
@@ -51,7 +51,7 @@ namespace Stateless
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger, guard, (t, args) => internalAction(t)));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, guard, EventCallbackFactory.Create<Transition, object[]>((t, args) => internalAction(t))));
                 return this;
             }
 
@@ -68,7 +68,7 @@ namespace Stateless
                 if (trigger == null) throw new ArgumentNullException(nameof(trigger));
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger.Trigger, guard, (t, args) => internalAction(ParameterConversion.Unpack<TArg0>(args, 0), t)));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, guard, EventCallbackFactory.Create<Transition, object[]>((t, args) => internalAction(ParameterConversion.Unpack<TArg0>(args, 0), t))));
                 return this;
             }
 
@@ -86,9 +86,9 @@ namespace Stateless
                 if (trigger == null) throw new ArgumentNullException(nameof(trigger));
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger.Trigger, guard, (t, args) => internalAction(
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, guard, EventCallbackFactory.Create<Transition, object[]>((t, args) => internalAction(
                     ParameterConversion.Unpack<TArg0>(args, 0),
-                    ParameterConversion.Unpack<TArg1>(args, 1), t)));
+                    ParameterConversion.Unpack<TArg1>(args, 1), t))));
                 return this;
             }
 
@@ -107,10 +107,10 @@ namespace Stateless
                 if (trigger == null) throw new ArgumentNullException(nameof(trigger));
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger.Trigger, guard, (t, args) => internalAction(
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, guard, EventCallbackFactory.Create<Transition, object[]>((t, args) => internalAction(
                     ParameterConversion.Unpack<TArg0>(args, 0),
                     ParameterConversion.Unpack<TArg1>(args, 1),
-                    ParameterConversion.Unpack<TArg2>(args, 2), t)));
+                    ParameterConversion.Unpack<TArg2>(args, 2), t))));
                 return this;
             }
 

--- a/src/Stateless/StateConfiguration.Async.cs
+++ b/src/Stateless/StateConfiguration.Async.cs
@@ -1,6 +1,4 @@
-﻿#if TASKS
-
-using System;
+﻿using System;
 using System.Threading.Tasks;
 
 namespace Stateless
@@ -462,4 +460,3 @@ namespace Stateless
         }
     }
 }
-#endif

--- a/src/Stateless/StateConfiguration.cs
+++ b/src/Stateless/StateConfiguration.cs
@@ -68,7 +68,7 @@ namespace Stateless
             {
                 if (entryAction == null) throw new ArgumentNullException(nameof(entryAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Sync(trigger, guard, (t, args) => entryAction(t), guardDescription));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, guard, EventCallbackFactory.Create<Transition, object[]>((t, args) => entryAction(t)), guardDescription));
                 return this;
             }
 
@@ -95,7 +95,7 @@ namespace Stateless
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Sync(trigger, guard, (t, args) => internalAction(), guardDescription));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, guard, EventCallbackFactory.Create<Transition, object[]>((t, args) => internalAction()), guardDescription));
                 return this;
             }
 
@@ -112,7 +112,7 @@ namespace Stateless
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Sync(trigger, guard, (t, args) => internalAction(t), guardDescription));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger, guard, EventCallbackFactory.Create<Transition, object[]>((t, args) => internalAction(t)), guardDescription));
                 return this;
             }
 
@@ -154,7 +154,7 @@ namespace Stateless
                 if (trigger == null) throw new ArgumentNullException(nameof(trigger));
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Sync(trigger.Trigger, TransitionGuard.ToPackedGuard(guard), (t, args) => internalAction(ParameterConversion.Unpack<TArg0>(args, 0), t), guardDescription));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, TransitionGuard.ToPackedGuard(guard), EventCallbackFactory.Create<Transition, object[]>((t, args) => internalAction(ParameterConversion.Unpack<TArg0>(args, 0), t)), guardDescription));
                 return this;
             }
 
@@ -187,9 +187,9 @@ namespace Stateless
                 if (trigger == null) throw new ArgumentNullException(nameof(trigger));
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Sync(trigger.Trigger, guard, (t, args) => internalAction(
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, guard, EventCallbackFactory.Create<Transition, object[]>((t, args) => internalAction(
                      ParameterConversion.Unpack<TArg0>(args, 0),
-                     ParameterConversion.Unpack<TArg1>(args, 1), t),
+                     ParameterConversion.Unpack<TArg1>(args, 1), t)),
                      guardDescription));
                 return this;
             }
@@ -209,12 +209,12 @@ namespace Stateless
                 if (trigger == null) throw new ArgumentNullException(nameof(trigger));
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Sync(
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(
                     trigger.Trigger,
                     TransitionGuard.ToPackedGuard(guard),
-                    (t, args) => internalAction(
+                    EventCallbackFactory.Create<Transition, object[]>((t, args) => internalAction(
                     ParameterConversion.Unpack<TArg0>(args, 0),
-                    ParameterConversion.Unpack<TArg1>(args, 1), t),
+                    ParameterConversion.Unpack<TArg1>(args, 1), t)),
                     guardDescription
                     ));
                 return this;
@@ -236,10 +236,10 @@ namespace Stateless
                 if (trigger == null) throw new ArgumentNullException(nameof(trigger));
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Sync(trigger.Trigger, guard, (t, args) => internalAction(
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, guard, EventCallbackFactory.Create<Transition, object[]>((t, args) => internalAction(
                     ParameterConversion.Unpack<TArg0>(args, 0),
                     ParameterConversion.Unpack<TArg1>(args, 1),
-                    ParameterConversion.Unpack<TArg2>(args, 2), t),
+                    ParameterConversion.Unpack<TArg2>(args, 2), t)),
                     guardDescription));
                 return this;
             }
@@ -260,10 +260,10 @@ namespace Stateless
                 if (trigger == null) throw new ArgumentNullException(nameof(trigger));
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Sync(trigger.Trigger, TransitionGuard.ToPackedGuard(guard), (t, args) => internalAction(
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour(trigger.Trigger, TransitionGuard.ToPackedGuard(guard), EventCallbackFactory.Create<Transition, object[]>((t, args) => internalAction(
                     ParameterConversion.Unpack<TArg0>(args, 0),
                     ParameterConversion.Unpack<TArg1>(args, 1),
-                    ParameterConversion.Unpack<TArg2>(args, 2), t),
+                    ParameterConversion.Unpack<TArg2>(args, 2), t)),
                     guardDescription));
                 return this;
             }
@@ -321,7 +321,7 @@ namespace Stateless
             }
 
             /// <summary>
-            ///  Accept the specified trigger, transition to the destination state, and guard condition. 
+            ///  Accept the specified trigger, transition to the destination state, and guard condition.
             /// </summary>
             /// <typeparam name="TArg0"></typeparam>
             /// <param name="trigger">The accepted trigger.</param>
@@ -365,7 +365,7 @@ namespace Stateless
             }
 
             /// <summary>
-            ///  Accept the specified trigger, transition to the destination state, and guard condition. 
+            ///  Accept the specified trigger, transition to the destination state, and guard condition.
             /// </summary>
             /// <typeparam name="TArg0"></typeparam>
             /// <typeparam name="TArg1"></typeparam>
@@ -388,7 +388,7 @@ namespace Stateless
             }
 
             /// <summary>
-            ///  Accept the specified trigger, transition to the destination state, and guard condition. 
+            ///  Accept the specified trigger, transition to the destination state, and guard condition.
             /// </summary>
             /// <typeparam name="TArg0"></typeparam>
             /// <typeparam name="TArg1"></typeparam>
@@ -412,7 +412,7 @@ namespace Stateless
             }
 
             /// <summary>
-            ///  Accept the specified trigger, transition to the destination state, and guard condition. 
+            ///  Accept the specified trigger, transition to the destination state, and guard condition.
             /// </summary>
             /// <typeparam name="TArg0"></typeparam>
             /// <typeparam name="TArg1"></typeparam>
@@ -436,7 +436,7 @@ namespace Stateless
             }
 
             /// <summary>
-            ///  Accept the specified trigger, transition to the destination state, and guard condition. 
+            ///  Accept the specified trigger, transition to the destination state, and guard condition.
             /// </summary>
             /// <typeparam name="TArg0"></typeparam>
             /// <typeparam name="TArg1"></typeparam>
@@ -517,7 +517,7 @@ namespace Stateless
             }
 
             /// <summary>
-            ///  Accept the specified trigger, transition to the destination state, and guard condition. 
+            ///  Accept the specified trigger, transition to the destination state, and guard condition.
             /// </summary>
             /// <typeparam name="TArg0"></typeparam>
             /// <param name="trigger">The accepted trigger.</param>
@@ -557,7 +557,7 @@ namespace Stateless
             }
 
             /// <summary>
-            ///  Accept the specified trigger, transition to the destination state, and guard condition. 
+            ///  Accept the specified trigger, transition to the destination state, and guard condition.
             /// </summary>
             /// <typeparam name="TArg0"></typeparam>
             /// <typeparam name="TArg1"></typeparam>
@@ -578,7 +578,7 @@ namespace Stateless
             }
 
             /// <summary>
-            ///  Accept the specified trigger, transition to the destination state, and guard condition. 
+            ///  Accept the specified trigger, transition to the destination state, and guard condition.
             /// </summary>
             /// <typeparam name="TArg0"></typeparam>
             /// <typeparam name="TArg1"></typeparam>
@@ -600,7 +600,7 @@ namespace Stateless
             }
 
             /// <summary>
-            ///  Accept the specified trigger, transition to the destination state, and guard condition. 
+            ///  Accept the specified trigger, transition to the destination state, and guard condition.
             /// </summary>
             /// <typeparam name="TArg0"></typeparam>
             /// <typeparam name="TArg1"></typeparam>
@@ -622,7 +622,7 @@ namespace Stateless
             }
 
             /// <summary>
-            ///  Accept the specified trigger, transition to the destination state, and guard condition. 
+            ///  Accept the specified trigger, transition to the destination state, and guard condition.
             /// </summary>
             /// <typeparam name="TArg0"></typeparam>
             /// <typeparam name="TArg1"></typeparam>
@@ -1306,7 +1306,7 @@ namespace Stateless
             /// dynamically by the supplied function.
             /// </summary>
             /// <param name="trigger">The accepted trigger.</param>
-            /// <param name="destinationStateSelector">Function to calculate the state 
+            /// <param name="destinationStateSelector">Function to calculate the state
             /// that the trigger will cause a transition to.</param>
             /// <param name="destinationStateSelectorDescription">Description of the function to calculate the state </param>
             /// <param name="guard">Function that must return true in order for the
@@ -1348,7 +1348,7 @@ namespace Stateless
             /// dynamically by the supplied function.
             /// </summary>
             /// <param name="trigger">The accepted trigger.</param>
-            /// <param name="destinationStateSelector">Function to calculate the state 
+            /// <param name="destinationStateSelector">Function to calculate the state
             /// that the trigger will cause a transition to.</param>
             /// <param name="destinationStateSelectorDescription">Description of the function to calculate the state </param>
             /// <param name="guards">Functions and their descriptions that must return true in order for the
@@ -1401,7 +1401,7 @@ namespace Stateless
             /// </summary>
             /// <param name="trigger">The accepted trigger.</param>
             /// <param name="destinationStateSelector">Function to calculate the state
-            /// that the trigger will cause a transition to.</param>            
+            /// that the trigger will cause a transition to.</param>
             /// <returns>The receiver.</returns>
             /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
             public StateConfiguration PermitDynamicIf<TArg0>(TriggerWithParameters<TArg0> trigger, Func<TArg0, TState> destinationStateSelector)

--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -158,6 +158,12 @@ namespace Stateless
             }
         }
 
+        /// <summary>
+        /// This method handles the execution of a trigger handler. It finds a
+        /// handle, then updates the current state information.
+        /// </summary>
+        /// <param name="trigger"></param>
+        /// <param name="args"></param>
         async Task InternalFireOneAsync(TTrigger trigger, params object[] args)
         {
             // If this is a trigger with parameters, we must validate the parameter(s)

--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -11,7 +11,7 @@ namespace Stateless
     {
         /// <summary>
         /// Activates current state in asynchronous fashion. Actions associated with activating the currrent state
-        /// will be invoked. The activation is idempotent and subsequent activation of the same current state 
+        /// will be invoked. The activation is idempotent and subsequent activation of the same current state
         /// will not lead to re-execution of activation callbacks.
         /// </summary>
         public Task ActivateAsync()
@@ -22,7 +22,7 @@ namespace Stateless
 
         /// <summary>
         /// Deactivates current state in asynchronous fashion. Actions associated with deactivating the currrent state
-        /// will be invoked. The deactivation is idempotent and subsequent deactivation of the same current state 
+        /// will be invoked. The deactivation is idempotent and subsequent deactivation of the same current state
         /// will not lead to re-execution of deactivation callbacks.
         /// </summary>
         public Task DeactivateAsync()
@@ -201,11 +201,7 @@ namespace Stateless
                     {
                         // Internal transitions does not update the current state, but must execute the associated action.
                         var transition = new Transition(source, source, trigger, args);
-
-                        if (itb is InternalTriggerBehaviour.Async ita)
-                            await ita.ExecuteAsync(transition, args);
-                        else
-                            await Task.Run(() => itb.Execute(transition, args));
+                        await itb.Execute(transition, args).ConfigureAwait(false);
                         break;
                     }
                 default:
@@ -247,7 +243,7 @@ namespace Stateless
 
             //Alert all listeners of state transition
             await _onTransitionedEvent.InvokeAsync(transition);
-            var representation =await EnterStateAsync(newRepresentation, transition, args);
+            var representation = await EnterStateAsync(newRepresentation, transition, args);
 
             // Check if state has changed by entering new state (by fireing triggers in OnEntry or such)
             if (!representation.UnderlyingState.Equals(State))
@@ -256,7 +252,7 @@ namespace Stateless
                 State = representation.UnderlyingState;
             }
 
-           await _onTransitionCompletedEvent.InvokeAsync(new Transition(transition.Source, State, transition.Trigger, transition.Parameters));
+            await _onTransitionCompletedEvent.InvokeAsync(new Transition(transition.Source, State, transition.Trigger, transition.Parameters));
         }
 
 

--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -46,6 +46,23 @@ namespace Stateless
         }
 
         /// <summary>
+        /// Transition from the current state via the specified trigger.
+        /// The target state is determined by the configuration of the current state.
+        /// Actions associated with leaving the current state and entering the new one
+        /// will be invoked.
+        /// </summary>
+        /// <param name="trigger">The trigger to fire.</param>
+        /// <param name="args">A variable-length parameters list containing arguments. </param>
+        /// <exception cref="System.InvalidOperationException">The current state does
+        /// not allow the trigger to be fired.</exception>
+        public Task FireAsync(TriggerWithParameters trigger, params object[] args)
+        {
+            if (trigger == null) throw new ArgumentNullException(nameof(trigger));
+
+            return InternalFireAsync(trigger.Trigger, args);
+        }
+
+        /// <summary>
         /// Transition from the current state via the specified trigger in async fashion.
         /// The target state is determined by the configuration of the current state.
         /// Actions associated with leaving the current state and entering the new one

--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -170,7 +170,7 @@ namespace Stateless
             // Try to find a trigger handler, either in the current state or a super state.
             if (!representativeState.TryFindHandler(trigger, args, out TriggerBehaviourResult result))
             {
-                await _unhandledTriggerAction.ExecuteAsync(representativeState.UnderlyingState, trigger, result?.UnmetGuardConditions);
+                await _unhandledTriggerAction.Execute(representativeState.UnderlyingState, trigger, result?.UnmetGuardConditions).ConfigureAwait(false);
                 return;
             }
 
@@ -298,7 +298,7 @@ namespace Stateless
         public void OnUnhandledTriggerAsync(Func<TState, TTrigger, Task> unhandledTriggerAction)
         {
             if (unhandledTriggerAction == null) throw new ArgumentNullException(nameof(unhandledTriggerAction));
-            _unhandledTriggerAction = new UnhandledTriggerAction.Async((s, t, c) => unhandledTriggerAction(s, t));
+            _unhandledTriggerAction = new UnhandledTriggerAction(EventCallbackFactory.Create<TState, TTrigger, ICollection<string>>((s, t, c) => unhandledTriggerAction(s, t)));
         }
 
         /// <summary>
@@ -309,7 +309,7 @@ namespace Stateless
         public void OnUnhandledTriggerAsync(Func<TState, TTrigger, ICollection<string>, Task> unhandledTriggerAction)
         {
             if (unhandledTriggerAction == null) throw new ArgumentNullException(nameof(unhandledTriggerAction));
-            _unhandledTriggerAction = new UnhandledTriggerAction.Async(unhandledTriggerAction);
+            _unhandledTriggerAction = new UnhandledTriggerAction(EventCallbackFactory.Create(unhandledTriggerAction));
         }
 
         /// <summary>

--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -195,7 +195,7 @@ namespace Stateless
             // Try to find a trigger handler, either in the current state or a super state.
             if (!representativeState.TryFindHandler(trigger, args, out TriggerBehaviourResult result))
             {
-                await _unhandledTriggerAction.Execute(representativeState.UnderlyingState, trigger, result?.UnmetGuardConditions).ConfigureAwait(false);
+                await _unhandledTriggerAction.ExecuteAsync(representativeState.UnderlyingState, trigger, result?.UnmetGuardConditions).ConfigureAwait(false);
                 return;
             }
 
@@ -226,7 +226,7 @@ namespace Stateless
                     {
                         // Internal transitions does not update the current state, but must execute the associated action.
                         var transition = new Transition(source, source, trigger, args);
-                        await itb.Execute(transition, args).ConfigureAwait(false);
+                        await itb.ExecuteAsync(transition, args).ConfigureAwait(false);
                         break;
                     }
                 default:

--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -1,5 +1,3 @@
-#if TASKS
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -363,5 +361,3 @@ namespace Stateless
         }
     }
 }
-
-#endif

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -411,11 +411,11 @@ namespace Stateless
 
                         break;
                     }
-                case InternalTriggerBehaviour _:
+                case InternalTriggerBehaviour itb:
                     {
                         // Internal transitions does not update the current state, but must execute the associated action.
                         var transition = new Transition(source, source, trigger, args);
-                        CurrentRepresentation.InternalAction(transition, args);
+                        itb.Execute(transition, args).GetAwaiter().GetResult();
                         break;
                     }
                 default:

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -426,14 +426,14 @@ namespace Stateless
         private void HandleReentryTrigger(object[] args, StateRepresentation representativeState, Transition transition)
         {
             StateRepresentation representation;
-            transition = representativeState.Exit(transition);
+            transition = representativeState.ExitAsync(transition).GetAwaiter().GetResult();
             var newRepresentation = GetRepresentation(transition.Destination);
 
             if (!transition.Source.Equals(transition.Destination))
             {
                 // Then Exit the final superstate
                 transition = new Transition(transition.Destination, transition.Destination, transition.Trigger, args);
-                newRepresentation.Exit(transition);
+                newRepresentation.ExitAsync(transition).GetAwaiter().GetResult();
 
                 _onTransitionedEvent.Invoke(transition);
                 representation = EnterState(newRepresentation, transition, args);
@@ -451,7 +451,7 @@ namespace Stateless
 
         private void HandleTransitioningTrigger(object[] args, StateRepresentation representativeState, Transition transition)
         {
-            transition = representativeState.Exit(transition);
+            transition = representativeState.ExitAsync(transition).GetAwaiter().GetResult();
 
             State = transition.Destination;
             var newRepresentation = GetRepresentation(transition.Destination);
@@ -473,7 +473,7 @@ namespace Stateless
         private StateRepresentation EnterState(StateRepresentation representation, Transition transition, object[] args)
         {
             // Enter the new state
-            representation.Enter(transition, args);
+            representation.EnterAsync(transition, args).GetAwaiter().GetResult();
 
             if (FiringMode.Immediate.Equals(_firingMode) && !State.Equals(transition.Destination))
             {

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -324,45 +324,11 @@ namespace Stateless
                     InternalFireOneAsync(trigger, args).GetAwaiter().GetResult();
                     break;
                 case FiringMode.Queued:
-                    InternalFireQueued(trigger, args);
+                    InternalFireQueuedAsync(trigger, args).GetAwaiter().GetResult();
                     break;
                 default:
                     // If something is completely messed up we let the user know ;-)
                     throw new InvalidOperationException("The firing mode has not been configured!");
-            }
-        }
-
-        /// <summary>
-        /// Queue events and then fire in order.
-        /// If only one event is queued, this behaves identically to the non-queued version.
-        /// </summary>
-        /// <param name="trigger">  The trigger. </param>
-        /// <param name="args">     A variable-length parameters list containing arguments. </param>
-        private void InternalFireQueued(TTrigger trigger, params object[] args)
-        {
-            // Add trigger to queue
-            _eventQueue.Enqueue(new QueuedTrigger { Trigger = trigger, Args = args });
-
-            // If a trigger is already being handled then the trigger will be queued (FIFO) and processed later.
-            if (_firing)
-            {
-                return;
-            }
-
-            try
-            {
-                _firing = true;
-
-                // Empty queue for triggers
-                while (_eventQueue.Any())
-                {
-                    var queuedEvent = _eventQueue.Dequeue();
-                    InternalFireOneAsync(queuedEvent.Trigger, queuedEvent.Args).GetAwaiter().GetResult();
-                }
-            }
-            finally
-            {
-                _firing = false;
             }
         }
 

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -201,7 +201,7 @@ namespace Stateless
         /// not allow the trigger to be fired.</exception>
         public void Fire(TTrigger trigger)
         {
-            InternalFire(trigger, new object[0]);
+            InternalFireAsync(trigger, new object[0]).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -217,7 +217,7 @@ namespace Stateless
         public void Fire(TriggerWithParameters trigger, params object[] args)
         {
             if (trigger == null) throw new ArgumentNullException(nameof(trigger));
-            InternalFire(trigger.Trigger, args);
+            InternalFireAsync(trigger.Trigger, args).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -248,7 +248,7 @@ namespace Stateless
         public void Fire<TArg0>(TriggerWithParameters<TArg0> trigger, TArg0 arg0)
         {
             if (trigger == null) throw new ArgumentNullException(nameof(trigger));
-            InternalFire(trigger.Trigger, arg0);
+            InternalFireAsync(trigger.Trigger, arg0).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -267,7 +267,7 @@ namespace Stateless
         public void Fire<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, TArg0 arg0, TArg1 arg1)
         {
             if (trigger == null) throw new ArgumentNullException(nameof(trigger));
-            InternalFire(trigger.Trigger, arg0, arg1);
+            InternalFireAsync(trigger.Trigger, arg0, arg1).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -288,7 +288,7 @@ namespace Stateless
         public void Fire<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, TArg0 arg0, TArg1 arg1, TArg2 arg2)
         {
             if (trigger == null) throw new ArgumentNullException(nameof(trigger));
-            InternalFire(trigger.Trigger, arg0, arg1, arg2);
+            InternalFireAsync(trigger.Trigger, arg0, arg1, arg2).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -309,27 +309,6 @@ namespace Stateless
         public void Deactivate()
         {
             DeactivateAsync().GetAwaiter().GetResult();
-        }
-
-        /// <summary>
-        /// Determine how to Fire the trigger
-        /// </summary>
-        /// <param name="trigger">The trigger. </param>
-        /// <param name="args">A variable-length parameters list containing arguments. </param>
-        void InternalFire(TTrigger trigger, params object[] args)
-        {
-            switch (_firingMode)
-            {
-                case FiringMode.Immediate:
-                    InternalFireOneAsync(trigger, args).GetAwaiter().GetResult();
-                    break;
-                case FiringMode.Queued:
-                    InternalFireQueuedAsync(trigger, args).GetAwaiter().GetResult();
-                    break;
-                default:
-                    // If something is completely messed up we let the user know ;-)
-                    throw new InvalidOperationException("The firing mode has not been configured!");
-            }
         }
 
         /// <summary>

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -201,7 +201,7 @@ namespace Stateless
         /// not allow the trigger to be fired.</exception>
         public void Fire(TTrigger trigger)
         {
-            InternalFireAsync(trigger, new object[0]).GetAwaiter().GetResult();
+            FireAsync(trigger).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -216,8 +216,7 @@ namespace Stateless
         /// not allow the trigger to be fired.</exception>
         public void Fire(TriggerWithParameters trigger, params object[] args)
         {
-            if (trigger == null) throw new ArgumentNullException(nameof(trigger));
-            InternalFireAsync(trigger.Trigger, args).GetAwaiter().GetResult();
+            FireAsync(trigger, args).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -247,8 +246,7 @@ namespace Stateless
         /// not allow the trigger to be fired.</exception>
         public void Fire<TArg0>(TriggerWithParameters<TArg0> trigger, TArg0 arg0)
         {
-            if (trigger == null) throw new ArgumentNullException(nameof(trigger));
-            InternalFireAsync(trigger.Trigger, arg0).GetAwaiter().GetResult();
+            FireAsync(trigger, arg0).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -266,8 +264,7 @@ namespace Stateless
         /// not allow the trigger to be fired.</exception>
         public void Fire<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, TArg0 arg0, TArg1 arg1)
         {
-            if (trigger == null) throw new ArgumentNullException(nameof(trigger));
-            InternalFireAsync(trigger.Trigger, arg0, arg1).GetAwaiter().GetResult();
+            FireAsync(trigger, arg0, arg1).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -287,8 +284,7 @@ namespace Stateless
         /// not allow the trigger to be fired.</exception>
         public void Fire<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, TArg0 arg0, TArg1 arg1, TArg2 arg2)
         {
-            if (trigger == null) throw new ArgumentNullException(nameof(trigger));
-            InternalFireAsync(trigger.Trigger, arg0, arg1, arg2).GetAwaiter().GetResult();
+            FireAsync(trigger, arg0, arg1, arg2).GetAwaiter().GetResult();
         }
 
         /// <summary>

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -298,8 +298,7 @@ namespace Stateless
         /// </summary>
         public void Activate()
         {
-            var representativeState = GetRepresentation(State);
-            representativeState.Activate();
+            ActivateAsync().GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -309,8 +308,7 @@ namespace Stateless
         /// </summary>
         public void Deactivate()
         {
-            var representativeState = GetRepresentation(State);
-            representativeState.Deactivate();
+            DeactivateAsync().GetAwaiter().GetResult();
         }
 
         /// <summary>

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -407,7 +407,7 @@ namespace Stateless
                     {
                         // Handle transition, and set new state
                         var transition = new Transition(source, destination, trigger, args);
-                        HandleTransitioningTrigger(args, representativeState, transition);
+                        HandleTransitioningTriggerAsync(args, representativeState, transition).GetAwaiter().GetResult();
 
                         break;
                     }
@@ -421,27 +421,6 @@ namespace Stateless
                 default:
                     throw new InvalidOperationException("State machine configuration incorrect, no handler for trigger.");
             }
-        }
-
-        private void HandleTransitioningTrigger(object[] args, StateRepresentation representativeState, Transition transition)
-        {
-            transition = representativeState.ExitAsync(transition).GetAwaiter().GetResult();
-
-            State = transition.Destination;
-            var newRepresentation = GetRepresentation(transition.Destination);
-
-            //Alert all listeners of state transition
-            _onTransitionedEvent.Invoke(transition);
-            var representation = EnterStateAsync(newRepresentation, transition, args).GetAwaiter().GetResult();
-
-            // Check if state has changed by entering new state (by fireing triggers in OnEntry or such)
-            if (!representation.UnderlyingState.Equals(State))
-            {
-                // The state has been changed after entering the state, must update current state to new one
-                State = representation.UnderlyingState;
-            }
-
-            _onTransitionCompletedEvent.Invoke(new Transition(transition.Source, State, transition.Trigger, transition.Parameters));
         }
 
         /// <summary>

--- a/src/Stateless/StateRepresentation.Async.cs
+++ b/src/Stateless/StateRepresentation.Async.cs
@@ -24,21 +24,17 @@ namespace Stateless
                 if (action == null) throw new ArgumentNullException(nameof(action));
 
                 EntryActions.Add(
-                    new EntryActionBehavior.Async((t, args) =>
-                    {
-                        if (t.Trigger.Equals(trigger))
-                            return action(t, args);
-
-                        return TaskResult.Done;
-                    },
-                    entryActionDescription));
+                    new EntryActionBehavior.From<TTrigger>(
+                        trigger,
+                        EventCallbackFactory.Create(action),
+                        entryActionDescription));
             }
 
             public void AddEntryAction(Func<Transition, object[], Task> action, Reflection.InvocationInfo entryActionDescription)
             {
                 EntryActions.Add(
-                    new EntryActionBehavior.Async(
-                        action,
+                    new EntryActionBehavior(
+                        EventCallbackFactory.Create(action),
                         entryActionDescription));
             }
 
@@ -126,7 +122,7 @@ namespace Stateless
             async Task ExecuteEntryActionsAsync(Transition transition, object[] entryArgs)
             {
                 foreach (var action in EntryActions)
-                    await action.ExecuteAsync(transition, entryArgs).ConfigureAwait(false);
+                    await action.Execute(transition, entryArgs).ConfigureAwait(false);
             }
 
             async Task ExecuteExitActionsAsync(Transition transition)

--- a/src/Stateless/StateRepresentation.Async.cs
+++ b/src/Stateless/StateRepresentation.Async.cs
@@ -44,7 +44,7 @@ namespace Stateless
 
             public void AddExitAction(Func<Transition, Task> action, Reflection.InvocationInfo exitActionDescription)
             {
-                ExitActions.Add(new ExitActionBehavior.Async(action, exitActionDescription));
+                ExitActions.Add(new ExitActionBehavior(EventCallbackFactory.Create(action), exitActionDescription));
             }
 
             public async Task ActivateAsync()
@@ -132,7 +132,7 @@ namespace Stateless
             async Task ExecuteExitActionsAsync(Transition transition)
             {
                 foreach (var action in ExitActions)
-                    await action.ExecuteAsync(transition).ConfigureAwait(false);
+                    await action.Execute(transition).ConfigureAwait(false);
             }
         }
     }

--- a/src/Stateless/StateRepresentation.Async.cs
+++ b/src/Stateless/StateRepresentation.Async.cs
@@ -16,7 +16,7 @@ namespace Stateless
 
             public void AddDeactivateAction(Func<Task> action, Reflection.InvocationInfo deactivateActionDescription)
             {
-                DeactivateActions.Add(new DeactivateActionBehaviour.Async(_state, action, deactivateActionDescription));
+                DeactivateActions.Add(new DeactivateActionBehaviour(_state, EventCallbackFactory.Create(action), deactivateActionDescription));
             }
 
             public void AddEntryAction(TTrigger trigger, Func<Transition, object[], Task> action, Reflection.InvocationInfo entryActionDescription)
@@ -72,7 +72,7 @@ namespace Stateless
             async Task ExecuteDeactivationActionsAsync()
             {
                 foreach (var action in DeactivateActions)
-                    await action.ExecuteAsync().ConfigureAwait(false);
+                    await action.Execute().ConfigureAwait(false);
             }
 
 

--- a/src/Stateless/StateRepresentation.Async.cs
+++ b/src/Stateless/StateRepresentation.Async.cs
@@ -62,13 +62,13 @@ namespace Stateless
             async Task ExecuteActivationActionsAsync()
             {
                 foreach (var action in ActivateActions)
-                    await action.Execute().ConfigureAwait(false);
+                    await action.ExecuteAsync().ConfigureAwait(false);
             }
 
             async Task ExecuteDeactivationActionsAsync()
             {
                 foreach (var action in DeactivateActions)
-                    await action.Execute().ConfigureAwait(false);
+                    await action.ExecuteAsync().ConfigureAwait(false);
             }
 
 
@@ -122,13 +122,13 @@ namespace Stateless
             async Task ExecuteEntryActionsAsync(Transition transition, object[] entryArgs)
             {
                 foreach (var action in EntryActions)
-                    await action.Execute(transition, entryArgs).ConfigureAwait(false);
+                    await action.ExecuteAsync(transition, entryArgs).ConfigureAwait(false);
             }
 
             async Task ExecuteExitActionsAsync(Transition transition)
             {
                 foreach (var action in ExitActions)
-                    await action.Execute(transition).ConfigureAwait(false);
+                    await action.ExecuteAsync(transition).ConfigureAwait(false);
             }
         }
     }

--- a/src/Stateless/StateRepresentation.Async.cs
+++ b/src/Stateless/StateRepresentation.Async.cs
@@ -1,5 +1,3 @@
-#if TASKS
-
 using System;
 using System.Threading.Tasks;
 
@@ -133,5 +131,3 @@ namespace Stateless
         }
     }
 }
-
-#endif

--- a/src/Stateless/StateRepresentation.Async.cs
+++ b/src/Stateless/StateRepresentation.Async.cs
@@ -11,7 +11,7 @@ namespace Stateless
         {
             public void AddActivateAction(Func<Task> action, Reflection.InvocationInfo activateActionDescription)
             {
-                ActivateActions.Add(new ActivateActionBehaviour.Async(_state, action, activateActionDescription));
+                ActivateActions.Add(new ActivateActionBehaviour(_state, EventCallbackFactory.Create(action), activateActionDescription));
             }
 
             public void AddDeactivateAction(Func<Task> action, Reflection.InvocationInfo deactivateActionDescription)
@@ -66,7 +66,7 @@ namespace Stateless
             async Task ExecuteActivationActionsAsync()
             {
                 foreach (var action in ActivateActions)
-                    await action.ExecuteAsync().ConfigureAwait(false);
+                    await action.Execute().ConfigureAwait(false);
             }
 
             async Task ExecuteDeactivationActionsAsync()
@@ -90,7 +90,7 @@ namespace Stateless
                     await ExecuteEntryActionsAsync(transition, entryArgs).ConfigureAwait(false);
                 }
             }
-            
+
             public async Task<Transition> ExitAsync(Transition transition)
             {
                 if (transition.IsReentry)

--- a/src/Stateless/StateRepresentation.cs
+++ b/src/Stateless/StateRepresentation.cs
@@ -122,7 +122,7 @@ namespace Stateless
 
             public void AddDeactivateAction(Action action, Reflection.InvocationInfo deactivateActionDescription)
             {
-                DeactivateActions.Add(new DeactivateActionBehaviour.Sync(_state, action, deactivateActionDescription));
+                DeactivateActions.Add(new DeactivateActionBehaviour(_state, EventCallbackFactory.Create(action), deactivateActionDescription));
             }
 
             public void AddEntryAction(TTrigger trigger, Action<Transition, object[]> action, Reflection.InvocationInfo entryActionDescription)
@@ -165,7 +165,7 @@ namespace Stateless
             void ExecuteDeactivationActions()
             {
                 foreach (var action in DeactivateActions)
-                    action.Execute();
+                    action.Execute().GetAwaiter().GetResult();
             }
 
             public void Enter(Transition transition, params object[] entryArgs)

--- a/src/Stateless/StateRepresentation.cs
+++ b/src/Stateless/StateRepresentation.cs
@@ -140,28 +140,6 @@ namespace Stateless
                 ExitActions.Add(new ExitActionBehavior(EventCallbackFactory.Create(action), exitActionDescription));
             }
 
-            internal void InternalAction(Transition transition, object[] args)
-            {
-                InternalTriggerBehaviour internalTransition = null;
-
-                // Look for actions in superstate(s) recursivly until we hit the topmost superstate, or we actually find some trigger handlers.
-                StateRepresentation aStateRep = this;
-                while (aStateRep != null)
-                {
-                    if (aStateRep.TryFindLocalHandler(transition.Trigger, args, out TriggerBehaviourResult result))
-                    {
-                        // Trigger handler found in this state
-                        internalTransition = result.Handler as InternalTriggerBehaviour;
-                        break;
-                    }
-                    // Try to look for trigger handlers in superstate (if it exists)
-                    aStateRep = aStateRep._superstate;
-                }
-
-                // Execute internal transition event handler
-                if (internalTransition == null) throw new ArgumentNullException("The configuration is incorrect, no action assigned to this internal transition.");
-                internalTransition.Execute(transition, args).GetAwaiter().GetResult();
-            }
             public void AddTriggerBehaviour(TriggerBehaviour triggerBehaviour)
             {
                 if (!TriggerBehaviours.TryGetValue(triggerBehaviour.Trigger, out ICollection<TriggerBehaviour> allowed))

--- a/src/Stateless/StateRepresentation.cs
+++ b/src/Stateless/StateRepresentation.cs
@@ -228,7 +228,7 @@ namespace Stateless
             }
             internal void InternalAction(Transition transition, object[] args)
             {
-                InternalTriggerBehaviour.Sync internalTransition = null;
+                InternalTriggerBehaviour internalTransition = null;
 
                 // Look for actions in superstate(s) recursivly until we hit the topmost superstate, or we actually find some trigger handlers.
                 StateRepresentation aStateRep = this;
@@ -237,10 +237,7 @@ namespace Stateless
                     if (aStateRep.TryFindLocalHandler(transition.Trigger, args, out TriggerBehaviourResult result))
                     {
                         // Trigger handler found in this state
-                        if (result.Handler is InternalTriggerBehaviour.Async)
-                            throw new InvalidOperationException("Running Async internal actions in synchronous mode is not allowed");
-
-                        internalTransition = result.Handler as InternalTriggerBehaviour.Sync;
+                        internalTransition = result.Handler as InternalTriggerBehaviour;
                         break;
                     }
                     // Try to look for trigger handlers in superstate (if it exists)
@@ -249,7 +246,7 @@ namespace Stateless
 
                 // Execute internal transition event handler
                 if (internalTransition == null) throw new ArgumentNullException("The configuration is incorrect, no action assigned to this internal transition.");
-                internalTransition.InternalAction(transition, args);
+                internalTransition.Execute(transition, args).GetAwaiter().GetResult();
             }
             public void AddTriggerBehaviour(TriggerBehaviour triggerBehaviour)
             {

--- a/src/Stateless/StateRepresentation.cs
+++ b/src/Stateless/StateRepresentation.cs
@@ -137,7 +137,7 @@ namespace Stateless
 
             public void AddExitAction(Action<Transition> action, Reflection.InvocationInfo exitActionDescription)
             {
-                ExitActions.Add(new ExitActionBehavior.Sync(action, exitActionDescription));
+                ExitActions.Add(new ExitActionBehavior(EventCallbackFactory.Create(action), exitActionDescription));
             }
 
             public void Activate()
@@ -224,7 +224,7 @@ namespace Stateless
             void ExecuteExitActions(Transition transition)
             {
                 foreach (var action in ExitActions)
-                    action.Execute(transition);
+                    action.Execute(transition).GetAwaiter().GetResult();
             }
             internal void InternalAction(Transition transition, object[] args)
             {

--- a/src/Stateless/StateRepresentation.cs
+++ b/src/Stateless/StateRepresentation.cs
@@ -140,26 +140,6 @@ namespace Stateless
                 ExitActions.Add(new ExitActionBehavior(EventCallbackFactory.Create(action), exitActionDescription));
             }
 
-            public void Activate()
-            {
-                ActivateAsync().GetAwaiter().GetResult();
-            }
-
-            public void Deactivate()
-            {
-                DeactivateAsync().GetAwaiter().GetResult();
-            }
-
-            public void Enter(Transition transition, params object[] entryArgs)
-            {
-                EnterAsync(transition, entryArgs).GetAwaiter().GetResult();
-            }
-
-            public Transition Exit(Transition transition)
-            {
-                return ExitAsync(transition).GetAwaiter().GetResult();
-            }
-
             internal void InternalAction(Transition transition, object[] args)
             {
                 InternalTriggerBehaviour internalTransition = null;

--- a/src/Stateless/StateRepresentation.cs
+++ b/src/Stateless/StateRepresentation.cs
@@ -127,12 +127,12 @@ namespace Stateless
 
             public void AddEntryAction(TTrigger trigger, Action<Transition, object[]> action, Reflection.InvocationInfo entryActionDescription)
             {
-                EntryActions.Add(new EntryActionBehavior.SyncFrom<TTrigger>(trigger, action, entryActionDescription));
+                EntryActions.Add(new EntryActionBehavior.From<TTrigger>(trigger, EventCallbackFactory.Create(action), entryActionDescription));
             }
 
             public void AddEntryAction(Action<Transition, object[]> action, Reflection.InvocationInfo entryActionDescription)
             {
-                EntryActions.Add(new EntryActionBehavior.Sync(action, entryActionDescription));
+                EntryActions.Add(new EntryActionBehavior(EventCallbackFactory.Create(action), entryActionDescription));
             }
 
             public void AddExitAction(Action<Transition> action, Reflection.InvocationInfo exitActionDescription)
@@ -218,7 +218,7 @@ namespace Stateless
             void ExecuteEntryActions(Transition transition, object[] entryArgs)
             {
                 foreach (var action in EntryActions)
-                    action.Execute(transition, entryArgs);
+                    action.Execute(transition, entryArgs).GetAwaiter().GetResult();
             }
 
             void ExecuteExitActions(Transition transition)

--- a/src/Stateless/StateRepresentation.cs
+++ b/src/Stateless/StateRepresentation.cs
@@ -64,7 +64,7 @@ namespace Stateless
                     handlerResult = null;
                     return false;
                 }
-               
+
                 // Guard functions are executed here
                 var actual = possible
                     .Select(h => new TriggerBehaviourResult(h, h.UnmetGuardConditions(args)))
@@ -117,7 +117,7 @@ namespace Stateless
 
             public void AddActivateAction(Action action, Reflection.InvocationInfo activateActionDescription)
             {
-                ActivateActions.Add(new ActivateActionBehaviour.Sync(_state, action, activateActionDescription));
+                ActivateActions.Add(new ActivateActionBehaviour(_state, EventCallbackFactory.Create(action), activateActionDescription));
             }
 
             public void AddDeactivateAction(Action action, Reflection.InvocationInfo deactivateActionDescription)
@@ -159,7 +159,7 @@ namespace Stateless
             void ExecuteActivationActions()
             {
                 foreach (var action in ActivateActions)
-                    action.Execute();
+                    action.Execute().GetAwaiter().GetResult();
             }
 
             void ExecuteDeactivationActions()
@@ -308,13 +308,13 @@ namespace Stateless
                     (_superstate != null && _superstate.IsIncludedIn(state));
             }
 
-			public IEnumerable<TTrigger> PermittedTriggers
-			{
-				get
-				{
-					return GetPermittedTriggers();
-				}
-			}
+            public IEnumerable<TTrigger> PermittedTriggers
+            {
+                get
+                {
+                    return GetPermittedTriggers();
+                }
+            }
 
             public IEnumerable<TTrigger> GetPermittedTriggers(params object[] args)
             {

--- a/src/Stateless/Stateless.csproj
+++ b/src/Stateless/Stateless.csproj
@@ -29,6 +29,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\asset\Stateless.png" Pack="true" PackagePath="\"/>
+    <None Include="..\..\asset\Stateless.png" Pack="true" PackagePath="\" />
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
+    <PackageReference Include="Microsoft.Bcl.Async" Version="1.0.168" />
+  </ItemGroup>
+
 </Project>

--- a/src/Stateless/TaskResult.cs
+++ b/src/Stateless/TaskResult.cs
@@ -1,10 +1,18 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace Stateless
 {
     internal static class TaskResult
     {
         internal static readonly Task Done = FromResult(1);
+
+        internal static Task FromException(Exception exception)
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            tcs.SetException(exception);
+            return tcs.Task;
+        }
 
         static Task<T> FromResult<T>(T value)
         {

--- a/src/Stateless/UnhandledTriggerAction.cs
+++ b/src/Stateless/UnhandledTriggerAction.cs
@@ -15,7 +15,7 @@ namespace Stateless
                 _callback = action;
             }
 
-            public virtual Task Execute(TState state, TTrigger trigger, ICollection<string> unmetGuards)
+            public virtual Task ExecuteAsync(TState state, TTrigger trigger, ICollection<string> unmetGuards)
             {
                 return _callback.InvokeAsync(state, trigger, unmetGuards);
             }

--- a/src/Stateless/UnhandledTriggerAction.cs
+++ b/src/Stateless/UnhandledTriggerAction.cs
@@ -6,52 +6,18 @@ namespace Stateless
 {
     public partial class StateMachine<TState, TTrigger>
     {
-        abstract class UnhandledTriggerAction
+        internal class UnhandledTriggerAction
         {
-            public abstract void Execute(TState state, TTrigger trigger, ICollection<string> unmetGuards);
-            public abstract Task ExecuteAsync(TState state, TTrigger trigger, ICollection<string> unmetGuards);
+            private readonly EventCallback<TState, TTrigger, ICollection<string>> _callback;
 
-            internal class Sync : UnhandledTriggerAction
+            public UnhandledTriggerAction(EventCallback<TState, TTrigger, ICollection<string>> action = null)
             {
-                readonly Action<TState, TTrigger, ICollection<string>> _action;
-
-                internal Sync(Action<TState, TTrigger, ICollection<string>> action = null)
-                {
-                    _action = action;
-                }
-
-                public override void Execute(TState state, TTrigger trigger, ICollection<string> unmetGuards)
-                {
-                    _action(state, trigger, unmetGuards);
-                }
-
-                public override Task ExecuteAsync(TState state, TTrigger trigger, ICollection<string> unmetGuards)
-                {
-                    Execute(state, trigger, unmetGuards);
-                    return TaskResult.Done;
-                }
+                _callback = action;
             }
 
-            internal class Async : UnhandledTriggerAction
+            public virtual Task Execute(TState state, TTrigger trigger, ICollection<string> unmetGuards)
             {
-                readonly Func<TState, TTrigger, ICollection<string>, Task> _action;
-
-                internal Async(Func<TState, TTrigger, ICollection<string>, Task> action)
-                {
-                    _action = action;
-                }
-
-                public override void Execute(TState state, TTrigger trigger, ICollection<string> unmetGuards)
-                {
-                    throw new InvalidOperationException(
-                        "Cannot execute asynchronous action specified in OnUnhandledTrigger. " +
-                        "Use asynchronous version of Fire [FireAsync]");
-                }
-
-                public override Task ExecuteAsync(TState state, TTrigger trigger, ICollection<string> unmetGuards)
-                {
-                    return _action(state, trigger, unmetGuards);
-                }
+                return _callback.InvokeAsync(state, trigger, unmetGuards);
             }
         }
     }

--- a/test/Stateless.Tests/AsyncActionsFixture.cs
+++ b/test/Stateless.Tests/AsyncActionsFixture.cs
@@ -121,20 +121,6 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        public void WhenSyncFireAsyncEntryAction()
-        {
-            var sm = new StateMachine<State, Trigger>(State.A);
-
-            sm.Configure(State.A)
-              .Permit(Trigger.X, State.B);
-
-            sm.Configure(State.B)
-              .OnEntryAsync(() => TaskResult.Done);
-
-            Assert.Throws<InvalidOperationException>(() => sm.Fire(Trigger.X));
-        }
-
-        [Fact]
         public async Task CanFireAsyncExitAction()
         {
             var sm = new StateMachine<State, Trigger>(State.A);

--- a/test/Stateless.Tests/AsyncActionsFixture.cs
+++ b/test/Stateless.Tests/AsyncActionsFixture.cs
@@ -353,18 +353,6 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        public void WhenSyncDeactivateAsyncOnDeactivateAction()
-        {
-            var sm = new StateMachine<State, Trigger>(State.A);
-
-            sm.Configure(State.A)
-              .OnDeactivateAsync(() => TaskResult.Done);
-
-            sm.Activate();
-
-            Assert.Throws<InvalidOperationException>(() => sm.Deactivate());
-        }
-        [Fact]
         public async void IfSelfTransitionPermited_ActionsFire_InSubstate_async()
         {
             var sm = new StateMachine<State, Trigger>(State.A);

--- a/test/Stateless.Tests/AsyncActionsFixture.cs
+++ b/test/Stateless.Tests/AsyncActionsFixture.cs
@@ -21,7 +21,7 @@ namespace Stateless.Tests
             sm.FireAsync(Trigger.X);
             Assert.Equal(1, count);
         }
-        
+
         [Fact]
         public async Task SuperStateShouldNotExitOnSubStateTransition_WhenUsingAsyncTriggers()
         {
@@ -33,7 +33,7 @@ namespace Stateless.Tests
                 .OnEntryAsync(() => Task.Run(() => record.Add("Entered state A")))
                 .OnExitAsync(() => Task.Run(() => record.Add("Exited state A")))
                 .Permit(Trigger.X, State.B);
-            
+
             sm.Configure(State.B) // Our super state.
                 .InitialTransition(State.C)
                 .OnEntryAsync(() => Task.Run(() => record.Add("Entered super state B")))
@@ -49,11 +49,11 @@ namespace Stateless.Tests
                 .OnExitAsync(() => Task.Run(() => record.Add("Exited sub state D")))
                 .SubstateOf(State.B);
 
-            
+
             // Act.
             await sm.FireAsync(Trigger.X).ConfigureAwait(false);
             await sm.FireAsync(Trigger.Y).ConfigureAwait(false);
-            
+
             // Assert.
             Assert.Equal("Exited state A", record[0]);
             Assert.Equal("Entered super state B", record[1]);
@@ -73,7 +73,7 @@ namespace Stateless.Tests
                 .OnEntry(() => record.Add("Entered state A"))
                 .OnExit(() => record.Add("Exited state A"))
                 .Permit(Trigger.X, State.B);
-            
+
             sm.Configure(State.B) // Our super state.
                 .InitialTransition(State.C)
                 .OnEntry(() => record.Add("Entered super state B"))
@@ -89,11 +89,11 @@ namespace Stateless.Tests
                 .OnExit(() => record.Add("Exited sub state D"))
                 .SubstateOf(State.B);
 
-            
+
             // Act.
             sm.Fire(Trigger.X);
             sm.Fire(Trigger.Y);
-            
+
             // Assert.
             Assert.Equal("Exited state A", record[0]);
             Assert.Equal("Entered super state B", record[1]);
@@ -101,7 +101,7 @@ namespace Stateless.Tests
             Assert.Equal("Exited sub state C", record[3]);
             Assert.Equal("Entered sub state D", record[4]);
         }
-        
+
         [Fact]
         public async Task CanFireAsyncEntryAction()
         {
@@ -353,17 +353,6 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        public void WhenSyncActivateAsyncOnActivateAction()
-        {
-            var sm = new StateMachine<State, Trigger>(State.A);
-
-            sm.Configure(State.A)
-              .OnActivateAsync(() => TaskResult.Done);
-
-            Assert.Throws<InvalidOperationException>(() => sm.Activate());
-        }
-
-        [Fact]
         public void WhenSyncDeactivateAsyncOnDeactivateAction()
         {
             var sm = new StateMachine<State, Trigger>(State.A);
@@ -443,7 +432,7 @@ namespace Stateless.Tests
                 // >>> The following statement should not throw a NullReferenceException
                 await stateMachine.FireAsync(Trigger.X);
             }
-            catch (NullReferenceException )
+            catch (NullReferenceException)
             {
                 nullRefExcThrown = true;
             }

--- a/test/Stateless.Tests/AsyncActionsFixture.cs
+++ b/test/Stateless.Tests/AsyncActionsFixture.cs
@@ -151,18 +151,6 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        public void WhenSyncFireAsyncExitAction()
-        {
-            var sm = new StateMachine<State, Trigger>(State.A);
-
-            sm.Configure(State.A)
-              .OnExitAsync(() => TaskResult.Done)
-              .Permit(Trigger.X, State.B);
-
-            Assert.Throws<InvalidOperationException>(() => sm.Fire(Trigger.X));
-        }
-
-        [Fact]
         public async Task CanFireInternalAsyncAction()
         {
             var sm = new StateMachine<State, Trigger>(State.A);

--- a/test/Stateless.Tests/AsyncActionsFixture.cs
+++ b/test/Stateless.Tests/AsyncActionsFixture.cs
@@ -151,17 +151,6 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        public void WhenSyncFireInternalAsyncAction()
-        {
-            var sm = new StateMachine<State, Trigger>(State.A);
-
-            sm.Configure(State.A)
-              .InternalTransitionAsync(Trigger.X, () => TaskResult.Done);
-
-            Assert.Throws<InvalidOperationException>(() => sm.Fire(Trigger.X));
-        }
-
-        [Fact]
         public async Task CanInvokeOnTransitionedAsyncAction()
         {
             var sm = new StateMachine<State, Trigger>(State.A);

--- a/test/Stateless.Tests/AsyncActionsFixture.cs
+++ b/test/Stateless.Tests/AsyncActionsFixture.cs
@@ -241,30 +241,6 @@ namespace Stateless.Tests
 
             Assert.Equal("foo", test); // Should await action
         }
-        [Fact]
-        public void WhenSyncFireOnUnhandledTriggerAsyncTask()
-        {
-            var sm = new StateMachine<State, Trigger>(State.A);
-
-            sm.Configure(State.A)
-                .Permit(Trigger.X, State.B);
-
-            sm.OnUnhandledTriggerAsync((s, t) => TaskResult.Done);
-
-            Assert.Throws<InvalidOperationException>(() => sm.Fire(Trigger.Z));
-        }
-        [Fact]
-        public void WhenSyncFireOnUnhandledTriggerAsyncAction()
-        {
-            var sm = new StateMachine<State, Trigger>(State.A);
-
-            sm.Configure(State.A)
-              .Permit(Trigger.X, State.B);
-
-            sm.OnUnhandledTriggerAsync((s, t, u) => TaskResult.Done);
-
-            Assert.Throws<InvalidOperationException>(() => sm.Fire(Trigger.Z));
-        }
 
         [Fact]
         public async Task WhenActivateAsync()

--- a/test/Stateless.Tests/AsyncActionsFixture.cs
+++ b/test/Stateless.Tests/AsyncActionsFixture.cs
@@ -1,5 +1,3 @@
-#if TASKS
-
 using System;
 using System.Threading.Tasks;
 using System.Collections.Generic;
@@ -370,5 +368,3 @@ namespace Stateless.Tests
         }
     }
 }
-
-#endif

--- a/test/Stateless.Tests/AsyncActionsFixture.cs
+++ b/test/Stateless.Tests/AsyncActionsFixture.cs
@@ -192,13 +192,16 @@ namespace Stateless.Tests
 
             var test1 = "";
             var test2 = "";
+            var test3 = "";
             sm.OnTransitioned(_ => test1 = "foo1");
             sm.OnTransitionedAsync(_ => Task.Run(() => test2 = "foo2"));
+            sm.OnTransitioned(_ => test3 = "foo3");
 
             await sm.FireAsync(Trigger.X).ConfigureAwait(false);
 
             Assert.Equal("foo1", test1);
             Assert.Equal("foo2", test2);
+            Assert.Equal("foo3", test3);
         }
 
         [Fact]
@@ -211,39 +214,16 @@ namespace Stateless.Tests
 
             var test1 = "";
             var test2 = "";
+            var test3 = "";
             sm.OnTransitionCompleted(_ => test1 = "foo1");
             sm.OnTransitionCompletedAsync(_ => Task.Run(() => test2 = "foo2"));
+            sm.OnTransitionCompleted(_ => test3 = "foo3");
 
             await sm.FireAsync(Trigger.X).ConfigureAwait(false);
 
             Assert.Equal("foo1", test1);
             Assert.Equal("foo2", test2);
-        }
-
-        [Fact]
-        public void WhenSyncFireAsyncOnTransitionedAction()
-        {
-            var sm = new StateMachine<State, Trigger>(State.A);
-
-            sm.Configure(State.A)
-              .Permit(Trigger.X, State.B);
-
-            sm.OnTransitionedAsync(_ => TaskResult.Done);
-
-            Assert.Throws<InvalidOperationException>(() => sm.Fire(Trigger.X));
-        }
-
-        [Fact]
-        public void WhenSyncFireAsyncOnTransitionCompletedAction()
-        {
-            var sm = new StateMachine<State, Trigger>(State.A);
-
-            sm.Configure(State.A)
-              .Permit(Trigger.X, State.B);
-
-            sm.OnTransitionCompletedAsync(_ => TaskResult.Done);
-
-            Assert.Throws<InvalidOperationException>(() => sm.Fire(Trigger.X));
+            Assert.Equal("foo3", test3);
         }
 
         [Fact]

--- a/test/Stateless.Tests/AsyncFireingModesFixture.cs
+++ b/test/Stateless.Tests/AsyncFireingModesFixture.cs
@@ -1,5 +1,4 @@
-﻿#if TASKS
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -151,7 +150,7 @@ namespace Stateless.Tests
 
             await sm.FireAsync(Trigger.X);
 
-            Assert.Equal(new List<State>() { 
+            Assert.Equal(new List<State>() {
                 State.B,
                 State.C,
                 State.A
@@ -204,4 +203,3 @@ namespace Stateless.Tests
         }
     }
 }
-#endif

--- a/test/Stateless.Tests/EventCallbackFixture.cs
+++ b/test/Stateless.Tests/EventCallbackFixture.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+
+using Xunit;
+
+namespace Stateless.Tests
+{
+
+    public class EventCallbackFixture
+    {
+        [Fact]
+        public async Task CanInvokeDelegate()
+        {
+            int count = 0;
+            await EventCallbackFactory.Create(() => count = 1).InvokeAsync();
+
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public async Task CanInvokeDelegateOneArgument()
+        {
+            int[] count = { };
+            await EventCallbackFactory.Create((int first) =>
+            {
+                count = new int[] { first, };
+            }).InvokeAsync(1);
+
+            Assert.Equal(new[] { 1, }, count);
+        }
+
+        [Fact]
+        public async Task CanInvokeDelegateTwoArguments()
+        {
+            int[] count = { };
+            await EventCallbackFactory.Create((int first, int second) =>
+            {
+                count = new int[] { first, second, };
+            }).InvokeAsync(1, 2);
+
+            Assert.Equal(new[] { 1, 2, }, count);
+        }
+
+        [Fact]
+        public async Task CanInvokeDelegateThreeArguments()
+        {
+            int[] count = { };
+            await EventCallbackFactory.Create((int first, int second, int third) =>
+            {
+                count = new int[] { first, second, third, };
+            }).InvokeAsync(1, 2, 3);
+
+            Assert.Equal(new[] { 1, 2, 3, }, count);
+        }
+
+        [Fact]
+        public async Task CanInvokeDelegateFourArguments()
+        {
+            int[] count = { };
+            await EventCallbackFactory.Create((int first, int second, int third, int four) =>
+            {
+                count = new int[] { first, second, third, four, };
+            }).InvokeAsync(1, 2, 3, 4);
+
+            Assert.Equal(new[] { 1, 2, 3, 4, }, count);
+        }
+
+        [Fact]
+        public async Task CanInvokeAsyncDelegate()
+        {
+            int count = 0;
+            await EventCallbackFactory.Create(() => Task.Run(() => count = 1)).InvokeAsync();
+
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public async Task CanInvokeAsyncDelegateOneArgument()
+        {
+            int[] count = { };
+            await EventCallbackFactory.Create((int first) =>
+            {
+                count = new int[] { first, };
+            }).InvokeAsync(1);
+
+            Assert.Equal(new[] { 1, }, count);
+        }
+
+        [Fact]
+        public async Task CanInvokeAsyncDelegateTwoArguments()
+        {
+            int[] count = { };
+            await EventCallbackFactory.Create((int first, int second) => Task.Run(() =>
+            {
+                count = new int[] { first, second, };
+            })).InvokeAsync(1, 2);
+
+            Assert.Equal(new[] { 1, 2, }, count);
+        }
+
+        [Fact]
+        public async Task CanInvokeAsyncDelegateThreeArguments()
+        {
+            int[] count = { };
+            await EventCallbackFactory.Create((int first, int second, int third) => Task.Run(() =>
+            {
+                count = new int[] { first, second, third, };
+            })).InvokeAsync(1, 2, 3);
+
+            Assert.Equal(new[] { 1, 2, 3, }, count);
+        }
+
+        [Fact]
+        public async Task CanInvokeAsyncDelegateFourArguments()
+        {
+            int[] count = { };
+            await EventCallbackFactory.Create((int first, int second, int third, int four) => Task.Run(() =>
+            {
+                count = new int[] { first, second, third, four, };
+            })).InvokeAsync(1, 2, 3, 4);
+
+            Assert.Equal(new[] { 1, 2, 3, 4, }, count);
+        }
+    }
+}

--- a/test/Stateless.Tests/StateRepresentationFixture.cs
+++ b/test/Stateless.Tests/StateRepresentationFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Stateless.Tests
@@ -9,50 +10,50 @@ namespace Stateless.Tests
     public class StateRepresentationFixture
     {
         [Fact]
-        public void UponEntering_EnteringActionsExecuted()
+        public async Task UponEntering_EnteringActionsExecuted()
         {
             var stateRepresentation = CreateRepresentation(State.B);
             StateMachine<State, Trigger>.Transition
                 transition = new StateMachine<State, Trigger>.Transition(State.A, State.B, Trigger.X),
                 actualTransition = null;
             stateRepresentation.AddEntryAction((t, a) => actualTransition = t, Reflection.InvocationInfo.Create(null, "entryActionDescription"));
-            stateRepresentation.Enter(transition);
+            await stateRepresentation.EnterAsync(transition);
             Assert.Equal(transition, actualTransition);
         }
 
         [Fact]
-        public void UponLeaving_EnteringActionsNotExecuted()
+        public async Task UponLeaving_EnteringActionsNotExecuted()
         {
             var stateRepresentation = CreateRepresentation(State.B);
             StateMachine<State, Trigger>.Transition
                 transition = new StateMachine<State, Trigger>.Transition(State.A, State.B, Trigger.X),
                 actualTransition = null;
             stateRepresentation.AddEntryAction((t, a) => actualTransition = t, Reflection.InvocationInfo.Create(null, "entryActionDescription"));
-            stateRepresentation.Exit(transition);
+            await stateRepresentation.ExitAsync(transition);
             Assert.Null(actualTransition);
         }
 
         [Fact]
-        public void UponLeaving_LeavingActionsExecuted()
+        public async Task UponLeaving_LeavingActionsExecuted()
         {
             var stateRepresentation = CreateRepresentation(State.A);
             StateMachine<State, Trigger>.Transition
                 transition = new StateMachine<State, Trigger>.Transition(State.A, State.B, Trigger.X),
                 actualTransition = null;
             stateRepresentation.AddExitAction(t => actualTransition = t, Reflection.InvocationInfo.Create(null, "entryActionDescription"));
-            stateRepresentation.Exit(transition);
+            await stateRepresentation.ExitAsync(transition);
             Assert.Equal(transition, actualTransition);
         }
 
         [Fact]
-        public void UponEntering_LeavingActionsNotExecuted()
+        public async Task UponEntering_LeavingActionsNotExecuted()
         {
             var stateRepresentation = CreateRepresentation(State.A);
             StateMachine<State, Trigger>.Transition
                 transition = new StateMachine<State, Trigger>.Transition(State.A, State.B, Trigger.X),
                 actualTransition = null;
             stateRepresentation.AddExitAction(t => actualTransition = t, Reflection.InvocationInfo.Create(null, "exitActionDescription"));
-            stateRepresentation.Enter(transition);
+            await stateRepresentation.EnterAsync(transition);
             Assert.Null(actualTransition);
         }
 
@@ -117,79 +118,79 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        public void WhenTransitioningFromSubToSuperstate_SubstateEntryActionsExecuted()
+        public async Task WhenTransitioningFromSubToSuperstate_SubstateEntryActionsExecuted()
         {
             CreateSuperSubstatePair(out StateMachine<State, Trigger>.StateRepresentation super, out StateMachine<State, Trigger>.StateRepresentation sub);
 
             var executed = false;
             sub.AddEntryAction((t, a) => executed = true, Reflection.InvocationInfo.Create(null, "entryActionDescription"));
             var transition = new StateMachine<State, Trigger>.Transition(super.UnderlyingState, sub.UnderlyingState, Trigger.X);
-            sub.Enter(transition);
+            await sub.EnterAsync(transition);
             Assert.True(executed);
         }
 
         [Fact]
-        public void WhenTransitioningFromSubToSuperstate_SubstateExitActionsExecuted()
+        public async Task WhenTransitioningFromSubToSuperstate_SubstateExitActionsExecuted()
         {
             CreateSuperSubstatePair(out StateMachine<State, Trigger>.StateRepresentation super, out StateMachine<State, Trigger>.StateRepresentation sub);
 
             var executed = false;
             sub.AddExitAction(t => executed = true, Reflection.InvocationInfo.Create(null, "exitActionDescription"));
             var transition = new StateMachine<State, Trigger>.Transition(sub.UnderlyingState, super.UnderlyingState, Trigger.X);
-            sub.Exit(transition);
+            await sub.ExitAsync(transition);
             Assert.True(executed);
         }
 
         [Fact]
-        public void WhenTransitioningToSuperFromSubstate_SuperEntryActionsNotExecuted()
+        public async Task WhenTransitioningToSuperFromSubstate_SuperEntryActionsNotExecuted()
         {
             CreateSuperSubstatePair(out StateMachine<State, Trigger>.StateRepresentation super, out StateMachine<State, Trigger>.StateRepresentation sub);
 
             var executed = false;
             super.AddEntryAction((t, a) => executed = true, Reflection.InvocationInfo.Create(null, "entryActionDescription"));
             var transition = new StateMachine<State, Trigger>.Transition(super.UnderlyingState, sub.UnderlyingState, Trigger.X);
-            super.Enter(transition);
+            await super.EnterAsync(transition);
             Assert.False(executed);
         }
 
         [Fact]
-        public void WhenTransitioningFromSuperToSubstate_SuperExitActionsNotExecuted()
+        public async Task WhenTransitioningFromSuperToSubstate_SuperExitActionsNotExecuted()
         {
             CreateSuperSubstatePair(out StateMachine<State, Trigger>.StateRepresentation super, out StateMachine<State, Trigger>.StateRepresentation sub);
 
             var executed = false;
             super.AddExitAction(t => executed = true, Reflection.InvocationInfo.Create(null, "exitActionDescription"));
             var transition = new StateMachine<State, Trigger>.Transition(super.UnderlyingState, sub.UnderlyingState, Trigger.X);
-            super.Exit(transition);
+            await super.ExitAsync(transition);
             Assert.False(executed);
         }
 
         [Fact]
-        public void WhenEnteringSubstate_SuperEntryActionsExecuted()
+        public async Task WhenEnteringSubstate_SuperEntryActionsExecuted()
         {
             CreateSuperSubstatePair(out StateMachine<State, Trigger>.StateRepresentation super, out StateMachine<State, Trigger>.StateRepresentation sub);
 
             var executed = false;
             super.AddEntryAction((t, a) => executed = true, Reflection.InvocationInfo.Create(null, "entryActionDescription"));
             var transition = new StateMachine<State, Trigger>.Transition(State.C, sub.UnderlyingState, Trigger.X);
-            sub.Enter(transition);
+            await sub.EnterAsync(transition);
             Assert.True(executed);
         }
 
         [Fact]
-        public void WhenLeavingSubstate_SuperExitActionsExecuted()
+        public async Task WhenLeavingSubstate_SuperExitActionsExecuted()
         {
             CreateSuperSubstatePair(out StateMachine<State, Trigger>.StateRepresentation super, out StateMachine<State, Trigger>.StateRepresentation sub);
 
             var executed = false;
             super.AddExitAction(t => executed = true, Reflection.InvocationInfo.Create(null, "exitActionDescription"));
             var transition = new StateMachine<State, Trigger>.Transition(sub.UnderlyingState, State.C, Trigger.X);
-            sub.Exit(transition);
+            await sub.ExitAsync(transition);
             Assert.True(executed);
         }
 
         [Fact]
-        public void EntryActionsExecuteInOrder()
+        public async Task EntryActionsExecuteInOrder()
         {
             var actual = new List<int>();
 
@@ -197,7 +198,7 @@ namespace Stateless.Tests
             rep.AddEntryAction((t, a) => actual.Add(0), Reflection.InvocationInfo.Create(null, "entryActionDescription"));
             rep.AddEntryAction((t, a) => actual.Add(1), Reflection.InvocationInfo.Create(null, "entryActionDescription"));
 
-            rep.Enter(new StateMachine<State, Trigger>.Transition(State.A, State.B, Trigger.X));
+            await rep.EnterAsync(new StateMachine<State, Trigger>.Transition(State.A, State.B, Trigger.X));
 
             Assert.Equal(2, actual.Count);
             Assert.Equal(0, actual[0]);
@@ -205,7 +206,7 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        public void ExitActionsExecuteInOrder()
+        public async Task ExitActionsExecuteInOrder()
         {
             var actual = new List<int>();
 
@@ -213,7 +214,7 @@ namespace Stateless.Tests
             rep.AddExitAction(t => actual.Add(0), Reflection.InvocationInfo.Create(null, "entryActionDescription"));
             rep.AddExitAction(t => actual.Add(1), Reflection.InvocationInfo.Create(null, "entryActionDescription"));
 
-            rep.Exit(new StateMachine<State, Trigger>.Transition(State.B, State.C, Trigger.X));
+            await rep.ExitAsync(new StateMachine<State, Trigger>.Transition(State.B, State.C, Trigger.X));
 
             Assert.Equal(2, actual.Count);
             Assert.Equal(0, actual[0]);
@@ -247,7 +248,7 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        public void WhenEnteringSubstate_SuperstateEntryActionsExecuteBeforeSubstate()
+        public async Task WhenEnteringSubstate_SuperstateEntryActionsExecuteBeforeSubstate()
         {
             CreateSuperSubstatePair(out StateMachine<State, Trigger>.StateRepresentation super, out StateMachine<State, Trigger>.StateRepresentation sub);
 
@@ -255,12 +256,12 @@ namespace Stateless.Tests
             super.AddEntryAction((t, a) => superOrder = order++, Reflection.InvocationInfo.Create(null, "entryActionDescription"));
             sub.AddEntryAction((t, a) => subOrder = order++, Reflection.InvocationInfo.Create(null, "entryActionDescription"));
             var transition = new StateMachine<State, Trigger>.Transition(State.C, sub.UnderlyingState, Trigger.X);
-            sub.Enter(transition);
+            await sub.EnterAsync(transition);
             Assert.True(superOrder < subOrder);
         }
 
         [Fact]
-        public void WhenExitingSubstate_SubstateEntryActionsExecuteBeforeSuperstate()
+        public async Task WhenExitingSubstate_SubstateEntryActionsExecuteBeforeSuperstate()
         {
             CreateSuperSubstatePair(out StateMachine<State, Trigger>.StateRepresentation super, out StateMachine<State, Trigger>.StateRepresentation sub);
 
@@ -268,7 +269,7 @@ namespace Stateless.Tests
             super.AddExitAction(t => superOrder = order++, Reflection.InvocationInfo.Create(null, "entryActionDescription"));
             sub.AddExitAction(t => subOrder = order++, Reflection.InvocationInfo.Create(null, "entryActionDescription"));
             var transition = new StateMachine<State, Trigger>.Transition(sub.UnderlyingState, State.C, Trigger.X);
-            sub.Exit(transition);
+            await sub.ExitAsync(transition);
             Assert.True(subOrder < superOrder);
         }
 
@@ -319,12 +320,12 @@ namespace Stateless.Tests
             var transition = new StateMachine<State, Trigger>.TransitioningTriggerBehaviour(Trigger.X, State.C, transitionGuard);
             super.AddTriggerBehaviour(transition);
 
-            var reslt= sub.TryFindHandler(Trigger.X, new object[0], out StateMachine<State, Trigger>.TriggerBehaviourResult result);
+            var reslt = sub.TryFindHandler(Trigger.X, new object[0], out StateMachine<State, Trigger>.TriggerBehaviourResult result);
 
             Assert.False(reslt);
             Assert.False(sub.CanHandle(Trigger.X));
             Assert.False(super.CanHandle(Trigger.X));
-            
+
         }
         [Fact]
         public void WhenTransitionExistSuperstateMetGuardConditions_CanBeFired()
@@ -343,7 +344,7 @@ namespace Stateless.Tests
 
             Assert.True(sub.CanHandle(Trigger.X));
             Assert.True(super.CanHandle(Trigger.X));
-            Assert.NotNull(result);     
+            Assert.NotNull(result);
             Assert.True(result?.Handler.GuardConditionsMet());
             Assert.False(result?.UnmetGuardConditions.Any());
 
@@ -401,7 +402,7 @@ namespace Stateless.Tests
             Assert.Equal(fsm.State, State.A);
             Assert.True(guardDescriptions != null);
             Assert.Equal(2, guardDescriptions.Count);
-            foreach(var description in guardDescriptions)
+            foreach (var description in guardDescriptions)
             {
                 Assert.True(expectedGuardDescriptions.Contains(description));
             }


### PR DESCRIPTION
This PR deletes many duplicate codes that support both synchronous and asynchronous methods. It is done by introducing `EventCallback`, part of ASP.NET Core, prioritizing asynchronous code, and making synchronous code proxy it.

The interesting thing is that asynchronous code runs synchronously before it executes Task.Run or async I/O code.
As a result, the whole methods are acting the same as before.