### PR TITLE
Allow GetPermittedTriggers to Accept StronglyTyped Triggers with Guards in the Configurations

### DIFF
--- a/src/Stateless/StateRepresentation.cs
+++ b/src/Stateless/StateRepresentation.cs
@@ -318,12 +318,23 @@ namespace Stateless
 
             public IEnumerable<TTrigger> GetPermittedTriggers(params object[] args)
             {
-                var result = TriggerBehaviours
-                    .Where(t => t.Value.Any(a => !a.UnmetGuardConditions(args).Any()))
-                    .Select(t => t.Key);
+                var result = new HashSet<TTrigger>();
+                foreach (var triggerBehaviour in TriggerBehaviours)
+                {
+                    try
+                    {
+                        if (triggerBehaviour.Value.Any(a => !a.UnmetGuardConditions(args).Any()))
+                            result.Add(triggerBehaviour.Key);
+                    }
+                    catch (Exception)
+                    {
+                        //Ignore
+                        //There is no need to throw an exception when trying to get the Permitted Triggers. If it's not valid just don't return it.
+                    }
+                }
 
                 if (Superstate != null)
-                    result = result.Union(Superstate.GetPermittedTriggers(args));
+                    result.UnionWith(Superstate.GetPermittedTriggers(args));
 
                 return result;
             }

--- a/test/Stateless.Tests/Trigger.cs
+++ b/test/Stateless.Tests/Trigger.cs
@@ -4,4 +4,15 @@
     {
         X, Y, Z
     }
+    class FirstFakeTrigger
+    {
+        public bool IsAllowed { get; set; }
+    }
+
+
+
+    class SecondFakeTrigger
+    {
+        public bool IsOk { get; set; }
+    }
 }

--- a/test/Stateless.Tests/TriggerWithParametersFixture.cs
+++ b/test/Stateless.Tests/TriggerWithParametersFixture.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Stateless.Tests
@@ -72,6 +73,40 @@ namespace Stateless.Tests
         {
             var twp = new StateMachine<State, Trigger>.TriggerWithParameters(Trigger.X, new Type[] { typeof(int), typeof(string) });
             twp.ValidateParameters(new object[] { 123, "arg" });
+        }
+
+        [Fact]
+        public void GetPermittedTriggersShouldAcceptStronglyTypedTriggersWithConditionalGuardsConfigurations()
+        {
+            var stateMachine = new StateMachine<State, Trigger>(State.A);
+            var firstTrigger = new StateMachine<State, Trigger>.TriggerWithParameters<FirstFakeTrigger>(Trigger.X);
+            var secondTrigger = new StateMachine<State, Trigger>.TriggerWithParameters<SecondFakeTrigger>(Trigger.Y);
+
+            stateMachine.Configure(State.A)
+                .PermitIf(firstTrigger, State.B, trigger => trigger.IsAllowed)
+                .PermitIf(secondTrigger, State.C, trigger => trigger.IsOk);
+
+            var fakeTriggers = new List<object>()
+            {
+                new FirstFakeTrigger
+                {
+                    IsAllowed = true
+                },
+                new SecondFakeTrigger
+                {
+                    IsOk = false
+                },
+            };
+
+            var availableTriggers = new List<Trigger>();
+            foreach (var fakeTrigger in fakeTriggers)
+            {
+                var temp = stateMachine.GetPermittedTriggers(fakeTrigger);
+                availableTriggers.AddRange(temp);
+            }
+
+            Assert.Contains(Trigger.X, availableTriggers);
+            Assert.DoesNotContain(Trigger.Y, availableTriggers);
         }
     }
 }


### PR DESCRIPTION
There is no need to throw an exception when trying to get the Permitted Triggers. If it's not valid just don't return it.
The previous behavior was throwing exceptions when you have different types of strongly typed triggers and you try to check the available triggers for one of them.
I've added a Test Case to cover the issue.