### PR TITLE
- Method CanFire supports trigger with parameters

### DIFF
--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -549,6 +549,18 @@ namespace Stateless
         {
             return CurrentRepresentation.CanHandle(trigger);
         }
+        /// <summary>
+        /// Returns true if <paramref name="trigger"/> can be fired
+        /// in the current state.
+        /// </summary>
+        /// <param name="trigger">The trigger to fire.</param>
+        /// <param name="args">A variable-length parameters list containing arguments. </param>
+        /// <returns>True if the trigger can be fired, false otherwise.</returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public bool CanFire(TriggerWithParameters trigger, params object[] args) {
+            if (trigger == null) throw new ArgumentNullException(nameof(trigger));
+            return CurrentRepresentation.CanHandle(trigger.Trigger, args);
+        }
 
         /// <summary>
         /// Returns true if <paramref name="trigger"/> can be fired

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -962,6 +962,15 @@ namespace Stateless.Tests
         }
 
         [Fact]
+        public void WhenParameterizedGuardTrue_ThenStateMachineCanFireTrigger() {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var x = sm.SetTriggerParameters<int>(Trigger.X);
+            sm.Configure(State.A).PermitIf(x, State.B, i => i == 2);
+            Assert.False(sm.CanFire(x, 1));
+            Assert.True(sm.CanFire(x, 2));
+        }
+
+        [Fact]
         public void WhenConfigureConditionallyPermittedTransitionOnTriggerWithParameters_ThenStateMachineCanEnumeratePermittedTriggers()
         {
             var trigger = Trigger.X;


### PR DESCRIPTION
I use CanFire for allow/deny actions(trigger) on our application's workflow. I need pass parameters to CanFire to determinate allowed actions in the current state.