### PR TITLE
Moved formating state to the base class

### DIFF
--- a/src/Stateless/Graph/GraphStyleBase.cs
+++ b/src/Stateless/Graph/GraphStyleBase.cs
@@ -49,6 +49,13 @@ namespace Stateless.Graph
         public abstract string FormatOneDecisionNode(string nodeName, string label);
 
         /// <summary>
+        /// Returns the formatted text for a initial state.
+        /// </summary>
+        /// <param name="initialStateName"></param>
+        /// <returns></returns>
+        public abstract string FormatInitialState(string initialStateName);
+
+        /// <summary>
         /// Returns the formatted text for all the transitions found in the state graph.
         /// This form, which can be overridden, determines the type of each transition and passes the appropriate
         /// parameters to the virtual FormatOneTransition() function.

--- a/src/Stateless/Graph/UmlDotGraphStyle.cs
+++ b/src/Stateless/Graph/UmlDotGraphStyle.cs
@@ -122,5 +122,20 @@ namespace Stateless.Graph
         {
             return $"\"{fromNodeName}\" -> \"{toNodeName}\" [style=\"solid\", label=\"{label}\"];";
         }
+
+        /// <summary>
+        /// Generate the text for a initial state
+        /// </summary>
+        /// <param name="initialStateName">Name of state</param>
+        /// <returns></returns>
+        public override string FormatInitialState(string initialStateName)
+        {
+            string f = System.Environment.NewLine + $" init [label=\"\", shape=point];";
+            f += System.Environment.NewLine + $" init -> \"{initialStateName}\"[style = \"solid\"]";
+
+            f += System.Environment.NewLine + "}";
+
+            return f;
+        }
     }
 }


### PR DESCRIPTION
I moved the formatting initial state to the base class because the current solution blocks the possibility of adding a new graph format.