### PR TITLE
Add explicit .NET 6.0 framework support

### DIFF
--- a/src/Stateless/Stateless.csproj
+++ b/src/Stateless/Stateless.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyTitle>Stateless</AssemblyTitle>
     <Product>Stateless</Product>
-    <TargetFrameworks>netstandard2.0;netstandard1.0;net45;net40;net472;net50</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.0;net45;net40;net472;net5.0;net6.0</TargetFrameworks>
     <Description>Create state machines and lightweight state machine-based workflows directly in .NET code</Description>
     <Copyright>Copyright © Stateless Contributors 2009-2019</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
@@ -24,7 +24,7 @@
     <DefineConstants>$(DefineConstants);PORTABLE_REFLECTION;TASKS</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net50'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'net472' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'net6.0'">
     <DefineConstants>$(DefineConstants);TASKS</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
Add .NET 6.0 as a target framework, with the net6.0 TFM.

Corrected the .NET 5.0 TFM from net50 to net5.0

TFM documentation reference:
https://docs.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks