### PR TITLE
Hardcode the AssemblyName attribute in the .csproj to "Stateless".

### DIFF
--- a/src/Stateless/Stateless.csproj
+++ b/src/Stateless/Stateless.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <AssemblyName>Stateless</AssemblyName>
     <AssemblyTitle>Stateless</AssemblyTitle>
     <Product>Stateless</Product>
     <TargetFrameworks>netstandard2.0;netstandard1.0;net45;net40;net472;net50</TargetFrameworks>


### PR DESCRIPTION
This ensures that the output .dll is always named "Stateless.dll"
instead of "stateless.dll", which can occur due to quirks in the build
environment and the way the build system is called.

This, in turn, ensures that the output dll name aligns with the
AssemblyTitle attribute, ensuring that build systems consuming the
library are not confused.

This is a single commit version of the https://github.com/dotnet-state-machine/stateless/pull/470 PR with a more descriptive commit message. It also does not alter the version number. Should fix https://github.com/dotnet-state-machine/stateless/issues/449