### PR TITLE
Stateless.Tests -> .NET 6

### DIFF
--- a/test/Stateless.Tests/Stateless.Tests.csproj
+++ b/test/Stateless.Tests/Stateless.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);TASKS</DefineConstants>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <TargetFrameworks>net50</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AssemblyName>Stateless.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../asset/Stateless.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
Update the Stateless.Tests project target framework from net50 to the net6.0 TFM, to re-target the tests project onto the latest .NET 6.0 LTS.