### PR TITLE
Add method to get permitted triggers with parameter information

### DIFF
--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -131,6 +131,17 @@ namespace Stateless
             return CurrentRepresentation.GetPermittedTriggers(args);
         }
 
+#if !NETSTANDARD1_0
+        /// <summary>
+        /// Gets the currently-permissible triggers with any configured parameters.
+        /// </summary>
+        public IEnumerable<TriggerDetails<TState, TTrigger>> GetDetailedPermittedTriggers(params object[] args)
+        {
+            return CurrentRepresentation.GetPermittedTriggers(args)
+                .Select(trigger => new TriggerDetails<TState, TTrigger>(trigger, _triggerConfiguration));
+        }
+#endif
+
         StateRepresentation CurrentRepresentation
         {
             get

--- a/src/Stateless/TriggerDetails.cs
+++ b/src/Stateless/TriggerDetails.cs
@@ -31,7 +31,7 @@ namespace Stateless
 
         /// <summary>
         /// When <see cref="HasParameters"/> is <code>true</code>, returns the parameters required by 
-        /// this trigger; otherwise, returns <code>false</code>.
+        /// this trigger; otherwise, returns <code>null</code>.
         /// </summary>
         public StateMachine<TState, TTrigger>.TriggerWithParameters Parameters { get; }
     }

--- a/src/Stateless/TriggerDetails.cs
+++ b/src/Stateless/TriggerDetails.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+
+namespace Stateless
+{
+    /// <summary>
+    /// Represents a trigger with details of any configured trigger parameters.
+    /// </summary>
+    public sealed class TriggerDetails<TState, TTrigger>
+    {
+        /// <summary>
+        /// Creates a new instance of <see cref="TriggerDetails{TState, TTrigger}"/>.
+        /// </summary>
+        /// <param name="trigger">The trigger.</param>
+        /// <param name="triggerConfiguration">The trigger configurations dictionary.</param>
+        internal TriggerDetails(TTrigger trigger, IDictionary<TTrigger, StateMachine<TState, TTrigger>.TriggerWithParameters> triggerConfiguration)
+        {
+            Trigger = trigger;
+            HasParameters = triggerConfiguration.ContainsKey(trigger);
+            Parameters = HasParameters ? triggerConfiguration[trigger] : null;
+        }
+
+        /// <summary>
+        /// Gets the trigger.
+        /// </summary>
+        public TTrigger Trigger { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the trigger has been configured with parameters.
+        /// </summary>
+        public bool HasParameters { get; }
+
+        /// <summary>
+        /// When <see cref="HasParameters"/> is <code>true</code>, returns the parameters required by 
+        /// this trigger; otherwise, returns <code>false</code>.
+        /// </summary>
+        public StateMachine<TState, TTrigger>.TriggerWithParameters Parameters { get; }
+    }
+}

--- a/src/Stateless/TriggerWithParameters.cs
+++ b/src/Stateless/TriggerWithParameters.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace Stateless
 {
@@ -22,6 +23,11 @@ namespace Stateless
                 _underlyingTrigger = underlyingTrigger;
                 _argumentTypes = argumentTypes ?? throw new ArgumentNullException(nameof(argumentTypes));
             }
+
+            /// <summary>
+            /// Gets the arguments types expected by this trigger.
+            /// </summary>
+            public IEnumerable<Type> ArgumentTypes => _argumentTypes;
 
             /// <summary>
             /// Gets the underlying trigger value that has been configured.

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -1066,5 +1066,36 @@ namespace Stateless.Tests
             Assert.True(unmetGuards?.Count == 0);
         }
 
+        [Fact]
+        public void GetDetailedPermittedTriggers_ReturnsTriggerWithoutParameters()
+        {
+            var sm = new StateMachine<State, Trigger>(State.B);
+
+            sm.Configure(State.B)
+                .Permit(Trigger.X, State.A);
+
+            var permitted = sm.GetDetailedPermittedTriggers().ToList();
+            Assert.Single(permitted);
+            var triggerDetails = permitted.First();
+            Assert.False(triggerDetails.HasParameters);
+            Assert.Null(triggerDetails.Parameters);
+        }
+
+        [Fact]
+        public void GetDetailedPermittedTriggers_ReturnsTriggerWithParameters()
+        {
+            var sm = new StateMachine<State, Trigger>(State.B);
+
+            var pt = sm.SetTriggerParameters<int>(Trigger.X);
+            sm.Configure(State.B)
+                .Permit(Trigger.X, State.A);
+
+            var permitted = sm.GetDetailedPermittedTriggers().ToList();
+            Assert.Single(permitted);
+            var triggerDetails = permitted.First();
+            Assert.True(triggerDetails.HasParameters);
+            Assert.Equal(pt, triggerDetails.Parameters);
+        }
+
     }
 }

--- a/test/Stateless.Tests/TriggerWithParametersFixture.cs
+++ b/test/Stateless.Tests/TriggerWithParametersFixture.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace Stateless.Tests
@@ -72,6 +74,35 @@ namespace Stateless.Tests
         {
             var twp = new StateMachine<State, Trigger>.TriggerWithParameters(Trigger.X, new Type[] { typeof(int), typeof(string) });
             twp.ValidateParameters(new object[] { 123, "arg" });
+        }
+
+        [Fact]
+        public void Arguments_Returs_Single_Argument()
+        {
+            var twp = new StateMachine<State, Trigger>.TriggerWithParameters<int>(Trigger.X);
+            Assert.Single(twp.ArgumentTypes);
+            Assert.Equal(typeof(int), twp.ArgumentTypes.First());
+        }
+
+        [Fact]
+        public void Arguments_Returs_Two_Arguments()
+        {
+            var twp = new StateMachine<State, Trigger>.TriggerWithParameters<int, string>(Trigger.X);
+            var args = twp.ArgumentTypes.ToList();
+            Assert.Equal(2, args.Count);
+            Assert.Equal(typeof(int), args[0]);
+            Assert.Equal(typeof(string), args[1]);
+        }
+
+        [Fact]
+        public void Arguments_Returs_Three_Arguments()
+        {
+            var twp = new StateMachine<State, Trigger>.TriggerWithParameters<int, string, List<bool>>(Trigger.X);
+            var args = twp.ArgumentTypes.ToList();
+            Assert.Equal(3, args.Count);
+            Assert.Equal(typeof(int), args[0]);
+            Assert.Equal(typeof(string), args[1]);
+            Assert.Equal(typeof(List<bool>), args[2]);
         }
     }
 }


### PR DESCRIPTION
As discussed in issue #492, this proposed change adds a new method, `GetDetailedPermittedTriggers`, to `StateMachine<TState, TTrigger>` that returns both the permitted triggers and their parameters if configured. Additionally, a new property, `ArgumentTypes`, on `TriggerWithParameters` provides access to the argument types required by the trigger.

@Pokis @ffMathy please let me know any feedback you have!