### PR TITLE
Fix incorrect initial state in dotgraph after trigger fired

### DIFF
--- a/src/Stateless/Reflection/StateMachineInfo.cs
+++ b/src/Stateless/Reflection/StateMachineInfo.cs
@@ -20,12 +20,11 @@ namespace Stateless.Reflection
         /// <summary>
         /// Exposes the initial state of this state machine.
         /// </summary>
-
         public StateInfo InitialState { get; }
+
         /// <summary>
         /// Exposes the states, transitions, and actions of this machine.
         /// </summary>
-
         public IEnumerable<StateInfo> States { get; }
 
         /// <summary>

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -30,6 +30,7 @@ namespace Stateless
         private UnhandledTriggerAction _unhandledTriggerAction;
         private readonly OnTransitionedEvent _onTransitionedEvent;
         private readonly OnTransitionedEvent _onTransitionCompletedEvent;
+        private readonly TState _initialState;
         private readonly FiringMode _firingMode;
 
         private class QueuedTrigger
@@ -69,6 +70,7 @@ namespace Stateless
             _stateAccessor = stateAccessor ?? throw new ArgumentNullException(nameof(stateAccessor));
             _stateMutator = stateMutator ?? throw new ArgumentNullException(nameof(stateMutator));
 
+            _initialState = stateAccessor();
             _firingMode = firingMode;
         }
 
@@ -83,6 +85,7 @@ namespace Stateless
             _stateAccessor = () => reference.State;
             _stateMutator = s => reference.State = s;
 
+            _initialState = initialState;
             _firingMode = firingMode;
         }
 
@@ -155,7 +158,7 @@ namespace Stateless
         /// </summary>
         public StateMachineInfo GetInfo()
         {
-            var initialState = StateInfo.CreateStateInfo(new StateRepresentation(State));
+            var initialState = StateInfo.CreateStateInfo(new StateRepresentation(_initialState));
 
             var representations = _stateConfiguration.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 

--- a/test/Stateless.Tests/DotGraphFixture.cs
+++ b/test/Stateless.Tests/DotGraphFixture.cs
@@ -537,6 +537,27 @@ namespace Stateless.Tests
             Assert.Equal(expected, dotGraph);
         }
 
+        [Fact]
+        public void Initial_State_Not_Changed_After_Trigger_Fired()
+        {
+            var expected = Prefix(Style.UML) + Box(Style.UML, "A") + Box(Style.UML, "B") + Line("A", "B", "X") + suffix;
+
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+                .Permit(Trigger.X, State.B);
+
+            sm.Fire(Trigger.X);
+
+            string dotGraph = UmlDotGraph.Format(sm.GetInfo());
+
+#if WRITE_DOTS_TO_FOLDER
+            System.IO.File.WriteAllText(DestinationFolder + "SimpleTransition.dot", dotGraph);
+#endif
+
+            Assert.Equal(expected, dotGraph);
+        }
+
         private void TestEntryAction() { }
         private void TestEntryActionString(string val) { }
         private State DestinationSelector() { return State.A; }


### PR DESCRIPTION
Update to issue #285 to ensure the initial state in the DOT graph is unaffected by the current state machine state.