### PR TITLE
fix: InternalTransitionAsyncIf guard parameters

### DIFF
--- a/src/Stateless/InternalTriggerBehaviour.cs
+++ b/src/Stateless/InternalTriggerBehaviour.cs
@@ -45,7 +45,7 @@ namespace Stateless
             {
                 readonly Func<Transition, object[], Task> InternalAction;
 
-                public Async(TTrigger trigger, Func<bool> guard,Func<Transition, object[], Task> internalAction, string guardDescription = null) : base(trigger, new TransitionGuard(guard, guardDescription))
+                public Async(TTrigger trigger, Func<object[], bool> guard,Func<Transition, object[], Task> internalAction, string guardDescription = null) : base(trigger, new TransitionGuard(guard, guardDescription))
                 {
                     InternalAction = internalAction;
                 }

--- a/src/Stateless/StateConfiguration.Async.cs
+++ b/src/Stateless/StateConfiguration.Async.cs
@@ -12,21 +12,6 @@ namespace Stateless
             /// <summary>
             /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
             /// </summary>
-            /// <param name="trigger"></param>
-            /// <param name="guard">Function that must return true in order for the trigger to be accepted.</param>
-            /// <param name="entryAction"></param>
-            /// <returns></returns>
-            public StateConfiguration InternalTransitionAsyncIf(TTrigger trigger, Func<bool> guard, Func<Transition, Task> entryAction)
-            {
-                if (entryAction == null) throw new ArgumentNullException(nameof(entryAction));
-
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger, guard, (t, args) => entryAction(t)));
-                return this;
-            }
-
-            /// <summary>
-            /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
-            /// </summary>
             /// <param name="trigger">The accepted trigger</param>
             /// <param name="guard">Function that must return true in order for the\r\n            /// trigger to be accepted.</param>
             /// <param name="internalAction">The asynchronous action performed by the internal transition</param>
@@ -35,23 +20,22 @@ namespace Stateless
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger, guard, (t, args) => internalAction()));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger, t => guard(), (t, args) => internalAction()));
                 return this;
             }
 
             /// <summary>
             /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
             /// </summary>
-            /// <typeparam name="TArg0"></typeparam>
             /// <param name="trigger">The accepted trigger</param>
             /// <param name="guard">Function that must return true in order for the trigger to be accepted.</param>
             /// <param name="internalAction">The asynchronous action performed by the internal transition</param>
             /// <returns></returns>
-            public StateConfiguration InternalTransitionAsyncIf<TArg0>(TTrigger trigger, Func<bool> guard, Func<Transition, Task> internalAction)
+            public StateConfiguration InternalTransitionAsyncIf(TTrigger trigger, Func<bool> guard, Func<Transition, Task> internalAction)
             {
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger, guard, (t, args) => internalAction(t)));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger, t => guard(), (t, args) => internalAction(t)));
                 return this;
             }
 
@@ -63,12 +47,12 @@ namespace Stateless
             /// <param name="guard">Function that must return true in order for the trigger to be accepted.</param>
             /// <param name="internalAction">The asynchronous action performed by the internal transition</param>
             /// <returns></returns>
-            public StateConfiguration InternalTransitionAsyncIf<TArg0>(TriggerWithParameters<TArg0> trigger, Func<bool> guard, Func<TArg0, Transition, Task> internalAction)
+            public StateConfiguration InternalTransitionAsyncIf<TArg0>(TriggerWithParameters<TArg0> trigger, Func<TArg0, bool> guard, Func<TArg0, Transition, Task> internalAction)
             {
                 if (trigger == null) throw new ArgumentNullException(nameof(trigger));
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger.Trigger, guard, (t, args) => internalAction(ParameterConversion.Unpack<TArg0>(args, 0), t)));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger.Trigger, TransitionGuard.ToPackedGuard(guard), (t, args) => internalAction(ParameterConversion.Unpack<TArg0>(args, 0), t)));
                 return this;
             }
 
@@ -81,12 +65,12 @@ namespace Stateless
             /// <param name="guard">Function that must return true in order for the trigger to be accepted.</param>
             /// <param name="internalAction">The asynchronous action performed by the internal transition</param>
             /// <returns></returns>
-            public StateConfiguration InternalTransitionAsyncIf<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Func<bool> guard, Func<TArg0, TArg1, Transition, Task> internalAction)
+            public StateConfiguration InternalTransitionAsyncIf<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Func<TArg0, TArg1, bool> guard, Func<TArg0, TArg1, Transition, Task> internalAction)
             {
                 if (trigger == null) throw new ArgumentNullException(nameof(trigger));
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger.Trigger, guard, (t, args) => internalAction(
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger.Trigger, TransitionGuard.ToPackedGuard(guard), (t, args) => internalAction(
                     ParameterConversion.Unpack<TArg0>(args, 0),
                     ParameterConversion.Unpack<TArg1>(args, 1), t)));
                 return this;
@@ -102,29 +86,19 @@ namespace Stateless
             /// <param name="guard">Function that must return true in order for the trigger to be accepted.</param>
             /// <param name="internalAction">The asynchronous action performed by the internal transition</param>
             /// <returns></returns>
-            public StateConfiguration InternalTransitionAsyncIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Func<bool> guard, Func<TArg0, TArg1, TArg2, Transition, Task> internalAction)
+            public StateConfiguration InternalTransitionAsyncIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Func<TArg0, TArg1, TArg2, bool> guard, Func<TArg0, TArg1, TArg2, Transition, Task> internalAction)
             {
                 if (trigger == null) throw new ArgumentNullException(nameof(trigger));
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger.Trigger, guard, (t, args) => internalAction(
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger.Trigger, TransitionGuard.ToPackedGuard(guard), (t, args) => internalAction(
                     ParameterConversion.Unpack<TArg0>(args, 0),
                     ParameterConversion.Unpack<TArg1>(args, 1),
                     ParameterConversion.Unpack<TArg2>(args, 2), t)));
                 return this;
             }
 
-
-            /// <summary>
-            /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
-            /// </summary>
-            /// <param name="trigger"></param>
-            /// <param name="entryAction"></param>
-            /// <returns></returns>
-            public StateConfiguration InternalTransitionAsync(TTrigger trigger, Func<Transition, Task> entryAction)
-            {
-                return InternalTransitionAsyncIf(trigger, () => true, entryAction);
-            }
+            
             /// <summary>
             /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
             /// </summary>
@@ -138,11 +112,10 @@ namespace Stateless
             /// <summary>
             /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
             /// </summary>
-            /// <typeparam name="TArg0"></typeparam>
             /// <param name="trigger">The accepted trigger</param>
             /// <param name="internalAction">The asynchronous action performed by the internal transition</param>
             /// <returns></returns>
-            public StateConfiguration InternalTransitionAsync<TArg0>(TTrigger trigger, Func<Transition, Task> internalAction)
+            public StateConfiguration InternalTransitionAsync(TTrigger trigger, Func<Transition, Task> internalAction)
             {
                 return InternalTransitionAsyncIf(trigger, () => true, internalAction);
             }
@@ -155,7 +128,7 @@ namespace Stateless
             /// <returns></returns>
             public StateConfiguration InternalTransitionAsync<TArg0>(TriggerWithParameters<TArg0> trigger, Func<TArg0, Transition, Task> internalAction)
             {
-                return InternalTransitionAsyncIf(trigger, () => true, internalAction);
+                return InternalTransitionAsyncIf(trigger, t => true, internalAction);
             }
 
             /// <summary>
@@ -168,7 +141,7 @@ namespace Stateless
             /// <returns></returns>
             public StateConfiguration InternalTransitionAsync<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Func<TArg0, TArg1, Transition, Task> internalAction)
             {
-                return InternalTransitionAsyncIf(trigger, () => true, internalAction);
+                return InternalTransitionAsyncIf(trigger, (t1, t2) => true, internalAction);
             }
 
             /// <summary>
@@ -182,7 +155,7 @@ namespace Stateless
             /// <returns></returns>
             public StateConfiguration InternalTransitionAsync<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Func<TArg0, TArg1, TArg2, Transition, Task> internalAction)
             {
-                return InternalTransitionAsyncIf(trigger, () => true, internalAction);
+                return InternalTransitionAsyncIf(trigger, (t1, t2, t3) => true, internalAction);
             }
 
             /// <summary>

--- a/test/Stateless.Tests/InternalTransitionAsyncFixture.cs
+++ b/test/Stateless.Tests/InternalTransitionAsyncFixture.cs
@@ -5,6 +5,99 @@ namespace Stateless.Tests
 {
     public class InternalTransitionAsyncFixture
     {
+        [Fact]
+        public async Task InternalTransitionAsyncIf_AllowGuardWithParameter()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var trigger = sm.SetTriggerParameters<int>(Trigger.X);
+            const int intParam = 5;
+            var guardInvoked = false;
+            var callbackInvoked = false;
+
+            sm.Configure(State.A)
+                .InternalTransitionAsyncIf(trigger, i =>
+                {
+                    guardInvoked = true;
+                    Assert.Equal(intParam, i);
+                    return true;
+                }, (i, transition) =>
+                {
+                    callbackInvoked = true;
+                    Assert.Equal(intParam, i);
+                    return Task.CompletedTask;
+                });
+
+            await sm.FireAsync(trigger, intParam);
+
+            Assert.True(guardInvoked);
+            Assert.True(callbackInvoked);
+        }
+    
+        [Fact]
+        public async Task InternalTransitionAsyncIf_AllowGuardWithTwoParameters()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var trigger = sm.SetTriggerParameters<int, string>(Trigger.X);
+            const int intParam = 5;
+            const string stringParam = "5";
+            var guardInvoked = false;
+            var callbackInvoked = false;
+
+            sm.Configure(State.A)
+                .InternalTransitionAsyncIf(trigger, (i, s) =>
+                {
+                    guardInvoked = true;
+                    Assert.Equal(intParam, i);
+                    Assert.Equal(stringParam, s);
+                    return true;
+                }, (i, s, transition) =>
+                {
+                    callbackInvoked = true;
+                    Assert.Equal(intParam, i);
+                    Assert.Equal(stringParam, s);
+                    return Task.CompletedTask;
+                });
+
+            await sm.FireAsync(trigger, intParam, stringParam);
+
+            Assert.True(guardInvoked);
+            Assert.True(callbackInvoked);
+        }
+    
+        [Fact]
+        public async Task InternalTransitionAsyncIf_AllowGuardWithThreeParameters()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var trigger = sm.SetTriggerParameters<int, string, bool>(Trigger.X);
+            const int intParam = 5;
+            const string stringParam = "5";
+            const bool boolParam = true;
+            var guardInvoked = false;
+            var callbackInvoked = false;
+
+            sm.Configure(State.A)
+                .InternalTransitionAsyncIf(trigger, (i, s, b) =>
+                {
+                    guardInvoked = true;
+                    Assert.Equal(intParam, i);
+                    Assert.Equal(stringParam, s);
+                    Assert.Equal(boolParam, b);
+                    return true;
+                }, (i, s, b, transition) =>
+                {
+                    callbackInvoked = true;
+                    Assert.Equal(intParam, i);
+                    Assert.Equal(stringParam, s);
+                    Assert.Equal(boolParam, b);
+                    return Task.CompletedTask;
+                });
+
+            await sm.FireAsync(trigger, intParam, stringParam, boolParam);
+
+            Assert.True(guardInvoked);
+            Assert.True(callbackInvoked);
+        }
+    
         /// <summary>
         /// This unit test demonstrated bug report #417
         /// </summary>


### PR DESCRIPTION
#303 

Should I keep the old "wrong" overloads for backwards compatibility?