### PR TITLE
Fix spelling mistake "fireing" to "firing"

### DIFF
--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -249,7 +249,7 @@ namespace Stateless
             await _onTransitionedEvent.InvokeAsync(transition);
             var representation =await EnterStateAsync(newRepresentation, transition, args);
 
-            // Check if state has changed by entering new state (by fireing triggers in OnEntry or such)
+            // Check if state has changed by entering new state (by firing triggers in OnEntry or such)
             if (!representation.UnderlyingState.Equals(State))
             {
                 // The state has been changed after entering the state, must update current state to new one

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -64,7 +64,7 @@ namespace Stateless
         /// </summary>
         /// <param name="stateAccessor">A function that will be called to read the current state value.</param>
         /// <param name="stateMutator">An action that will be called to write new state values.</param>
-        /// <param name="firingMode">Optional specification of fireing mode.</param>
+        /// <param name="firingMode">Optional specification of firing mode.</param>
         public StateMachine(Func<TState> stateAccessor, Action<TState> stateMutator, FiringMode firingMode) : this()
         {
             _stateAccessor = stateAccessor ?? throw new ArgumentNullException(nameof(stateAccessor));
@@ -78,7 +78,7 @@ namespace Stateless
         /// Construct a state machine.
         /// </summary>
         /// <param name="initialState">The initial state.</param>
-        /// <param name="firingMode">Optional specification of fireing mode.</param>
+        /// <param name="firingMode">Optional specification of firing mode.</param>
         public StateMachine(TState initialState, FiringMode firingMode) : this()
         {
             var reference = new StateReference { State = initialState };
@@ -476,7 +476,7 @@ namespace Stateless
             _onTransitionedEvent.Invoke(transition);
             var representation = EnterState(newRepresentation, transition, args);
 
-            // Check if state has changed by entering new state (by fireing triggers in OnEntry or such)
+            // Check if state has changed by entering new state (by firing triggers in OnEntry or such)
             if (!representation.UnderlyingState.Equals(State))
             {
                 // The state has been changed after entering the state, must update current state to new one

--- a/test/Stateless.Tests/AsyncFiringModesFixture.cs
+++ b/test/Stateless.Tests/AsyncFiringModesFixture.cs
@@ -9,10 +9,10 @@ namespace Stateless.Tests
     /// <summary>
     /// This test class verifies that the firing modes are working as expected
     /// </summary>
-    public class AsyncFireingModesFixture
+    public class AsyncFiringModesFixture
     {
         /// <summary>
-        /// Check that the immediate fireing modes executes entry/exit out of order.
+        /// Check that the immediate Firing modes executes entry/exit out of order.
         /// </summary>
         [Fact]
         public void ImmediateEntryAProcessedBeforeEnterB()
@@ -46,7 +46,7 @@ namespace Stateless.Tests
         }
 
         /// <summary>
-        /// Checks that queued fireing mode executes triggers in order
+        /// Checks that queued Firing mode executes triggers in order
         /// </summary>
         [Fact]
         public void ImmediateEntryAProcessedBeforeEterB()
@@ -79,10 +79,10 @@ namespace Stateless.Tests
         }
 
         /// <summary>
-        /// Check that the immediate fireing modes executes entry/exit out of order.
+        /// Check that the immediate Firing modes executes entry/exit out of order.
         /// </summary>
         [Fact]
-        public void ImmediateFireingOnEntryEndsUpInCorrectState()
+        public void ImmediateFiringOnEntryEndsUpInCorrectState()
         {
             var record = new List<string>();
             var sm = new StateMachine<State, Trigger>(State.A, FiringMode.Immediate);
@@ -119,7 +119,7 @@ namespace Stateless.Tests
         }
 
         /// <summary>
-        /// Check that the immediate fireing modes executes entry/exit out of order.
+        /// Check that the immediate Firing modes executes entry/exit out of order.
         /// </summary>
         [Fact]
         public async Task ImmediateModeTransitionsAreInCorrectOrderWithAsyncDriving()

--- a/test/Stateless.Tests/FiringModesFixture.cs
+++ b/test/Stateless.Tests/FiringModesFixture.cs
@@ -7,10 +7,10 @@ namespace Stateless.Tests
     /// <summary>
     /// This test class verifies that the firing modes are working as expected
     /// </summary>
-    public class FireingModesFixture
+    public class FiringModesFixture
     {
         /// <summary>
-        /// Check that the immediate fireing modes executes entry/exit out of order.
+        /// Check that the immediate firing modes executes entry/exit out of order.
         /// </summary>
         [Fact]
         public void ImmediateEntryAProcessedBeforeEnterB()
@@ -43,10 +43,10 @@ namespace Stateless.Tests
         }
 
         /// <summary>
-        /// Checks that queued fireing mode executes triggers in order
+        /// Checks that queued firing mode executes triggers in order
         /// </summary>
         [Fact]
-        public void ImmediateEntryAProcessedBeforeEterB()
+        public void QueuedEntryAProcessedAfterEnterB()
         {
             var record = new List<string>();
             var sm = new StateMachine<State, Trigger>(State.A, FiringMode.Queued);
@@ -76,10 +76,10 @@ namespace Stateless.Tests
         }
 
         /// <summary>
-        /// Check that the immediate fireing modes executes entry/exit out of order.
+        /// Check that the immediate firing modes executes entry/exit out of order.
         /// </summary>
         [Fact]
-        public void ImmediateFireingOnEntryEndsUpInCorrectState()
+        public void ImmediateFiringOnEntryEndsUpInCorrectState()
         {
             var record = new List<string>();
             var sm = new StateMachine<State, Trigger>(State.A, FiringMode.Immediate);


### PR DESCRIPTION
"ImmediateEntryAProcessedBeforeEterB" also had a typo in it of "Eter".
However, there already was a method called "ImmediateEntryAProcessedBeforeEnterB".

On closer examination, I renamed the test to reflect the expected result:
* "QueuedEntryAProcessedAfterEnterB"