### PR TITLE
StateMachineInfo.InitialState.Transitions throws if AddRelationships not called

### DIFF
--- a/src/Stateless/Reflection/StateInfo.cs
+++ b/src/Stateless/Reflection/StateInfo.cs
@@ -143,7 +143,14 @@ namespace Stateless.Reflection
         /// <summary> 
         /// Transitions defined for this state.
         /// </summary>
-        public IEnumerable<TransitionInfo> Transitions { get { return FixedTransitions.Concat<TransitionInfo>(DynamicTransitions); } }
+        public IEnumerable<TransitionInfo> Transitions 
+        {
+            get { 
+                return FixedTransitions == null // A quick way to check if AddRelationships has been called.
+                            ? null 
+                            : FixedTransitions.Concat<TransitionInfo>(DynamicTransitions); 
+            } 
+        }
 
         /// <summary>
         /// Transitions defined for this state.

--- a/test/Stateless.Tests/StateInfoTests.cs
+++ b/test/Stateless.Tests/StateInfoTests.cs
@@ -1,0 +1,25 @@
+﻿using Stateless.Reflection;
+using Xunit;
+
+namespace Stateless.Tests;
+
+public class StateInfoTests
+{
+    /// <summary>
+    /// For StateInfo, Substates, FixedTransitions and DynamicTransitions are only initialised by a call to AddRelationships.
+    /// However, for StateMachineInfo.InitialState, this never happens. Therefore StateMachineInfo.InitialState.Transitions
+    /// throws a System.ArgumentNullException. 
+    /// </summary>
+    [Fact]
+    public void StateInfo_transitions_should_default_to_empty()
+    {
+        // ARRANGE
+        var stateInfo = StateInfo.CreateStateInfo(new StateMachine<State, Trigger>.StateRepresentation(State.A));
+        
+        // ACT
+        var stateInfoTransitions = stateInfo.Transitions;
+        
+        // ASSERT
+        Assert.Null(stateInfoTransitions);
+    } 
+}


### PR DESCRIPTION
For StateInfo, Substates, FixedTransitions and DynamicTransitions are only initialised by a call to AddRelationships.

However, for StateMachineInfo.InitialState, this never happens. 

Therefore StateMachineInfo.InitialState.Transitions throws a System.ArgumentNullException. 

The StateInfo object should not throw if "half initialised"