### PR TITLE
Execute sync trigger directly

### DIFF
--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -205,7 +205,7 @@ namespace Stateless
                         if (itb is InternalTriggerBehaviour.Async ita)
                             await ita.ExecuteAsync(transition, args);
                         else
-                            await Task.Run(() => itb.Execute(transition, args));
+                            itb.Execute(transition, args);
                         break;
                     }
                 default:


### PR DESCRIPTION
Instead of delegating the execution of the internal trigger behaviour to a thread pool thread and waiting for it, simply execute it.

Whilst Task.Run is recommended within libraries, it has a side effect of dropping the synchronization context.

This PR is part of a larger change that I am working on to fix an issue caused by the introduction of ConfigureAwait(false) everywhere (which also loses the synchronization context) and breaks queued mode usage in Microsoft Orleans. More on that to follow in a different PR.
