### PR TITLE
Retain SynchronizationContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ phoneCall.Configure(State.OffHook)
 
 Guard clauses within a state must be mutually exclusive (multiple guard clauses cannot be valid at the same time.) Substates can override transitions by respecifying them, however substates cannot disallow transitions that are allowed by the superstate.
 
-The guard clauses will be evaluated whenever a trigger is fired. Guards should therefor be made side effect free.
+The guard clauses will be evaluated whenever a trigger is fired. Guards should therefore be made side effect free.
 
 ### Parameterised Triggers
 
@@ -224,6 +224,20 @@ await stateMachine.FireAsync(Trigger.Assigned);
 ```
 
 **Note:** while `StateMachine` may be used _asynchronously_, it remains single-threaded and may not be used _concurrently_ by multiple threads.
+
+## Advanced Features ##
+
+### Retaining the SynchronizationContext ###
+In specific situations where all handler methods must be invoked with the consumer's SynchronizationContext, set the _RetainSynchronizationContext_ property on creation:
+
+```csharp
+var stateMachine = new StateMachine<State, Trigger>(initialState)
+{
+    RetainSynchronizationContext = true
+};
+```
+
+Setting this is vital within a Microsoft Orleans Grain for example, which requires the SynchronizationContext in order to make calls to other Grains.
 
 ## Building
 

--- a/src/Stateless/OnTransitionedEvent.cs
+++ b/src/Stateless/OnTransitionedEvent.cs
@@ -10,7 +10,7 @@ namespace Stateless
         {
             event Action<Transition> _onTransitioned;
             readonly List<Func<Transition, Task>> _onTransitionedAsync = new List<Func<Transition, Task>>();
-
+            
             public void Invoke(Transition transition)
             {
                 if (_onTransitionedAsync.Count != 0)
@@ -22,12 +22,12 @@ namespace Stateless
             }
 
 #if TASKS
-            public async Task InvokeAsync(Transition transition)
+            public async Task InvokeAsync(Transition transition, bool retainSynchronizationContext)
             {
                 _onTransitioned?.Invoke(transition);
 
                 foreach (var callback in _onTransitionedAsync)
-                    await callback(transition).ConfigureAwait(false);
+                    await callback(transition).ConfigureAwait(retainSynchronizationContext);
             }
 #endif
 

--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -144,12 +144,12 @@ namespace Stateless
             {
                 _firing = true;
 
-                await InternalFireOneAsync(trigger, args).ConfigureAwait(false);
+                await InternalFireOneAsync(trigger, args).ConfigureAwait(RetainSynchronizationContext);
 
                 while (_eventQueue.Count != 0)
                 {
                     var queuedEvent = _eventQueue.Dequeue();
-                    await InternalFireOneAsync(queuedEvent.Trigger, queuedEvent.Args).ConfigureAwait(false);
+                    await InternalFireOneAsync(queuedEvent.Trigger, queuedEvent.Args).ConfigureAwait(RetainSynchronizationContext);
                 }
             }
             finally
@@ -225,15 +225,15 @@ namespace Stateless
                 transition = new Transition(transition.Destination, transition.Destination, transition.Trigger, args);
                 await newRepresentation.ExitAsync(transition);
 
-                await _onTransitionedEvent.InvokeAsync(transition);
+                await _onTransitionedEvent.InvokeAsync(transition, RetainSynchronizationContext);
                 representation = await EnterStateAsync(newRepresentation, transition, args);
-                await _onTransitionCompletedEvent.InvokeAsync(transition);
+                await _onTransitionCompletedEvent.InvokeAsync(transition, RetainSynchronizationContext);
             }
             else
             {
-                await _onTransitionedEvent.InvokeAsync(transition);
+                await _onTransitionedEvent.InvokeAsync(transition, RetainSynchronizationContext);
                 representation = await EnterStateAsync(newRepresentation, transition, args);
-                await _onTransitionCompletedEvent.InvokeAsync(transition);
+                await _onTransitionCompletedEvent.InvokeAsync(transition, RetainSynchronizationContext);
             }
             State = representation.UnderlyingState;
         }
@@ -246,7 +246,7 @@ namespace Stateless
             var newRepresentation = GetRepresentation(transition.Destination);
 
             //Alert all listeners of state transition
-            await _onTransitionedEvent.InvokeAsync(transition);
+            await _onTransitionedEvent.InvokeAsync(transition, RetainSynchronizationContext);
             var representation =await EnterStateAsync(newRepresentation, transition, args);
 
             // Check if state has changed by entering new state (by firing triggers in OnEntry or such)
@@ -256,7 +256,7 @@ namespace Stateless
                 State = representation.UnderlyingState;
             }
 
-           await _onTransitionCompletedEvent.InvokeAsync(new Transition(transition.Source, State, transition.Trigger, transition.Parameters));
+            await _onTransitionCompletedEvent.InvokeAsync(new Transition(transition.Source, State, transition.Trigger, transition.Parameters), RetainSynchronizationContext);
         }
 
 
@@ -287,7 +287,7 @@ namespace Stateless
                 representation = GetRepresentation(representation.InitialTransitionTarget);
 
                 // Alert all listeners of initial state transition
-                await _onTransitionedEvent.InvokeAsync(new Transition(transition.Destination, initialTransition.Destination, transition.Trigger, transition.Parameters));
+                await _onTransitionedEvent.InvokeAsync(new Transition(transition.Destination, initialTransition.Destination, transition.Trigger, transition.Parameters), RetainSynchronizationContext);
                 representation = await EnterStateAsync(representation, initialTransition, args);
             }
 

--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Stateless
@@ -205,7 +206,11 @@ namespace Stateless
                         if (itb is InternalTriggerBehaviour.Async ita)
                             await ita.ExecuteAsync(transition, args);
                         else
-                            await Task.Run(() => itb.Execute(transition, args));
+                            if (RetainSynchronizationContext)
+                                await Task.Factory.StartNew(() => itb.Execute(transition, args),
+                                    CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.FromCurrentSynchronizationContext());
+                            else
+                                await Task.Run(() => itb.Execute(transition, args));
                         break;
                     }
                 default:

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -162,7 +162,7 @@ namespace Stateless
         /// </summary>
         public StateMachineInfo GetInfo()
         {
-            var initialState = StateInfo.CreateStateInfo(new StateRepresentation(_initialState));
+            var initialState = StateInfo.CreateStateInfo(new StateRepresentation(_initialState, RetainSynchronizationContext));
 
             var representations = _stateConfiguration.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
@@ -172,7 +172,7 @@ namespace Stateless
             var reachable = behaviours
                 .Distinct()
                 .Except(representations.Keys)
-                .Select(underlying => new StateRepresentation(underlying))
+                .Select(underlying => new StateRepresentation(underlying, RetainSynchronizationContext))
                 .ToArray();
 
             foreach (var representation in reachable)

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -89,6 +89,10 @@ namespace Stateless
             _firingMode = firingMode;
         }
 
+        /// <summary>
+        /// For certain situations, it is essential that the SynchronizationContext is retained for all delegate calls.
+        /// </summary>
+        public bool RetainSynchronizationContext { get; set; } = false;
 
         /// <summary>
         /// Default constructor
@@ -186,7 +190,7 @@ namespace Stateless
         {
             if (!_stateConfiguration.TryGetValue(state, out StateRepresentation result))
             {
-                result = new StateRepresentation(state);
+                result = new StateRepresentation(state, RetainSynchronizationContext);
                 _stateConfiguration.Add(state, result);
             }
 

--- a/src/Stateless/StateRepresentation.Async.cs
+++ b/src/Stateless/StateRepresentation.Async.cs
@@ -46,29 +46,29 @@ namespace Stateless
             public async Task ActivateAsync()
             {
                 if (_superstate != null)
-                    await _superstate.ActivateAsync().ConfigureAwait(false);
+                    await _superstate.ActivateAsync().ConfigureAwait(_retainSynchronizationContext);
 
-                await ExecuteActivationActionsAsync().ConfigureAwait(false);
+                await ExecuteActivationActionsAsync().ConfigureAwait(_retainSynchronizationContext);
             }
 
             public async Task DeactivateAsync()
             {
-                await ExecuteDeactivationActionsAsync().ConfigureAwait(false);
+                await ExecuteDeactivationActionsAsync().ConfigureAwait(_retainSynchronizationContext);
 
                 if (_superstate != null)
-                    await _superstate.DeactivateAsync().ConfigureAwait(false);
+                    await _superstate.DeactivateAsync().ConfigureAwait(_retainSynchronizationContext);
             }
 
             async Task ExecuteActivationActionsAsync()
             {
                 foreach (var action in ActivateActions)
-                    await action.ExecuteAsync().ConfigureAwait(false);
+                    await action.ExecuteAsync().ConfigureAwait(_retainSynchronizationContext);
             }
 
             async Task ExecuteDeactivationActionsAsync()
             {
                 foreach (var action in DeactivateActions)
-                    await action.ExecuteAsync().ConfigureAwait(false);
+                    await action.ExecuteAsync().ConfigureAwait(_retainSynchronizationContext);
             }
 
 
@@ -76,14 +76,14 @@ namespace Stateless
             {
                 if (transition.IsReentry)
                 {
-                    await ExecuteEntryActionsAsync(transition, entryArgs).ConfigureAwait(false);
+                    await ExecuteEntryActionsAsync(transition, entryArgs).ConfigureAwait(_retainSynchronizationContext);
                 }
                 else if (!Includes(transition.Source))
                 {
                     if (_superstate != null && !(transition is InitialTransition))
-                        await _superstate.EnterAsync(transition, entryArgs).ConfigureAwait(false);
+                        await _superstate.EnterAsync(transition, entryArgs).ConfigureAwait(_retainSynchronizationContext);
 
-                    await ExecuteEntryActionsAsync(transition, entryArgs).ConfigureAwait(false);
+                    await ExecuteEntryActionsAsync(transition, entryArgs).ConfigureAwait(_retainSynchronizationContext);
                 }
             }
             
@@ -91,11 +91,11 @@ namespace Stateless
             {
                 if (transition.IsReentry)
                 {
-                    await ExecuteExitActionsAsync(transition).ConfigureAwait(false);
+                    await ExecuteExitActionsAsync(transition).ConfigureAwait(_retainSynchronizationContext);
                 }
                 else if (!Includes(transition.Destination))
                 {
-                    await ExecuteExitActionsAsync(transition).ConfigureAwait(false);
+                    await ExecuteExitActionsAsync(transition).ConfigureAwait(_retainSynchronizationContext);
 
                     // Must check if there is a superstate, and if we are leaving that superstate
                     if (_superstate != null)
@@ -106,13 +106,13 @@ namespace Stateless
                             // Destination state is within the list, exit first superstate only if it is NOT the first
                             if (!_superstate.UnderlyingState.Equals(transition.Destination))
                             {
-                                return await _superstate.ExitAsync(transition).ConfigureAwait(false);
+                                return await _superstate.ExitAsync(transition).ConfigureAwait(_retainSynchronizationContext);
                             }
                         }
                         else
                         {
                             // Exit the superstate as well
-                            return await _superstate.ExitAsync(transition).ConfigureAwait(false);
+                            return await _superstate.ExitAsync(transition).ConfigureAwait(_retainSynchronizationContext);
                         }
                     }
                 }
@@ -122,13 +122,13 @@ namespace Stateless
             async Task ExecuteEntryActionsAsync(Transition transition, object[] entryArgs)
             {
                 foreach (var action in EntryActions)
-                    await action.ExecuteAsync(transition, entryArgs).ConfigureAwait(false);
+                    await action.ExecuteAsync(transition, entryArgs).ConfigureAwait(_retainSynchronizationContext);
             }
 
             async Task ExecuteExitActionsAsync(Transition transition)
             {
                 foreach (var action in ExitActions)
-                    await action.ExecuteAsync(transition).ConfigureAwait(false);
+                    await action.ExecuteAsync(transition).ConfigureAwait(_retainSynchronizationContext);
             }
         }
     }

--- a/src/Stateless/StateRepresentation.cs
+++ b/src/Stateless/StateRepresentation.cs
@@ -9,6 +9,7 @@ namespace Stateless
         internal partial class StateRepresentation
         {
             readonly TState _state;
+            private readonly bool _retainSynchronizationContext;
 
             internal IDictionary<TTrigger, ICollection<TriggerBehaviour>> TriggerBehaviours { get; } = new Dictionary<TTrigger, ICollection<TriggerBehaviour>>();
             internal ICollection<EntryActionBehavior> EntryActions { get; } = new List<EntryActionBehavior>();
@@ -21,9 +22,10 @@ namespace Stateless
             readonly ICollection<StateRepresentation> _substates = new List<StateRepresentation>();
             public TState InitialTransitionTarget { get; private set; } = default;
 
-            public StateRepresentation(TState state)
+            public StateRepresentation(TState state, bool retainSynchronizationContext = false)
             {
                 _state = state;
+                _retainSynchronizationContext = retainSynchronizationContext;
             }
 
             internal ICollection<StateRepresentation> GetSubstates()

--- a/src/Stateless/StateRepresentation.cs
+++ b/src/Stateless/StateRepresentation.cs
@@ -22,7 +22,7 @@ namespace Stateless
             readonly ICollection<StateRepresentation> _substates = new List<StateRepresentation>();
             public TState InitialTransitionTarget { get; private set; } = default;
 
-            public StateRepresentation(TState state, bool retainSynchronizationContext = false)
+            public StateRepresentation(TState state, bool retainSynchronizationContext)
             {
                 _state = state;
                 _retainSynchronizationContext = retainSynchronizationContext;

--- a/src/Stateless/StateRepresentation.cs
+++ b/src/Stateless/StateRepresentation.cs
@@ -22,7 +22,7 @@ namespace Stateless
             readonly ICollection<StateRepresentation> _substates = new List<StateRepresentation>();
             public TState InitialTransitionTarget { get; private set; } = default;
 
-            public StateRepresentation(TState state, bool retainSynchronizationContext)
+            public StateRepresentation(TState state, bool retainSynchronizationContext = false)
             {
                 _state = state;
                 _retainSynchronizationContext = retainSynchronizationContext;

--- a/test/Stateless.Tests/SynchronizationContextFixture.cs
+++ b/test/Stateless.Tests/SynchronizationContextFixture.cs
@@ -24,10 +24,15 @@ public class SynchronizationContextFixture
         SynchronizationContext.SetSynchronizationContext(_syncContext);
     }
     
-    private async Task CaptureSyncContext()
+    private async Task CaptureSyncContextAsync()
     {
         _capturedSyncContext.Add(SynchronizationContext.Current);
         await Task.Delay(TimeSpan.FromMilliseconds(1)).ConfigureAwait(false);
+    }
+    
+    private void CaptureSyncContext()
+    {
+        _capturedSyncContext.Add(SynchronizationContext.Current);
     }
     
     private void AssertSyncContextAlwaysRetained(int? numberOfExpectedCalls = null)
@@ -43,7 +48,7 @@ public class SynchronizationContextFixture
     public async Task Ensure_XUnit_is_using_SyncContext()
     {
         SetSyncContext();
-        await CaptureSyncContext();
+        await CaptureSyncContextAsync();
         AssertSyncContextAlwaysRetained();
     }
     
@@ -70,7 +75,7 @@ public class SynchronizationContextFixture
         SetSyncContext();
         var sm = GetSut();
         sm.Configure(State.A)
-            .OnActivateAsync(CaptureSyncContext);
+            .OnActivateAsync(CaptureSyncContextAsync);
         
         // ACT
         await sm.ActivateAsync();
@@ -86,11 +91,11 @@ public class SynchronizationContextFixture
         SetSyncContext();
         var sm = GetSut();
         sm.Configure(State.A)
-            .OnActivateAsync(CaptureSyncContext)
+            .OnActivateAsync(CaptureSyncContextAsync)
             .SubstateOf(State.B);
             ;
         sm.Configure(State.B)
-            .OnActivateAsync(CaptureSyncContext);
+            .OnActivateAsync(CaptureSyncContextAsync);
         
         // ACT
         await sm.ActivateAsync();
@@ -106,11 +111,11 @@ public class SynchronizationContextFixture
         SetSyncContext();
         var sm = GetSut();
         sm.Configure(State.A)
-            .OnDeactivateAsync(CaptureSyncContext)
+            .OnDeactivateAsync(CaptureSyncContextAsync)
             .SubstateOf(State.B);
             ;
         sm.Configure(State.B)
-            .OnDeactivateAsync(CaptureSyncContext);
+            .OnDeactivateAsync(CaptureSyncContextAsync);
         
         // ACT
         await sm.DeactivateAsync();
@@ -126,9 +131,9 @@ public class SynchronizationContextFixture
         SetSyncContext();
         var sm = GetSut();
         sm.Configure(State.A)
-            .OnActivateAsync(CaptureSyncContext)
-            .OnActivateAsync(CaptureSyncContext)
-            .OnActivateAsync(CaptureSyncContext);
+            .OnActivateAsync(CaptureSyncContextAsync)
+            .OnActivateAsync(CaptureSyncContextAsync)
+            .OnActivateAsync(CaptureSyncContextAsync);
         
         // ACT
         await sm.ActivateAsync();
@@ -144,9 +149,9 @@ public class SynchronizationContextFixture
         SetSyncContext();
         var sm = GetSut();
         sm.Configure(State.A)
-            .OnDeactivateAsync(CaptureSyncContext)
-            .OnDeactivateAsync(CaptureSyncContext)
-            .OnDeactivateAsync(CaptureSyncContext);
+            .OnDeactivateAsync(CaptureSyncContextAsync)
+            .OnDeactivateAsync(CaptureSyncContextAsync)
+            .OnDeactivateAsync(CaptureSyncContextAsync);
         
         // ACT
         await sm.DeactivateAsync();
@@ -163,7 +168,7 @@ public class SynchronizationContextFixture
         var sm = GetSut();
         sm.Configure(State.A).Permit(Trigger.X, State.B);
         sm.Configure(State.B)
-            .OnEntryAsync(CaptureSyncContext);
+            .OnEntryAsync(CaptureSyncContextAsync);
         
         // ACT
         await sm.FireAsync(Trigger.X);
@@ -180,9 +185,9 @@ public class SynchronizationContextFixture
         var sm = GetSut();
         sm.Configure(State.A).Permit(Trigger.X, State.B);
         sm.Configure(State.B)
-            .OnEntryAsync(CaptureSyncContext)
-            .OnEntryAsync(CaptureSyncContext)
-            .OnEntryAsync(CaptureSyncContext);
+            .OnEntryAsync(CaptureSyncContextAsync)
+            .OnEntryAsync(CaptureSyncContextAsync)
+            .OnEntryAsync(CaptureSyncContextAsync);
         
         // ACT
         await sm.FireAsync(Trigger.X);
@@ -199,9 +204,9 @@ public class SynchronizationContextFixture
         var sm = GetSut();
         sm.Configure(State.A)
             .Permit(Trigger.X, State.B)
-            .OnExitAsync(CaptureSyncContext)
-            .OnExitAsync(CaptureSyncContext)
-            .OnExitAsync(CaptureSyncContext);
+            .OnExitAsync(CaptureSyncContextAsync)
+            .OnExitAsync(CaptureSyncContextAsync)
+            .OnExitAsync(CaptureSyncContextAsync);
         sm.Configure(State.B);
         
         // ACT
@@ -218,13 +223,13 @@ public class SynchronizationContextFixture
         SetSyncContext();
         var sm = GetSut(State.B);
         sm.Configure(State.A)
-            .OnExitAsync(CaptureSyncContext)
+            .OnExitAsync(CaptureSyncContextAsync)
             ;
         
         sm.Configure(State.B)
             .SubstateOf(State.A)
             .Permit(Trigger.X, State.C)
-            .OnExitAsync(CaptureSyncContext)
+            .OnExitAsync(CaptureSyncContextAsync)
             ;
         sm.Configure(State.C);
         
@@ -245,12 +250,12 @@ public class SynchronizationContextFixture
 
         sm.Configure(State.B)
             .SubstateOf(State.A)
-            .OnExitAsync(CaptureSyncContext);
+            .OnExitAsync(CaptureSyncContextAsync);
         
         sm.Configure(State.C)
             .SubstateOf(State.B)
             .Permit(Trigger.X, State.A)
-            .OnExitAsync(CaptureSyncContext);
+            .OnExitAsync(CaptureSyncContextAsync);
         
         // ACT
         await sm.FireAsync(Trigger.X);
@@ -266,8 +271,8 @@ public class SynchronizationContextFixture
         SetSyncContext();
         var sm = GetSut();
         sm.Configure(State.A).PermitReentry(Trigger.X)
-            .OnEntryAsync(CaptureSyncContext)
-            .OnEntryAsync(CaptureSyncContext);
+            .OnEntryAsync(CaptureSyncContextAsync)
+            .OnEntryAsync(CaptureSyncContextAsync);
         
         // ACT
         await sm.FireAsync(Trigger.X);
@@ -283,8 +288,8 @@ public class SynchronizationContextFixture
         SetSyncContext();
         var sm = GetSut();
         sm.Configure(State.A).PermitReentry(Trigger.X)
-            .OnExitAsync(CaptureSyncContext)
-            .OnExitAsync(CaptureSyncContext);
+            .OnExitAsync(CaptureSyncContextAsync)
+            .OnExitAsync(CaptureSyncContextAsync);
         
         // ACT
         await sm.FireAsync(Trigger.X);
@@ -302,13 +307,13 @@ public class SynchronizationContextFixture
         sm.Configure(State.A)
             .InternalTransitionAsync(Trigger.X, async () =>
             {
-                await CaptureSyncContext();
+                await CaptureSyncContextAsync();
                 await sm.FireAsync(Trigger.Y);
             })
             .Permit(Trigger.Y, State.B)
             ;
         sm.Configure(State.B)
-            .OnEntryAsync(CaptureSyncContext);
+            .OnEntryAsync(CaptureSyncContextAsync);
         
         // ACT
         await sm.FireAsync(Trigger.X);
@@ -328,14 +333,30 @@ public class SynchronizationContextFixture
 
         sm.Configure(State.B);
 
-        sm.OnTransitionedAsync(_ => CaptureSyncContext());
-        sm.OnTransitionedAsync(_ => CaptureSyncContext());
-        sm.OnTransitionedAsync(_ => CaptureSyncContext());
+        sm.OnTransitionedAsync(_ => CaptureSyncContextAsync());
+        sm.OnTransitionedAsync(_ => CaptureSyncContextAsync());
+        sm.OnTransitionedAsync(_ => CaptureSyncContextAsync());
         
         // ACT
         await sm.FireAsync(Trigger.X);
         
         // ASSERT
         AssertSyncContextAlwaysRetained(3);
+    }
+    
+    [Fact]
+    public async Task InternalTransition_firing_a_sync_action_should_retain_SyncContext()
+    {
+        // ARRANGE
+        SetSyncContext();
+        var sm = GetSut();
+        sm.Configure(State.A)
+            .InternalTransition(Trigger.X, CaptureSyncContext);
+        
+        // ACT
+        await sm.FireAsync(Trigger.X);
+        
+        // ASSERT
+        AssertSyncContextAlwaysRetained(1);
     }
 }

--- a/test/Stateless.Tests/SynchronizationContextFixture.cs
+++ b/test/Stateless.Tests/SynchronizationContextFixture.cs
@@ -82,22 +82,6 @@ public class SynchronizationContextFixture
     }
 
     [Fact]
-    public async Task Single_activation_should_retain_SyncContext()
-    {
-        // ARRANGE
-        SetSyncContext();
-        var sm = GetSut();
-        sm.Configure(State.A)
-            .OnActivateAsync(CaptureThenLoseSyncContext);
-        
-        // ACT
-        await sm.ActivateAsync();
-        
-        // ASSERT
-        AssertSyncContextAlwaysRetained(1);
-    }
-    
-    [Fact]
     public async Task Activation_of_state_with_superstate_should_retain_SyncContext()
     {
         // ARRANGE
@@ -173,23 +157,6 @@ public class SynchronizationContextFixture
         AssertSyncContextAlwaysRetained(3);
     }
     
-    [Fact]
-    public async Task OnEntry_should_retain_SyncContext()
-    {
-        // ARRANGE
-        SetSyncContext();
-        var sm = GetSut();
-        sm.Configure(State.A).Permit(Trigger.X, State.B);
-        sm.Configure(State.B)
-            .OnEntryAsync(CaptureThenLoseSyncContext);
-        
-        // ACT
-        await sm.FireAsync(Trigger.X);
-        
-        // ASSERT
-        AssertSyncContextAlwaysRetained(1);
-    }
-
     [Fact]
     public async Task Multiple_OnEntry_should_retain_SyncContext()
     {

--- a/test/Stateless.Tests/SynchronizationContextFixture.cs
+++ b/test/Stateless.Tests/SynchronizationContextFixture.cs
@@ -1,0 +1,341 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Stateless.Tests;
+
+public class SynchronizationContextFixture
+{
+    private readonly MaxConcurrencySyncContext _syncContext = new(3);
+    private readonly List<SynchronizationContext> _capturedSyncContext = new();
+    
+    private StateMachine<State, Trigger> GetSut(State initialState = State.A)
+    {
+        var sm = new StateMachine<State, Trigger>(initialState, FiringMode.Queued);
+        sm.RetainSynchronizationContext = true;
+        return sm;
+    }
+    
+    private void SetSyncContext()
+    {
+        SynchronizationContext.SetSynchronizationContext(_syncContext);
+    }
+    
+    private async Task CaptureSyncContext()
+    {
+        _capturedSyncContext.Add(SynchronizationContext.Current);
+        await Task.Delay(TimeSpan.FromMilliseconds(1)).ConfigureAwait(false);
+    }
+    
+    private void AssertSyncContextAlwaysRetained(int? numberOfExpectedCalls = null)
+    {
+        Assert.NotEmpty(_capturedSyncContext);
+        if (numberOfExpectedCalls is not null)
+            Assert.Equal(numberOfExpectedCalls, _capturedSyncContext.Count);
+        
+        Assert.All(_capturedSyncContext, actual => Assert.Equal(_syncContext, actual));
+    }
+
+    [Fact]
+    public async Task Ensure_XUnit_is_using_SyncContext()
+    {
+        SetSyncContext();
+        await CaptureSyncContext();
+        AssertSyncContextAlwaysRetained();
+    }
+    
+    [Fact]
+    public async Task ConfigureAwait_false_should_lose_sync_context()
+    {
+        SetSyncContext();
+        await Task.Delay(TimeSpan.FromMilliseconds(1)).ConfigureAwait(false);
+        Assert.NotEqual(_syncContext, SynchronizationContext.Current);
+    }
+
+    [Fact]
+    public async Task ConfigureAwait_true_should_retain_sync_context()
+    {
+        SetSyncContext();
+        await Task.Delay(TimeSpan.FromMilliseconds(1)).ConfigureAwait(true);
+        Assert.Equal(_syncContext, SynchronizationContext.Current);
+    }
+
+    [Fact]
+    public async Task Single_activation_should_retain_SyncContext()
+    {
+        // ARRANGE
+        SetSyncContext();
+        var sm = GetSut();
+        sm.Configure(State.A)
+            .OnActivateAsync(CaptureSyncContext);
+        
+        // ACT
+        await sm.ActivateAsync();
+        
+        // ASSERT
+        AssertSyncContextAlwaysRetained(1);
+    }
+    
+    [Fact]
+    public async Task Activation_of_state_with_superstate_should_retain_SyncContext()
+    {
+        // ARRANGE
+        SetSyncContext();
+        var sm = GetSut();
+        sm.Configure(State.A)
+            .OnActivateAsync(CaptureSyncContext)
+            .SubstateOf(State.B);
+            ;
+        sm.Configure(State.B)
+            .OnActivateAsync(CaptureSyncContext);
+        
+        // ACT
+        await sm.ActivateAsync();
+        
+        // ASSERT
+        AssertSyncContextAlwaysRetained(2);
+    }
+    
+    [Fact]
+    public async Task Deactivation_of_state_with_superstate_should_retain_SyncContext()
+    {
+        // ARRANGE
+        SetSyncContext();
+        var sm = GetSut();
+        sm.Configure(State.A)
+            .OnDeactivateAsync(CaptureSyncContext)
+            .SubstateOf(State.B);
+            ;
+        sm.Configure(State.B)
+            .OnDeactivateAsync(CaptureSyncContext);
+        
+        // ACT
+        await sm.DeactivateAsync();
+        
+        // ASSERT
+        AssertSyncContextAlwaysRetained(2);
+    }
+    
+    [Fact]
+    public async Task Multiple_activations_should_retain_SyncContext()
+    {
+        // ARRANGE
+        SetSyncContext();
+        var sm = GetSut();
+        sm.Configure(State.A)
+            .OnActivateAsync(CaptureSyncContext)
+            .OnActivateAsync(CaptureSyncContext)
+            .OnActivateAsync(CaptureSyncContext);
+        
+        // ACT
+        await sm.ActivateAsync();
+        
+        // ASSERT
+        AssertSyncContextAlwaysRetained(3);
+    }
+    
+    [Fact]
+    public async Task Multiple_Deactivations_should_retain_SyncContext()
+    {
+        // ARRANGE
+        SetSyncContext();
+        var sm = GetSut();
+        sm.Configure(State.A)
+            .OnDeactivateAsync(CaptureSyncContext)
+            .OnDeactivateAsync(CaptureSyncContext)
+            .OnDeactivateAsync(CaptureSyncContext);
+        
+        // ACT
+        await sm.DeactivateAsync();
+        
+        // ASSERT
+        AssertSyncContextAlwaysRetained(3);
+    }
+    
+    [Fact]
+    public async Task OnEntry_should_retain_SyncContext()
+    {
+        // ARRANGE
+        SetSyncContext();
+        var sm = GetSut();
+        sm.Configure(State.A).Permit(Trigger.X, State.B);
+        sm.Configure(State.B)
+            .OnEntryAsync(CaptureSyncContext);
+        
+        // ACT
+        await sm.FireAsync(Trigger.X);
+        
+        // ASSERT
+        AssertSyncContextAlwaysRetained(1);
+    }
+
+    [Fact]
+    public async Task Multiple_OnEntry_should_retain_SyncContext()
+    {
+        // ARRANGE
+        SetSyncContext();
+        var sm = GetSut();
+        sm.Configure(State.A).Permit(Trigger.X, State.B);
+        sm.Configure(State.B)
+            .OnEntryAsync(CaptureSyncContext)
+            .OnEntryAsync(CaptureSyncContext)
+            .OnEntryAsync(CaptureSyncContext);
+        
+        // ACT
+        await sm.FireAsync(Trigger.X);
+        
+        // ASSERT
+        AssertSyncContextAlwaysRetained(3);
+    } 
+    
+    [Fact]
+    public async Task Multiple_OnExit_should_retain_SyncContext()
+    {
+        // ARRANGE
+        SetSyncContext();
+        var sm = GetSut();
+        sm.Configure(State.A)
+            .Permit(Trigger.X, State.B)
+            .OnExitAsync(CaptureSyncContext)
+            .OnExitAsync(CaptureSyncContext)
+            .OnExitAsync(CaptureSyncContext);
+        sm.Configure(State.B);
+        
+        // ACT
+        await sm.FireAsync(Trigger.X);
+        
+        // ASSERT
+        AssertSyncContextAlwaysRetained(3);
+    }
+    
+    [Fact]
+    public async Task OnExit_state_with_superstate_should_retain_SyncContext()
+    {
+        // ARRANGE
+        SetSyncContext();
+        var sm = GetSut(State.B);
+        sm.Configure(State.A)
+            .OnExitAsync(CaptureSyncContext)
+            ;
+        
+        sm.Configure(State.B)
+            .SubstateOf(State.A)
+            .Permit(Trigger.X, State.C)
+            .OnExitAsync(CaptureSyncContext)
+            ;
+        sm.Configure(State.C);
+        
+        // ACT
+        await sm.FireAsync(Trigger.X);
+        
+        // ASSERT
+        AssertSyncContextAlwaysRetained(2);
+    }
+    
+    [Fact]
+    public async Task OnExit_state_and_superstate_should_retain_SyncContext()
+    {
+        // ARRANGE
+        SetSyncContext();
+        var sm = GetSut(State.C);
+        sm.Configure(State.A);
+
+        sm.Configure(State.B)
+            .SubstateOf(State.A)
+            .OnExitAsync(CaptureSyncContext);
+        
+        sm.Configure(State.C)
+            .SubstateOf(State.B)
+            .Permit(Trigger.X, State.A)
+            .OnExitAsync(CaptureSyncContext);
+        
+        // ACT
+        await sm.FireAsync(Trigger.X);
+        
+        // ASSERT
+        AssertSyncContextAlwaysRetained(2);
+    }
+    
+    [Fact]
+    public async Task Multiple_OnEntry_on_Reentry_should_retain_SyncContext()
+    {
+        // ARRANGE
+        SetSyncContext();
+        var sm = GetSut();
+        sm.Configure(State.A).PermitReentry(Trigger.X)
+            .OnEntryAsync(CaptureSyncContext)
+            .OnEntryAsync(CaptureSyncContext);
+        
+        // ACT
+        await sm.FireAsync(Trigger.X);
+        
+        // ASSERT
+        AssertSyncContextAlwaysRetained(2);
+    }
+    
+    [Fact]
+    public async Task Multiple_OnExit_on_Reentry_should_retain_SyncContext()
+    {
+        // ARRANGE
+        SetSyncContext();
+        var sm = GetSut();
+        sm.Configure(State.A).PermitReentry(Trigger.X)
+            .OnExitAsync(CaptureSyncContext)
+            .OnExitAsync(CaptureSyncContext);
+        
+        // ACT
+        await sm.FireAsync(Trigger.X);
+        
+        // ASSERT
+        AssertSyncContextAlwaysRetained(2);
+    }
+
+    [Fact]
+    public async Task Trigger_firing_another_Trigger_should_retain_SyncContext()
+    {
+        // ARRANGE
+        SetSyncContext();
+        var sm = GetSut();
+        sm.Configure(State.A)
+            .InternalTransitionAsync(Trigger.X, async () =>
+            {
+                await CaptureSyncContext();
+                await sm.FireAsync(Trigger.Y);
+            })
+            .Permit(Trigger.Y, State.B)
+            ;
+        sm.Configure(State.B)
+            .OnEntryAsync(CaptureSyncContext);
+        
+        // ACT
+        await sm.FireAsync(Trigger.X);
+        
+        // ASSERT
+        AssertSyncContextAlwaysRetained(2);
+    }
+    
+    [Fact]
+    public async Task OnTransition_should_retain_SyncContext()
+    {
+        // ARRANGE
+        SetSyncContext();
+        var sm = GetSut();
+        sm.Configure(State.A)
+            .Permit(Trigger.X, State.B);
+
+        sm.Configure(State.B);
+
+        sm.OnTransitionedAsync(_ => CaptureSyncContext());
+        sm.OnTransitionedAsync(_ => CaptureSyncContext());
+        sm.OnTransitionedAsync(_ => CaptureSyncContext());
+        
+        // ACT
+        await sm.FireAsync(Trigger.X);
+        
+        // ASSERT
+        AssertSyncContextAlwaysRetained(3);
+    }
+}

--- a/test/Stateless.Tests/SynchronizationContextFixture.cs
+++ b/test/Stateless.Tests/SynchronizationContextFixture.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;


### PR DESCRIPTION
It is recommended to use ConfigureAwait(false) and Task.Run(...) in library code. However, both of these statements lose the SynchronizationContext. There are certain circumstances where it is critical that this is retained, such as within Microsoft Orleans Grains.
I have added a new optional property called _RetainSynchronizationContext_ which defaults to the current behaviour of _false_. Setting it to _true_:

- changes all ConfigureAwait calls to true
- changes the Task.Run call (which uses the ThreadPool context) to the equivalent Task.Factory.New call, except with the TaskScheduler changed to use the SynchronizationContext.

I wrote unit tests to hit every ConfigureAwait call to prove they were losing the SynchronizationContext before implementing the flag. (I know right, actual red-green development!)

Questions and comments are most welcome. I've tried to make the code and unit tests readable but if there is further clarity that can be achieved, then please suggest away.