### PR TITLE
Update example apps to net6.0

### DIFF
--- a/example/BugTrackerExample/BugTrackerExample.csproj
+++ b/example/BugTrackerExample/BugTrackerExample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>BugTrackerExample</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>BugTrackerExample</PackageId>

--- a/example/JsonExample/JsonExample.csproj
+++ b/example/JsonExample/JsonExample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/example/OnOffExample/OnOffExample.csproj
+++ b/example/OnOffExample/OnOffExample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>OnOffExample</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>OnOffExample</PackageId>

--- a/example/TelephoneCallExample/TelephoneCallExample.csproj
+++ b/example/TelephoneCallExample/TelephoneCallExample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>TelephoneCallExample</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>TelephoneCallExample</PackageId>


### PR DESCRIPTION
netcoreapp2.1 apps have a known vulnerability, which my IDE is keen to point out every time I load the stateless solution. I see little harm in updating them to net6.0?