### PR TITLE
Remove redundant parentheses

### DIFF
--- a/example/JsonExample/Member.cs
+++ b/example/JsonExample/Member.cs
@@ -81,7 +81,7 @@ namespace JsonExample
 
         public bool Equals(Member anotherMember)
         {
-            return ((State == anotherMember.State) && (Name == anotherMember.Name));
+            return State == anotherMember.State && Name == anotherMember.Name;
         }
     }
 

--- a/src/Stateless/Graph/StateGraph.cs
+++ b/src/Stateless/Graph/StateGraph.cs
@@ -69,7 +69,7 @@ namespace Stateless.Graph
             // Next process all non-cluster states
             foreach (var state in States.Values)
             {
-                if ((state is SuperState) || (state is Decision) || (state.SuperState != null))
+                if (state is SuperState || state is Decision || state.SuperState != null)
                     continue;
                 dirgraphText += style.FormatOneState(state).Replace("\n", System.Environment.NewLine);
             }
@@ -115,8 +115,8 @@ namespace Stateless.Graph
                         // Does it have any incoming transitions that specify that trigger?
                         foreach (var transit in state.Arriving)
                         {
-                            if ((transit.ExecuteEntryExitActions)
-                                && (transit.Trigger.UnderlyingTrigger.ToString() == entryAction.FromTrigger))
+                            if (transit.ExecuteEntryExitActions
+                                && transit.Trigger.UnderlyingTrigger.ToString() == entryAction.FromTrigger)
                             {
                                 transit.DestinationEntryActions.Add(entryAction);
                             }
@@ -208,7 +208,7 @@ namespace Stateless.Graph
         /// <param name="machineInfo"></param>
         void AddSuperstates(StateMachineInfo machineInfo)
         {
-            foreach (var stateInfo in machineInfo.States.Where(sc => (sc.Substates?.Count() > 0) && (sc.Superstate == null)))
+            foreach (var stateInfo in machineInfo.States.Where(sc => sc.Substates?.Count() > 0 && sc.Superstate == null))
             {
                 SuperState state = new SuperState(stateInfo);
                 States[stateInfo.UnderlyingState.ToString()] = state;

--- a/src/Stateless/Graph/UmlDotGraphStyle.cs
+++ b/src/Stateless/Graph/UmlDotGraphStyle.cs
@@ -33,7 +33,7 @@ namespace Stateless.Graph
 
             StringBuilder label = new StringBuilder($"{sourceName}");
 
-            if ((stateInfo.EntryActions.Count > 0) || (stateInfo.ExitActions.Count > 0))
+            if (stateInfo.EntryActions.Count > 0 || stateInfo.ExitActions.Count > 0)
             {
                 label.Append("\\n----------");
                 label.Append(string.Concat(stateInfo.EntryActions.Select(act => "\\nentry / " + act)));
@@ -62,7 +62,7 @@ namespace Stateless.Graph
         /// <returns></returns>
         public override string FormatOneState(State state)
         {
-            if ((state.EntryActions.Count == 0) && (state.ExitActions.Count == 0))
+            if (state.EntryActions.Count == 0 && state.ExitActions.Count == 0)
                 return $"\"{state.StateName}\" [label=\"{state.StateName}\"];\n";
 
             string f = $"\"{state.StateName}\" [label=\"{state.StateName}|";

--- a/src/Stateless/Reflection/FixedTransitionInfo.cs
+++ b/src/Stateless/Reflection/FixedTransitionInfo.cs
@@ -14,7 +14,7 @@ namespace Stateless.Reflection
             {
                 Trigger = new TriggerInfo(behaviour.Trigger),
                 DestinationState = destinationStateInfo,
-                GuardConditionsMethodDescriptions = (behaviour.Guard == null)
+                GuardConditionsMethodDescriptions = behaviour.Guard == null
                     ? new List<InvocationInfo>() : behaviour.Guard.Conditions.Select(c => c.MethodDescription)
             };
 

--- a/src/Stateless/Reflection/IgnoredTransitionInfo.cs
+++ b/src/Stateless/Reflection/IgnoredTransitionInfo.cs
@@ -13,7 +13,7 @@ namespace Stateless.Reflection
             var transition = new IgnoredTransitionInfo
             {
                 Trigger = new TriggerInfo(behaviour.Trigger),
-                GuardConditionsMethodDescriptions = (behaviour.Guard == null)
+                GuardConditionsMethodDescriptions = behaviour.Guard == null
                     ? new List<InvocationInfo>() : behaviour.Guard.Conditions.Select(c => c.MethodDescription)
             };
 

--- a/src/Stateless/Reflection/InvocationInfo.cs
+++ b/src/Stateless/Reflection/InvocationInfo.cs
@@ -72,6 +72,6 @@ namespace Stateless.Reflection
         /// <summary>
         /// Returns true if the method is invoked asynchronously.
         /// </summary>
-        public bool IsAsync => (_timing == Timing.Asynchronous);
+        public bool IsAsync => _timing == Timing.Asynchronous;
     }
 }

--- a/src/Stateless/Reflection/StateInfo.cs
+++ b/src/Stateless/Reflection/StateInfo.cs
@@ -51,18 +51,18 @@ namespace Stateless.Reflection
             foreach (var triggerBehaviours in stateRepresentation.TriggerBehaviours)
             {
                 // First add all the deterministic transitions
-                foreach (var item in triggerBehaviours.Value.Where(behaviour => (behaviour is StateMachine<TState, TTrigger>.TransitioningTriggerBehaviour)))
+                foreach (var item in triggerBehaviours.Value.Where(behaviour => behaviour is StateMachine<TState, TTrigger>.TransitioningTriggerBehaviour))
                 {
                     var destinationInfo = lookupState(((StateMachine<TState, TTrigger>.TransitioningTriggerBehaviour)item).Destination);
                     fixedTransitions.Add(FixedTransitionInfo.Create(item, destinationInfo));
                 }
-                foreach (var item in triggerBehaviours.Value.Where(behaviour => (behaviour is StateMachine<TState, TTrigger>.ReentryTriggerBehaviour)))
+                foreach (var item in triggerBehaviours.Value.Where(behaviour => behaviour is StateMachine<TState, TTrigger>.ReentryTriggerBehaviour))
                 {
                     var destinationInfo = lookupState(((StateMachine<TState, TTrigger>.ReentryTriggerBehaviour)item).Destination);
                     fixedTransitions.Add(FixedTransitionInfo.Create(item, destinationInfo));
                 }
                 //Then add all the internal transitions
-                foreach (var item in triggerBehaviours.Value.Where(behaviour => (behaviour is StateMachine<TState, TTrigger>.InternalTriggerBehaviour)))
+                foreach (var item in triggerBehaviours.Value.Where(behaviour => behaviour is StateMachine<TState, TTrigger>.InternalTriggerBehaviour))
                 {
                     var destinationInfo = lookupState(stateRepresentation.UnderlyingState);
                     fixedTransitions.Add(FixedTransitionInfo.Create(item, destinationInfo));

--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -188,8 +188,8 @@ namespace Stateless
                         await HandleReentryTriggerAsync(args, representativeState, transition);
                         break;
                     }
-                case DynamicTriggerBehaviour _ when (result.Handler.ResultsInTransitionFrom(source, args, out var destination)):
-                case TransitioningTriggerBehaviour _ when (result.Handler.ResultsInTransitionFrom(source, args, out destination)):
+                case DynamicTriggerBehaviour _ when result.Handler.ResultsInTransitionFrom(source, args, out var destination):
+                case TransitioningTriggerBehaviour _ when result.Handler.ResultsInTransitionFrom(source, args, out destination):
                     {
                         // Handle transition, and set new state
                         var transition = new Transition(source, destination, trigger, args);

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -418,8 +418,8 @@ namespace Stateless
                     HandleReentryTrigger(args, representativeState, transition);
                     break;
                 }
-                case DynamicTriggerBehaviour _ when (result.Handler.ResultsInTransitionFrom(source, args, out var destination)):
-                case TransitioningTriggerBehaviour _ when (result.Handler.ResultsInTransitionFrom(source, args, out destination)):
+                case DynamicTriggerBehaviour _ when result.Handler.ResultsInTransitionFrom(source, args, out var destination):
+                case TransitioningTriggerBehaviour _ when result.Handler.ResultsInTransitionFrom(source, args, out destination):
                 {
                     // Handle transition, and set new state
                     var transition = new Transition(source, destination, trigger, args);

--- a/src/Stateless/StateRepresentation.cs
+++ b/src/Stateless/StateRepresentation.cs
@@ -47,8 +47,8 @@ namespace Stateless
             {
                 TriggerBehaviourResult superStateHandler = null;
 
-                bool handlerFound = (TryFindLocalHandler(trigger, args, out TriggerBehaviourResult localHandler) ||
-                                    (Superstate != null && Superstate.TryFindHandler(trigger, args, out superStateHandler)));
+                bool handlerFound = TryFindLocalHandler(trigger, args, out TriggerBehaviourResult localHandler) ||
+                                    (Superstate != null && Superstate.TryFindHandler(trigger, args, out superStateHandler));
 
                 // If no handler for super state, replace by local handler (see issue #398)
                 handler = superStateHandler ?? localHandler;

--- a/test/Stateless.Tests/ReflectionFixture.cs
+++ b/test/Stateless.Tests/ReflectionFixture.cs
@@ -587,7 +587,7 @@ namespace Stateless.Tests
             InvocationInfo method = methods.First();
 
             if (state == State.A)
-                Assert.Equal(prefix + body + ((timing == InvocationInfo.Timing.Asynchronous) ? "Async" : ""), method.Description);
+                Assert.Equal(prefix + body + (timing == InvocationInfo.Timing.Asynchronous ? "Async" : ""), method.Description);
             else if (state == State.B)
                 Assert.Equal(UserDescription + "B-" + body, method.Description);
             else if (state == State.C)
@@ -612,15 +612,15 @@ namespace Stateless.Tests
                 {
                     if (state == State.A)
                     {
-                        matches = (method.Description == (prefix + body
-                            + ((timing == InvocationInfo.Timing.Asynchronous) ? "Async" : "" + suffix)));
+                        matches = method.Description == prefix + body
+                                                               + (timing == InvocationInfo.Timing.Asynchronous ? "Async" : "" + suffix);
                     }
                     else if (state == State.B)
-                        matches = (UserDescription + "B-" + body + suffix == method.Description);
+                        matches = UserDescription + "B-" + body + suffix == method.Description;
                     else if (state == State.C)
-                        matches = (InvocationInfo.DefaultFunctionDescription == method.Description);
+                        matches = InvocationInfo.DefaultFunctionDescription == method.Description;
                     else if (state == State.D)
-                        matches = (UserDescription + "D-" + body + suffix == method.Description);
+                        matches = UserDescription + "D-" + body + suffix == method.Description;
                     //
                     if (matches)
                     {


### PR DESCRIPTION
There are many places where the code could be tidied up imho. Lots of c# recommendations and standard guidelines. Some are somewhat opinionated so I'm avoiding those for now! 😂 e.g. usage of the _var_ keyword.
Rider is happy to fix much of it automatically, which is nice. I thought I'd tackle some of the low-hanging fruit which is (hopefully!) unlikely to upset anyone.
