### PR TITLE
Change mechanism for losing the synchronization context

### DIFF
--- a/test/Stateless.Tests/SynchronizationContextFixture.cs
+++ b/test/Stateless.Tests/SynchronizationContextFixture.cs
@@ -42,7 +42,8 @@ public class SynchronizationContextFixture
 
     private async Task LoseSyncContext()
     {
-        await Task.Yield();
+        await Task.Run(() => { }).ConfigureAwait(false); // Switch synchronization context and continue
+        Assert.NotEqual(_customSynchronizationContext, SynchronizationContext.Current);
     }
 
     /// <summary>

--- a/test/Stateless.Tests/SynchronizationContextFixture.cs
+++ b/test/Stateless.Tests/SynchronizationContextFixture.cs
@@ -42,7 +42,7 @@ public class SynchronizationContextFixture
 
     private async Task LoseSyncContext()
     {
-        await Task.Delay(TimeSpan.FromMilliseconds(1)).ConfigureAwait(false); // Switch synchronization context and continue
+        await Task.Run(() => { }).ConfigureAwait(false); // Switch synchronization context and continue
         Assert.NotEqual(_customSynchronizationContext, SynchronizationContext.Current);
     }
 

--- a/test/Stateless.Tests/SynchronizationContextFixture.cs
+++ b/test/Stateless.Tests/SynchronizationContextFixture.cs
@@ -42,8 +42,7 @@ public class SynchronizationContextFixture
 
     private async Task LoseSyncContext()
     {
-        await Task.Run(() => { }).ConfigureAwait(false); // Switch synchronization context and continue
-        Assert.NotEqual(_customSynchronizationContext, SynchronizationContext.Current);
+        await Task.Yield();
     }
 
     /// <summary>


### PR DESCRIPTION
There is a race condition where Task.Delay could finish synchronously. Change to a mechanism that ensures a sync context change.
