### PR TITLE
fix: InternalTransitionAsyncIf guard parameters (update)

### DIFF
--- a/src/Stateless/InternalTriggerBehaviour.cs
+++ b/src/Stateless/InternalTriggerBehaviour.cs
@@ -20,8 +20,7 @@ namespace Stateless
                 return false;
             }
 
-
-            public class Sync: InternalTriggerBehaviour
+            public class Sync : InternalTriggerBehaviour
             {
                 public Action<Transition, object[]> InternalAction { get; }
 
@@ -29,6 +28,7 @@ namespace Stateless
                 {
                     InternalAction = internalAction;
                 }
+
                 public override void Execute(Transition transition, object[] args)
                 {
                     InternalAction(transition, args);
@@ -45,7 +45,13 @@ namespace Stateless
             {
                 readonly Func<Transition, object[], Task> InternalAction;
 
-                public Async(TTrigger trigger, Func<object[], bool> guard,Func<Transition, object[], Task> internalAction, string guardDescription = null) : base(trigger, new TransitionGuard(guard, guardDescription))
+                public Async(TTrigger trigger, Func<object[], bool> guard, Func<Transition, object[], Task> internalAction, string guardDescription = null) : base(trigger, new TransitionGuard(guard, guardDescription))
+                {
+                    InternalAction = internalAction;
+                }
+
+                [Obsolete]
+                public Async(TTrigger trigger, Func<bool> guard, Func<Transition, object[], Task> internalAction, string guardDescription = null) : base(trigger, new TransitionGuard(guard, guardDescription))
                 {
                     InternalAction = internalAction;
                 }
@@ -61,10 +67,7 @@ namespace Stateless
                 {
                     return InternalAction(transition, args);
                 }
-
             }
-
-
         }
     }
 }

--- a/src/Stateless/StateConfiguration.Async.cs
+++ b/src/Stateless/StateConfiguration.Async.cs
@@ -12,6 +12,98 @@ namespace Stateless
             /// <summary>
             /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
             /// </summary>
+            /// <typeparam name="TArg0"></typeparam>
+            /// <param name="trigger">The accepted trigger</param>
+            /// <param name="guard">Function that must return true in order for the trigger to be accepted.</param>
+            /// <param name="internalAction">The asynchronous action performed by the internal transition</param>
+            /// <returns></returns>
+            [Obsolete("Use InternalTransitionAsyncIf(TTrigger, Func<bool>, Func<Task>) instead.")]
+            public StateConfiguration InternalTransitionAsyncIf<TArg0>(TTrigger trigger, Func<bool> guard, Func<Transition, Task> internalAction)
+            {
+                if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
+
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger, guard, (t, args) => internalAction(t)));
+                return this;
+            }
+
+            /// <summary>
+            /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
+            /// </summary>
+            /// <typeparam name="TArg0"></typeparam>
+            /// <param name="trigger">The accepted trigger</param>
+            /// <param name="guard">Function that must return true in order for the trigger to be accepted.</param>
+            /// <param name="internalAction">The asynchronous action performed by the internal transition</param>
+            /// <returns></returns>
+            [Obsolete("Use InternalTransitionAsyncIf<TArg0>(TriggerWithParameters<TArg0>, Func<TArg0, bool>, Func<TArg0, Transition, Task>) instead.")]
+            public StateConfiguration InternalTransitionAsyncIf<TArg0>(TriggerWithParameters<TArg0> trigger, Func<bool> guard, Func<TArg0, Transition, Task> internalAction)
+            {
+                if (trigger == null) throw new ArgumentNullException(nameof(trigger));
+                if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
+
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger.Trigger, guard, (t, args) => internalAction(ParameterConversion.Unpack<TArg0>(args, 0), t)));
+                return this;
+            }
+
+            /// <summary>
+            /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
+            /// </summary>
+            /// <typeparam name="TArg0"></typeparam>
+            /// <typeparam name="TArg1"></typeparam>
+            /// <param name="trigger">The accepted trigger</param>
+            /// <param name="guard">Function that must return true in order for the trigger to be accepted.</param>
+            /// <param name="internalAction">The asynchronous action performed by the internal transition</param>
+            /// <returns></returns>
+            [Obsolete("Use InternalTransitionAsyncIf<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1>, Func<TArg0, TArg1, bool>, Func<TArg0, TArg1, Transition, Task>) instead.")]
+            public StateConfiguration InternalTransitionAsyncIf<TArg0, TArg1>(TriggerWithParameters<TArg0, TArg1> trigger, Func<bool> guard, Func<TArg0, TArg1, Transition, Task> internalAction)
+            {
+                if (trigger == null) throw new ArgumentNullException(nameof(trigger));
+                if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
+
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger.Trigger, guard, (t, args) => internalAction(
+                    ParameterConversion.Unpack<TArg0>(args, 0),
+                    ParameterConversion.Unpack<TArg1>(args, 1), t)));
+                return this;
+            }
+
+            /// <summary>
+            /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
+            /// </summary>
+            /// <typeparam name="TArg0"></typeparam>
+            /// <typeparam name="TArg1"></typeparam>
+            /// <typeparam name="TArg2"></typeparam>
+            /// <param name="trigger">The accepted trigger</param>
+            /// <param name="guard">Function that must return true in order for the trigger to be accepted.</param>
+            /// <param name="internalAction">The asynchronous action performed by the internal transition</param>
+            /// <returns></returns>
+            [Obsolete("Use InternalTransitionAsyncIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2>, Func<TArg0, TArg1, TArg2, bool>, Func<TArg0, TArg1, TArg2, Transition, Task>) instead.")]
+            public StateConfiguration InternalTransitionAsyncIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Func<bool> guard, Func<TArg0, TArg1, TArg2, Transition, Task> internalAction)
+            {
+                if (trigger == null) throw new ArgumentNullException(nameof(trigger));
+                if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
+
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger.Trigger, guard, (t, args) => internalAction(
+                    ParameterConversion.Unpack<TArg0>(args, 0),
+                    ParameterConversion.Unpack<TArg1>(args, 1),
+                    ParameterConversion.Unpack<TArg2>(args, 2), t)));
+                return this;
+            }
+
+            /// <summary>
+            /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
+            /// </summary>
+            /// <typeparam name="TArg0"></typeparam>
+            /// <param name="trigger">The accepted trigger</param>
+            /// <param name="internalAction">The asynchronous action performed by the internal transition</param>
+            /// <returns></returns>
+            [Obsolete("Use InternalTransitionAsync(TTrigger, Func<Transition, Task>) instead.")]
+            public StateConfiguration InternalTransitionAsync<TArg0>(TTrigger trigger, Func<Transition, Task> internalAction)
+            {
+                return InternalTransitionAsyncIf(trigger, () => true, internalAction);
+            }
+
+            /// <summary>
+            /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
+            /// </summary>
             /// <param name="trigger">The accepted trigger</param>
             /// <param name="guard">Function that must return true in order for the\r\n            /// trigger to be accepted.</param>
             /// <param name="internalAction">The asynchronous action performed by the internal transition</param>
@@ -98,7 +190,6 @@ namespace Stateless
                 return this;
             }
 
-            
             /// <summary>
             /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
             /// </summary>
@@ -203,7 +294,6 @@ namespace Stateless
                     (t, args) => entryAction(),
                     Reflection.InvocationInfo.Create(entryAction, entryActionDescription, Reflection.InvocationInfo.Timing.Asynchronous));
                 return this;
-
             }
 
             /// <summary>

--- a/test/Stateless.Tests/InternalTransitionAsyncFixture.cs
+++ b/test/Stateless.Tests/InternalTransitionAsyncFixture.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Stateless.Tests
@@ -97,7 +98,146 @@ namespace Stateless.Tests
             Assert.True(guardInvoked);
             Assert.True(callbackInvoked);
         }
-    
+
+        [Fact]
+        [Obsolete]
+        public async Task InternalTransitionAsyncIf_DeprecatedOverload_AllowGuardWithoutParameter()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var trigger = sm.SetTriggerParameters<int>(Trigger.X);
+            const int intParam = 5;
+            var guardInvoked = false;
+            var callbackInvoked = false;
+
+            sm.Configure(State.A)
+                .InternalTransitionAsyncIf(trigger, () =>
+                {
+                    guardInvoked = true;
+                    return true;
+                }, (i, transition) =>
+                {
+                    callbackInvoked = true;
+                    Assert.Equal(intParam, i);
+                    return Task.CompletedTask;
+                });
+
+            await sm.FireAsync(trigger, intParam);
+
+            Assert.True(guardInvoked);
+            Assert.True(callbackInvoked);
+        }
+
+        [Fact]
+        [Obsolete]
+        public async Task InternalTransitionAsyncIf_DeprecatedOverload_AllowGuardWithParameter()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var trigger = sm.SetTriggerParameters<int>(Trigger.X);
+            const int intParam = 5;
+            var guardInvoked = false;
+            var callbackInvoked = false;
+
+            sm.Configure(State.A)
+                .InternalTransitionAsyncIf(trigger, () =>
+                {
+                    guardInvoked = true;
+                    return true;
+                }, (i, transition) =>
+                {
+                    callbackInvoked = true;
+                    Assert.Equal(intParam, i);
+                    return Task.CompletedTask;
+                });
+
+            await sm.FireAsync(trigger, intParam);
+
+            Assert.True(guardInvoked);
+            Assert.True(callbackInvoked);
+        }
+
+        [Fact]
+        [Obsolete]
+        public async Task InternalTransitionAsyncIf_DeprecatedOverload_AllowGuardWithTwoParameters()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var trigger = sm.SetTriggerParameters<int, string>(Trigger.X);
+            const int intParam = 5;
+            const string stringParam = "5";
+            var guardInvoked = false;
+            var callbackInvoked = false;
+
+            sm.Configure(State.A)
+                .InternalTransitionAsyncIf(trigger, () =>
+                {
+                    guardInvoked = true;
+                    return true;
+                }, (i, s, transition) =>
+                {
+                    callbackInvoked = true;
+                    Assert.Equal(intParam, i);
+                    Assert.Equal(stringParam, s);
+                    return Task.CompletedTask;
+                });
+
+            await sm.FireAsync(trigger, intParam, stringParam);
+
+            Assert.True(guardInvoked);
+            Assert.True(callbackInvoked);
+        }
+
+        [Fact]
+        [Obsolete]
+        public async Task InternalTransitionAsyncIf_DeprecatedOverload_AllowGuardWithThreeParameters()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var trigger = sm.SetTriggerParameters<int, string, bool>(Trigger.X);
+            const int intParam = 5;
+            const string stringParam = "5";
+            const bool boolParam = true;
+            var guardInvoked = false;
+            var callbackInvoked = false;
+
+            sm.Configure(State.A)
+                .InternalTransitionAsyncIf(trigger, () =>
+                {
+                    guardInvoked = true;
+                    return true;
+                }, (i, s, b, transition) =>
+                {
+                    callbackInvoked = true;
+                    Assert.Equal(intParam, i);
+                    Assert.Equal(stringParam, s);
+                    Assert.Equal(boolParam, b);
+                    return Task.CompletedTask;
+                });
+
+            await sm.FireAsync(trigger, intParam, stringParam, boolParam);
+
+            Assert.True(guardInvoked);
+            Assert.True(callbackInvoked);
+        }
+
+        [Fact]
+        [Obsolete]
+        public async Task InternalTransitionAsyncIf_DeprecatedOverload_GuardExecutedOnlyOnce()
+        {
+            var guardCalls = 0;
+            var order = new Order
+            {
+                Status = OrderStatus.OrderPlaced,
+                PaymentStatus = PaymentStatus.Pending,
+            };
+            var stateMachine = new StateMachine<OrderStatus, OrderStateTrigger>(order.Status);
+            stateMachine.Configure(OrderStatus.OrderPlaced)
+                 .InternalTransitionAsyncIf<int>(OrderStateTrigger.PaymentCompleted,
+                       () => PreCondition(ref guardCalls),
+                       _ => ChangePaymentState(order, PaymentStatus.Completed));
+
+            await stateMachine.FireAsync(OrderStateTrigger.PaymentCompleted);
+
+            Assert.Equal(1, guardCalls);
+        }
+
         /// <summary>
         /// This unit test demonstrated bug report #417
         /// </summary>


### PR DESCRIPTION
Building on the work of @LipatovAlexander in PR #510 to address issue #303, this PR restores the original method signatures and marks them as `[Obsolete]`.