### PR TITLE
Bugfix: execute OnEntryFromAsync actions from FireAsync

### DIFF
--- a/src/Stateless/EntryActionBehaviour.cs
+++ b/src/Stateless/EntryActionBehaviour.cs
@@ -95,7 +95,10 @@ namespace Stateless
 
                 public override void Execute(Transition transition, object[] args)
                 {
-                    ExecuteAsync(transition, args);
+                    if (transition.Trigger.Equals(Trigger))
+                    {
+                        base.Execute(transition, args);
+                    }
                 }
 
                 public override Task ExecuteAsync(Transition transition, object[] args)

--- a/src/Stateless/EntryActionBehaviour.cs
+++ b/src/Stateless/EntryActionBehaviour.cs
@@ -95,13 +95,16 @@ namespace Stateless
 
                 public override void Execute(Transition transition, object[] args)
                 {
-                    if (transition.Trigger.Equals(Trigger))
-                        base.Execute(transition, args);
+                    ExecuteAsync(transition, args);
                 }
 
                 public override Task ExecuteAsync(Transition transition, object[] args)
                 {
-                    Execute(transition, args);
+                    if (transition.Trigger.Equals(Trigger))
+                    {
+                        return base.ExecuteAsync(transition, args);
+                    }
+
                     return TaskResult.Done;
                 }
             }

--- a/test/Stateless.Tests/AsyncActionsFixture.cs
+++ b/test/Stateless.Tests/AsyncActionsFixture.cs
@@ -474,6 +474,19 @@ namespace Stateless.Tests
         }
 
         [Fact]
+        public void OnEntryFromAsync_WhenTriggeredSynchronously_Throws()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A).Permit(Trigger.X, State.B);
+
+            sm.Configure(State.B)
+                .OnEntryFromAsync(Trigger.X, async () => await Task.Run(() => { }));
+
+            Assert.Throws<InvalidOperationException>(() => sm.Fire(Trigger.X));
+        }
+
+        [Fact]
         public async Task OnEntryFromAsync_WhenTriggered_InvokesAction()
         {
             bool wasInvoked = false;
@@ -491,6 +504,25 @@ namespace Stateless.Tests
         }
 
         [Fact]
+        public void OnEntryFromAsync_WhenEnteringByAnotherTriggerSynchronously_DoesNotThrow()
+        {
+            bool wasInvoked = false;
+
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+                .Permit(Trigger.X, State.B)
+                .Permit(Trigger.Y, State.B);
+
+            sm.Configure(State.B)
+                .OnEntryFromAsync(Trigger.X, async () => await Task.Run(() => { wasInvoked = true; }));
+
+            sm.Fire(Trigger.Y);
+
+            Assert.False(wasInvoked);
+        }
+
+        [Fact]
         public async Task OnEntryFromAsync_WhenEnteringByAnotherTrigger_InvokesAction()
         {
             bool wasInvoked = false;
@@ -499,7 +531,7 @@ namespace Stateless.Tests
 
             sm.Configure(State.A)
                 .Permit(Trigger.X, State.B)
-                .Permit(Trigger.Y, State.B); ;
+                .Permit(Trigger.Y, State.B);
 
             sm.Configure(State.B)
                 .OnEntryFromAsync(Trigger.X, async () => await Task.Run(() => { wasInvoked = true; }));

--- a/test/Stateless.Tests/AsyncActionsFixture.cs
+++ b/test/Stateless.Tests/AsyncActionsFixture.cs
@@ -472,6 +472,42 @@ namespace Stateless.Tests
 
             Assert.Equal(State.D, sm.State);
         }
+
+        [Fact]
+        public async Task OnEntryFromAsync_WhenTriggered_InvokesAction()
+        {
+            bool wasInvoked = false;
+
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A).Permit(Trigger.X, State.B);
+
+            sm.Configure(State.B)
+                .OnEntryFromAsync(Trigger.X, async () => await Task.Run(() => { wasInvoked = true; }));
+
+            await sm.FireAsync(Trigger.X);
+
+            Assert.True(wasInvoked);
+        }
+
+        [Fact]
+        public async Task OnEntryFromAsync_WhenEnteringByAnotherTrigger_InvokesAction()
+        {
+            bool wasInvoked = false;
+
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+                .Permit(Trigger.X, State.B)
+                .Permit(Trigger.Y, State.B); ;
+
+            sm.Configure(State.B)
+                .OnEntryFromAsync(Trigger.X, async () => await Task.Run(() => { wasInvoked = true; }));
+
+            await sm.FireAsync(Trigger.Y);
+
+            Assert.False(wasInvoked);
+        }
     }
 }
 


### PR DESCRIPTION
Proposed resolution for issue #531.

It seems we missed a mistake in #511 in class `AsyncFrom<TTriggerType>` such that a call to the async method `ExecuteAsync` would invoke the synchronous `Execute`, which intentionally throws an `InvalidOperationException`.

Additionally, the implementation of `AsyncFrom<TTriggerType>.ExecuteAsync(Transition, object[])` does not return the task queued to execute the entry action, and instead returns `Task.CompletedTask`, making it impossible for the caller to `await` completion of the entry action.

This PR changes `ExecuteAsync` so that it invokes the async action and returns the queued task.