### PR TITLE
Expose StateConfiguration.SaveTriggerConfiguration

### DIFF
--- a/src/Stateless/Reflection/DynamicTransitionInfo.cs
+++ b/src/Stateless/Reflection/DynamicTransitionInfo.cs
@@ -68,16 +68,7 @@ namespace Stateless.Reflection
         /// </summary>
         public DynamicStateInfos PossibleDestinationStates { get; private set; }
 
-        /// <summary>
-        /// Creates a new instance of <see cref="DynamicTransitionInfo"/>.
-        /// </summary>
-        /// <typeparam name="TTrigger">The trigger type.</typeparam>
-        /// <param name="trigger">The trigger associated with this transition.</param>
-        /// <param name="guards">The guard conditions associated with this transition.</param>
-        /// <param name="selector">The destination selector associated with this transition.</param>
-        /// <param name="possibleStates">The possible destination states.</param>
-        /// <returns></returns>
-        public static DynamicTransitionInfo Create<TTrigger>(TTrigger trigger, IEnumerable<InvocationInfo> guards,
+        internal static DynamicTransitionInfo Create<TTrigger>(TTrigger trigger, IEnumerable<InvocationInfo> guards,
             InvocationInfo selector, DynamicStateInfos possibleStates)
         {
             var transition = new DynamicTransitionInfo

--- a/src/Stateless/StateConfiguration.Async.cs
+++ b/src/Stateless/StateConfiguration.Async.cs
@@ -14,13 +14,13 @@ namespace Stateless
             /// </summary>
             /// <param name="trigger"></param>
             /// <param name="guard">Function that must return true in order for the trigger to be accepted.</param>
-            /// <param name="entryAction"></param>
+            /// <param name="internalAction">The asynchronous action performed by the internal transition</param>
             /// <returns></returns>
-            public StateConfiguration InternalTransitionAsyncIf(TTrigger trigger, Func<bool> guard, Func<Transition, Task> entryAction)
+            public StateConfiguration InternalTransitionAsyncIf(TTrigger trigger, Func<bool> guard, Func<Transition, Task> internalAction)
             {
-                if (entryAction == null) throw new ArgumentNullException(nameof(entryAction));
+                if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger, guard, (t, args) => entryAction(t)));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger, guard, (t, args) => internalAction(t)));
                 return this;
             }
 
@@ -36,22 +36,6 @@ namespace Stateless
                 if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
                 _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger, guard, (t, args) => internalAction()));
-                return this;
-            }
-
-            /// <summary>
-            /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
-            /// </summary>
-            /// <typeparam name="TArg0"></typeparam>
-            /// <param name="trigger">The accepted trigger</param>
-            /// <param name="guard">Function that must return true in order for the trigger to be accepted.</param>
-            /// <param name="internalAction">The asynchronous action performed by the internal transition</param>
-            /// <returns></returns>
-            public StateConfiguration InternalTransitionAsyncIf<TArg0>(TTrigger trigger, Func<bool> guard, Func<Transition, Task> internalAction)
-            {
-                if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
-
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Async(trigger, guard, (t, args) => internalAction(t)));
                 return this;
             }
 
@@ -118,12 +102,12 @@ namespace Stateless
             /// <summary>
             /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
             /// </summary>
-            /// <param name="trigger"></param>
-            /// <param name="entryAction"></param>
+            /// <param name="trigger">The accepted trigger</param>
+            /// <param name="internalAction">The asynchronous action performed by the internal transition</param>
             /// <returns></returns>
-            public StateConfiguration InternalTransitionAsync(TTrigger trigger, Func<Transition, Task> entryAction)
+            public StateConfiguration InternalTransitionAsync(TTrigger trigger, Func<Transition, Task> internalAction)
             {
-                return InternalTransitionAsyncIf(trigger, () => true, entryAction);
+                return InternalTransitionAsyncIf(trigger, () => true, internalAction);
             }
             /// <summary>
             /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
@@ -132,17 +116,6 @@ namespace Stateless
             /// <param name="internalAction">The asynchronous action performed by the internal transition</param>
             /// <returns></returns>
             public StateConfiguration InternalTransitionAsync(TTrigger trigger, Func<Task> internalAction)
-            {
-                return InternalTransitionAsyncIf(trigger, () => true, internalAction);
-            }
-            /// <summary>
-            /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
-            /// </summary>
-            /// <typeparam name="TArg0"></typeparam>
-            /// <param name="trigger">The accepted trigger</param>
-            /// <param name="internalAction">The asynchronous action performed by the internal transition</param>
-            /// <returns></returns>
-            public StateConfiguration InternalTransitionAsync<TArg0>(TTrigger trigger, Func<Transition, Task> internalAction)
             {
                 return InternalTransitionAsyncIf(trigger, () => true, internalAction);
             }

--- a/src/Stateless/StateConfiguration.cs
+++ b/src/Stateless/StateConfiguration.cs
@@ -48,27 +48,27 @@ namespace Stateless
             /// <summary>
             /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
             /// </summary>
-            /// <param name="trigger"></param>
-            /// <param name="entryAction"></param>
+            /// <param name="trigger">The accepted trigger</param>
+            /// <param name="internalAction">The action performed by the internal transition</param>
             /// <returns></returns>
-            public StateConfiguration InternalTransition(TTrigger trigger, Action<Transition> entryAction)
+            public StateConfiguration InternalTransition(TTrigger trigger, Action<Transition> internalAction)
             {
-                return InternalTransitionIf(trigger, t => true, entryAction);
+                return InternalTransitionIf(trigger, t => true, internalAction);
             }
 
             /// <summary>
             /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
             /// </summary>
-            /// <param name="trigger"></param>
+            /// <param name="trigger">The accepted trigger</param>
             /// <param name="guard">Function that must return true in order for the trigger to be accepted.</param>
-            /// <param name="entryAction"></param>
+            /// <param name="internalAction">The action performed by the internal transition</param>
             /// <param name="guardDescription">A description of the guard condition</param>
             /// <returns></returns>
-            public StateConfiguration InternalTransitionIf(TTrigger trigger, Func<object[], bool> guard, Action<Transition> entryAction, string guardDescription = null)
+            public StateConfiguration InternalTransitionIf(TTrigger trigger, Func<object[], bool> guard, Action<Transition> internalAction, string guardDescription = null)
             {
-                if (entryAction == null) throw new ArgumentNullException(nameof(entryAction));
+                if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
 
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Sync(trigger, guard, (t, args) => entryAction(t), guardDescription));
+                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Sync(trigger, guard, (t, args) => internalAction(t), guardDescription));
                 return this;
             }
 
@@ -97,35 +97,6 @@ namespace Stateless
 
                 _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Sync(trigger, guard, (t, args) => internalAction(), guardDescription));
                 return this;
-            }
-
-            /// <summary>
-            /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
-            /// </summary>
-            /// <typeparam name="TArg0"></typeparam>
-            /// <param name="trigger">The accepted trigger</param>
-            /// <param name="guard">Function that must return true in order for the trigger to be accepted.</param>
-            /// <param name="internalAction">The action performed by the internal transition</param>
-            /// <param name="guardDescription">A description of the guard condition</param>
-            /// <returns></returns>
-            public StateConfiguration InternalTransitionIf<TArg0>(TTrigger trigger, Func<object[], bool> guard, Action<Transition> internalAction, string guardDescription = null)
-            {
-                if (internalAction == null) throw new ArgumentNullException(nameof(internalAction));
-
-                _representation.AddTriggerBehaviour(new InternalTriggerBehaviour.Sync(trigger, guard, (t, args) => internalAction(t), guardDescription));
-                return this;
-            }
-
-            /// <summary>
-            /// Add an internal transition to the state machine. An internal action does not cause the Exit and Entry actions to be triggered, and does not change the state of the state machine
-            /// </summary>
-            /// <typeparam name="TArg0"></typeparam>
-            /// <param name="trigger">The accepted trigger</param>
-            /// <param name="internalAction">The action performed by the internal transition</param>
-            /// <returns></returns>
-            public StateConfiguration InternalTransition<TArg0>(TTrigger trigger, Action<Transition> internalAction)
-            {
-                return InternalTransitionIf(trigger, t => true, internalAction);
             }
 
             /// <summary>

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -246,7 +246,7 @@ namespace Stateless
         public TriggerWithParameters SetTriggerParameters(TTrigger trigger, params Type[] argumentTypes)
         {
             var configuration = new TriggerWithParameters(trigger, argumentTypes);
-            SaveTriggerConfiguration(configuration);
+            SetTriggerParameters(configuration);
             return configuration;
         }
 
@@ -600,7 +600,7 @@ namespace Stateless
         public TriggerWithParameters<TArg0> SetTriggerParameters<TArg0>(TTrigger trigger)
         {
             var configuration = new TriggerWithParameters<TArg0>(trigger);
-            SaveTriggerConfiguration(configuration);
+            SetTriggerParameters(configuration);
             return configuration;
         }
 
@@ -615,7 +615,7 @@ namespace Stateless
         public TriggerWithParameters<TArg0, TArg1> SetTriggerParameters<TArg0, TArg1>(TTrigger trigger)
         {
             var configuration = new TriggerWithParameters<TArg0, TArg1>(trigger);
-            SaveTriggerConfiguration(configuration);
+            SetTriggerParameters(configuration);
             return configuration;
         }
 
@@ -631,11 +631,15 @@ namespace Stateless
         public TriggerWithParameters<TArg0, TArg1, TArg2> SetTriggerParameters<TArg0, TArg1, TArg2>(TTrigger trigger)
         {
             var configuration = new TriggerWithParameters<TArg0, TArg1, TArg2>(trigger);
-            SaveTriggerConfiguration(configuration);
+            SetTriggerParameters(configuration);
             return configuration;
         }
 
-        void SaveTriggerConfiguration(TriggerWithParameters trigger)
+        /// <summary>
+        /// Specify the arguments that must be supplied when a specific trigger is fired.
+        /// </summary>
+        /// <param name="trigger">The underlying trigger value and the argument types expected by the trigger.</param>
+        public void SetTriggerParameters(TriggerWithParameters trigger)
         {
             if (_triggerConfiguration.ContainsKey(trigger.Trigger))
                 throw new InvalidOperationException(


### PR DESCRIPTION
* Publicly expose `StateConfiguration.SaveTriggerConfiguration` to allow trigger caching.
* Fix `internalAction` parameter names.
* Remove a few invalid generic method overloads that have a `<TArg0>` type parameter, but don't use it.