### PR TITLE
Fixed a null reference exception issue in InternalFireQueuedAsync method and added a fix to support multi-tasks firing triggers

### DIFF
--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -135,28 +135,37 @@ namespace Stateless
         /// <param name="args">     A variable-length parameters list containing arguments. </param>
         async Task InternalFireQueuedAsync(TTrigger trigger, params object[] args)
         {
-            if (_firing)
+            if (!_firing)
             {
-                _eventQueue.Enqueue(new QueuedTrigger { Trigger = trigger, Args = args });
-                return;
-            }
+                await _lock.WaitAsync();
 
-            try
-            {
-                _firing = true;
-
-                await InternalFireOneAsync(trigger, args).ConfigureAwait(RetainSynchronizationContext);
-
-                while (_eventQueue.Count != 0)
+                if(!_firing)
                 {
-                    var queuedEvent = _eventQueue.Dequeue();
-                    await InternalFireOneAsync(queuedEvent.Trigger, queuedEvent.Args).ConfigureAwait(RetainSynchronizationContext);
+                    try
+                    {
+                        _firing = true;
+                        _lock.Release();
+                        await InternalFireOneAsync(trigger, args).ConfigureAwait(RetainSynchronizationContext);
+
+                        while (!_eventQueue.IsEmpty)
+                        {
+                            bool suuccess = _eventQueue.TryDequeue(out QueuedTrigger queuedEvent);
+                            if (suuccess)
+                            {
+                                await InternalFireOneAsync(queuedEvent.Trigger, queuedEvent.Args).ConfigureAwait(RetainSynchronizationContext);
+                            }
+                        }
+                        return;
+                    }
+                    finally
+                    {
+                        _firing = false;
+                    }
                 }
+                _lock.Release();
             }
-            finally
-            {
-                _firing = false;
-            }
+
+            _eventQueue.Enqueue(new QueuedTrigger { Trigger = trigger, Args = args });
         }
 
         async Task InternalFireOneAsync(TTrigger trigger, params object[] args)


### PR DESCRIPTION
Using this NuGet in my own app, I came across a null reference exception in InternalFireQueuedAsync  method.
After a bit of investigation I came to a conclusion that there are 2 things needed to be fixed:
1) there is a use of object Queue when it's better to use ConcurrentQueue in order to be thread safe and avoid exceptions.
2) there was no lock in the InternalFireQueuedAsync  method so , what could happen (and happened in my own app) is that two threads will be able to go at the same time into the Dequeue sections and one of them will get null (if for example the queue has only one element).

I created 3 fixes:
1) changed the Queue object to ConcurrentQueue to support multiple threads
2) fixed the logic in the InternalFireQueuedAsync  to support double-checked locking in order to make sure that threads will not be able to dequeue at the same time.
3) created a new test to test this functionality 

for any more questions please feel free to contact me: yaeli.gimelshtein@kornit.com
 