### PR TITLE
Added FireAsync(TriggerWithParameters, params object[]) overload

### DIFF
--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -52,6 +52,23 @@ namespace Stateless
         /// Actions associated with leaving the current state and entering the new one
         /// will be invoked.
         /// </summary>
+        /// <param name="trigger">The trigger to fire.</param>
+        /// <param name="args">A variable-length parameters list containing arguments. </param>
+        /// <exception cref="System.InvalidOperationException">The current state does
+        /// not allow the trigger to be fired.</exception>
+        public Task FireAsync(TriggerWithParameters trigger, params object[] args)
+        {
+            if (trigger == null) throw new ArgumentNullException(nameof(trigger));
+
+            return InternalFireAsync(trigger.Trigger, args);
+        }
+
+        /// <summary>
+        /// Transition from the current state via the specified trigger in async fashion.
+        /// The target state is determined by the configuration of the current state.
+        /// Actions associated with leaving the current state and entering the new one
+        /// will be invoked.
+        /// </summary>
         /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
         /// <param name="trigger">The trigger to fire.</param>
         /// <param name="arg0">The first argument.</param>

--- a/test/Stateless.Tests/AsyncActionsFixture.cs
+++ b/test/Stateless.Tests/AsyncActionsFixture.cs
@@ -540,6 +540,31 @@ namespace Stateless.Tests
 
             Assert.False(wasInvoked);
         }
+
+        [Fact]
+        public async Task FireAsync_TriggerWithMoreThanThreeParameters()
+        {
+            const string expectedParam = "42-Stateless-True-420.69-Y";
+            string actualParam = null;
+
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+                .Permit(Trigger.X, State.B);
+
+            sm.Configure(State.B)
+                .OnEntryAsync(t =>
+                {
+                    actualParam = string.Join("-", t.Parameters);
+                    return Task.CompletedTask;
+                });
+
+            var parameterizedX = sm.SetTriggerParameters(Trigger.X, typeof(int), typeof(string), typeof(bool), typeof(double), typeof(Trigger));
+
+            await sm.FireAsync(parameterizedX, 42, "Stateless", true, 420.69, Trigger.Y);
+
+            Assert.Equal(expectedParam, actualParam);
+        }
     }
 }
 


### PR DESCRIPTION
This is async counterpart to existing Fire(TriggerWithParameters, params object[]) method. Required for firing triggers with more than 3 parameters asynchronously.