### PR TITLE
In the case of a superstate having a trigger that moves the state to …

### DIFF
--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -423,6 +423,10 @@ namespace Stateless
                 case DynamicTriggerBehaviour _ when result.Handler.ResultsInTransitionFrom(source, args, out var destination):
                 case TransitioningTriggerBehaviour _ when result.Handler.ResultsInTransitionFrom(source, args, out destination):
                 {
+                    //If a trigger was found on a superstate that would cause unintended reentry, don't trigger.
+                    if (source.Equals(destination))
+                        break;
+
                     // Handle transition, and set new state
                     var transition = new Transition(source, destination, trigger, args);
                     HandleTransitioningTrigger(args, representativeState, transition);

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -109,6 +109,29 @@ namespace Stateless.Tests
         }
 
         [Fact]
+        public void WhenInSubstate_TriggerSuperStateTwiceToSameSubstate_DoesNotReenterSubstate()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var eCount = 0;
+
+            sm.Configure(State.B)
+                .OnEntry(() => { eCount++;})
+                .SubstateOf(State.C);
+
+            sm.Configure(State.A)
+                .SubstateOf(State.C);
+
+
+            sm.Configure(State.C)
+                .Permit(Trigger.X, State.B);
+
+            sm.Fire(Trigger.X);
+            sm.Fire(Trigger.X);
+
+            Assert.Equal(1, eCount);
+        }
+
+        [Fact]
         public void PermittedTriggersIncludeSuperstatePermittedTriggers()
         {
             var sm = new StateMachine<State, Trigger>(State.B);


### PR DESCRIPTION
…a substate, if the machine is already in that substate then the entry action shouldn't trigger again. this pr is for Issue #543 