### PR TITLE
Small fixes: Potential NullReferenceException in the InvocationInfo class and FireAsync_TriggerWithMoreThanThreeParameters test failure

### DIFF
--- a/src/Stateless/Reflection/InvocationInfo.cs
+++ b/src/Stateless/Reflection/InvocationInfo.cs
@@ -63,9 +63,11 @@ namespace Stateless.Reflection
             {
                 if (_description != null)
                     return _description;
+                if (MethodName == null)
+                    return "<null>";
                 if (MethodName.IndexOfAny(new char[] { '<', '>', '`' }) >= 0)
                     return DefaultFunctionDescription;
-                return MethodName ?? "<null>";
+                return MethodName;
             }
         }
 

--- a/test/Stateless.Tests/AsyncActionsFixture.cs
+++ b/test/Stateless.Tests/AsyncActionsFixture.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 
 using Xunit;
+using System.Globalization;
 
 namespace Stateless.Tests
 {
@@ -544,7 +545,8 @@ namespace Stateless.Tests
         [Fact]
         public async Task FireAsync_TriggerWithMoreThanThreeParameters()
         {
-            const string expectedParam = "42-Stateless-True-420.69-Y";
+            var decimalSeparator = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
+            string expectedParam = $"42-Stateless-True-420{decimalSeparator}69-Y";
             string actualParam = null;
 
             var sm = new StateMachine<State, Trigger>(State.A);


### PR DESCRIPTION
* Fix a potential NullReferenceException in the InvocationInfo class
* Make FireAsync_TriggerWithMoreThanThreeParameters unit test culturally invariant. Otherwise, it fails on some system locales.