### PR TITLE
feature: Add FireAsync(TTrigger, params object[]) overload

### DIFF
--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -54,6 +54,19 @@ namespace Stateless
         /// </summary>
         /// <param name="trigger">The trigger to fire.</param>
         /// <param name="args">A variable-length parameters list containing arguments. </param>
+        public Task FireAsync(TTrigger trigger, params object[] args)
+        {
+            return InternalFireAsync(trigger, args);
+        }
+
+        /// <summary>
+        /// Transition from the current state via the specified trigger in async fashion.
+        /// The target state is determined by the configuration of the current state.
+        /// Actions associated with leaving the current state and entering the new one
+        /// will be invoked.
+        /// </summary>
+        /// <param name="trigger">The trigger to fire.</param>
+        /// <param name="args">A variable-length parameters list containing arguments. </param>
         /// <exception cref="System.InvalidOperationException">The current state does
         /// not allow the trigger to be fired.</exception>
         public Task FireAsync(TriggerWithParameters trigger, params object[] args)

--- a/test/Stateless.Tests/AsyncActionsFixture.cs
+++ b/test/Stateless.Tests/AsyncActionsFixture.cs
@@ -542,6 +542,29 @@ namespace Stateless.Tests
         }
 
         [Fact]
+        public async Task FireAsyncTriggerWithParametersArray()
+        {
+            const string expectedParam = "42-Stateless-True-420.69-Y";
+            string actualParam = null;
+
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+                .Permit(Trigger.X, State.B);
+
+            sm.Configure(State.B)
+                .OnEntryAsync(t =>
+                {
+                    actualParam = string.Join("-", t.Parameters);
+                    return Task.CompletedTask;
+                });
+
+            await sm.FireAsync(Trigger.X, 42, "Stateless", true, 420.69, Trigger.Y);
+
+            Assert.Equal(expectedParam, actualParam);
+        }
+
+        [Fact]
         public async Task FireAsync_TriggerWithMoreThanThreeParameters()
         {
             const string expectedParam = "42-Stateless-True-420.69-Y";


### PR DESCRIPTION
The ability for this was recently added for [TriggersWithParameters](https://github.com/dotnet-state-machine/stateless/pull/536).  Need similar functionality to reduce the need for reflection to get to the internal method.