### PR TITLE
Permit state reentry from dynamic transitions.

### DIFF
--- a/example/AlarmExample/Program.cs
+++ b/example/AlarmExample/Program.cs
@@ -21,7 +21,7 @@
             {
                 Console.Write("> ");
 
-                input = Console.ReadLine();
+                input = Console.ReadLine()!;
 
                 if (!string.IsNullOrWhiteSpace(input))
                     switch (input.Split(" ")[0])
@@ -101,7 +101,7 @@
                         Console.WriteLine($"{input.Split(" ")[1]} is not a valid AlarmCommand.");
                     }
                 }
-                catch (InvalidOperationException ex)
+                catch (InvalidOperationException)
                 {
                     Console.WriteLine($"{input.Split(" ")[1]} is not a valid AlarmCommand to the current state.");
                 }

--- a/src/Stateless/Reflection/InvocationInfo.cs
+++ b/src/Stateless/Reflection/InvocationInfo.cs
@@ -63,9 +63,11 @@ namespace Stateless.Reflection
             {
                 if (_description != null)
                     return _description;
+                if (MethodName == null)
+                    return "<null>";
                 if (MethodName.IndexOfAny(new char[] { '<', '>', '`' }) >= 0)
                     return DefaultFunctionDescription;
-                return MethodName ?? "<null>";
+                return MethodName;
             }
         }
 

--- a/src/Stateless/StateConfiguration.cs
+++ b/src/Stateless/StateConfiguration.cs
@@ -1162,8 +1162,10 @@ namespace Stateless
             /// dynamically by the supplied function.
             /// </summary>
             /// <param name="trigger">The accepted trigger.</param>
-            /// <param name="destinationStateSelector">Function to calculate the state
-            /// that the trigger will cause a transition to.</param>
+            /// <param name="destinationStateSelector">
+            /// Function to calculate the destination state; if the source and destination states are the same, it will be reentered and 
+            /// any exit or entry logic will be invoked.
+            /// </param>
             /// <param name="destinationStateSelectorDescription">Optional description for the function to calculate the state </param>
             /// <param name="possibleDestinationStates">Optional array of possible destination states (used by output formatters) </param>
             /// <returns>The receiver.</returns>
@@ -1190,8 +1192,10 @@ namespace Stateless
             /// dynamically by the supplied function.
             /// </summary>
             /// <param name="trigger">The accepted trigger.</param>
-            /// <param name="destinationStateSelector">Function to calculate the state
-            /// that the trigger will cause a transition to.</param>
+            /// <param name="destinationStateSelector">
+            /// Function to calculate the destination state; if the source and destination states are the same, it will be reentered and 
+            /// any exit or entry logic will be invoked.
+            /// </param>
             /// <param name="destinationStateSelectorDescription">Optional description of the function to calculate the state </param>
             /// <param name="possibleDestinationStates">Optional list of possible target states.</param>
             /// <returns>The receiver.</returns>
@@ -1222,8 +1226,10 @@ namespace Stateless
             /// dynamically by the supplied function.
             /// </summary>
             /// <param name="trigger">The accepted trigger.</param>
-            /// <param name="destinationStateSelector">Function to calculate the state
-            /// that the trigger will cause a transition to.</param>
+            /// <param name="destinationStateSelector">
+            /// Function to calculate the destination state; if the source and destination states are the same, it will be reentered and 
+            /// any exit or entry logic will be invoked.
+            /// </param>
             /// <param name="destinationStateSelectorDescription">Optional description of the function to calculate the state </param>
             /// <param name="possibleDestinationStates">Optional list of possible target states.</param>
             /// <returns>The receiver.</returns>
@@ -1254,8 +1260,10 @@ namespace Stateless
             /// dynamically by the supplied function.
             /// </summary>
             /// <param name="trigger">The accepted trigger.</param>
-            /// <param name="destinationStateSelector">Function to calculate the state
-            /// that the trigger will cause a transition to.</param>
+            /// <param name="destinationStateSelector">
+            /// Function to calculate the destination state; if the source and destination states are the same, it will be reentered and 
+            /// any exit or entry logic will be invoked.
+            /// </param>
             /// <param name="destinationStateSelectorDescription">Optional description of the function to calculate the state </param>
             /// <param name="possibleDestinationStates">Optional list of possible target states.</param>
             /// <returns>The receiver.</returns>
@@ -1288,8 +1296,10 @@ namespace Stateless
             /// dynamically by the supplied function.
             /// </summary>
             /// <param name="trigger">The accepted trigger.</param>
-            /// <param name="destinationStateSelector">Function to calculate the state
-            /// that the trigger will cause a transition to.</param>
+            /// <param name="destinationStateSelector">
+            /// Function to calculate the destination state; if the source and destination states are the same, it will be reentered and 
+            /// any exit or entry logic will be invoked.
+            /// </param>
             /// <param name="guard">Function that must return true in order for the
             /// trigger to be accepted.</param>
             /// <param name="guardDescription">Guard description</param>
@@ -1306,8 +1316,10 @@ namespace Stateless
             /// dynamically by the supplied function.
             /// </summary>
             /// <param name="trigger">The accepted trigger.</param>
-            /// <param name="destinationStateSelector">Function to calculate the state 
-            /// that the trigger will cause a transition to.</param>
+            /// <param name="destinationStateSelector">
+            /// Function to calculate the destination state; if the source and destination states are the same, it will be reentered and 
+            /// any exit or entry logic will be invoked.
+            /// </param>
             /// <param name="destinationStateSelectorDescription">Description of the function to calculate the state </param>
             /// <param name="guard">Function that must return true in order for the
             /// trigger to be accepted.</param>
@@ -1332,8 +1344,10 @@ namespace Stateless
             /// dynamically by the supplied function.
             /// </summary>
             /// <param name="trigger">The accepted trigger.</param>
-            /// <param name="destinationStateSelector">Function to calculate the state
-            /// that the trigger will cause a transition to.</param>
+            /// <param name="destinationStateSelector">
+            /// Function to calculate the destination state; if the source and destination states are the same, it will be reentered and 
+            /// any exit or entry logic will be invoked.
+            /// </param>
             /// <param name="guards">Functions and their descriptions that must return true in order for the
             /// trigger to be accepted.</param>
             /// <param name="possibleDestinationStates">Optional list of possible target states.</param>
@@ -1348,8 +1362,10 @@ namespace Stateless
             /// dynamically by the supplied function.
             /// </summary>
             /// <param name="trigger">The accepted trigger.</param>
-            /// <param name="destinationStateSelector">Function to calculate the state 
-            /// that the trigger will cause a transition to.</param>
+            /// <param name="destinationStateSelector">
+            /// Function to calculate the destination state; if the source and destination states are the same, it will be reentered and 
+            /// any exit or entry logic will be invoked.
+            /// </param>
             /// <param name="destinationStateSelectorDescription">Description of the function to calculate the state </param>
             /// <param name="guards">Functions and their descriptions that must return true in order for the
             /// trigger to be accepted.</param>
@@ -1373,8 +1389,10 @@ namespace Stateless
             /// dynamically by the supplied function.
             /// </summary>
             /// <param name="trigger">The accepted trigger.</param>
-            /// <param name="destinationStateSelector">Function to calculate the state
-            /// that the trigger will cause a transition to.</param>
+            /// <param name="destinationStateSelector">
+            /// Function to calculate the destination state; if the source and destination states are the same, it will be reentered and 
+            /// any exit or entry logic will be invoked.
+            /// </param>
             /// <param name="guard">Function that must return true in order for the
             /// trigger to be accepted.</param>
             /// <param name="guardDescription">Guard description</param>
@@ -1400,8 +1418,10 @@ namespace Stateless
             /// dynamically by the supplied function.
             /// </summary>
             /// <param name="trigger">The accepted trigger.</param>
-            /// <param name="destinationStateSelector">Function to calculate the state
-            /// that the trigger will cause a transition to.</param>            
+            /// <param name="destinationStateSelector">
+            /// Function to calculate the destination state; if the source and destination states are the same, it will be reentered and 
+            /// any exit or entry logic will be invoked.
+            /// </param>
             /// <returns>The receiver.</returns>
             /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
             public StateConfiguration PermitDynamicIf<TArg0>(TriggerWithParameters<TArg0> trigger, Func<TArg0, TState> destinationStateSelector)
@@ -1414,8 +1434,10 @@ namespace Stateless
             /// dynamically by the supplied function.
             /// </summary>
             /// <param name="trigger">The accepted trigger.</param>
-            /// <param name="destinationStateSelector">Function to calculate the state
-            /// that the trigger will cause a transition to.</param>
+            /// <param name="destinationStateSelector">
+            /// Function to calculate the destination state; if the source and destination states are the same, it will be reentered and 
+            /// any exit or entry logic will be invoked.
+            /// </param>
             /// <param name="possibleDestinationStates">Optional list of possible target states.</param>
             /// <param name="guards">Functions and their descriptions that must return true in order for the
             /// trigger to be accepted.</param>
@@ -1440,8 +1462,10 @@ namespace Stateless
             /// dynamically by the supplied function.
             /// </summary>
             /// <param name="trigger">The accepted trigger.</param>
-            /// <param name="destinationStateSelector">Function to calculate the state
-            /// that the trigger will cause a transition to.</param>
+            /// <param name="destinationStateSelector">
+            /// Function to calculate the destination state; if the source and destination states are the same, it will be reentered and 
+            /// any exit or entry logic will be invoked.
+            /// </param>
             /// <param name="guard">Function that must return true in order for the
             /// trigger to be accepted.</param>
             /// <param name="guardDescription">Guard description</param>
@@ -1469,8 +1493,10 @@ namespace Stateless
             /// dynamically by the supplied function.
             /// </summary>
             /// <param name="trigger">The accepted trigger.</param>
-            /// <param name="destinationStateSelector">Function to calculate the state
-            /// that the trigger will cause a transition to.</param>
+            /// <param name="destinationStateSelector">
+            /// Function to calculate the destination state; if the source and destination states are the same, it will be reentered and 
+            /// any exit or entry logic will be invoked.
+            /// </param>
             /// <param name="possibleDestinationStates">Optional list of possible target states.</param>
             /// <param name="guards">Functions and their descriptions that must return true in order for the
             /// trigger to be accepted.</param>
@@ -1497,8 +1523,10 @@ namespace Stateless
             /// dynamically by the supplied function.
             /// </summary>
             /// <param name="trigger">The accepted trigger.</param>
-            /// <param name="destinationStateSelector">Function to calculate the state
-            /// that the trigger will cause a transition to.</param>
+            /// <param name="destinationStateSelector">
+            /// Function to calculate the destination state; if the source and destination states are the same, it will be reentered and 
+            /// any exit or entry logic will be invoked.
+            /// </param>
             /// <returns>The receiver.</returns>
             /// <param name="guard">Function that must return true in order for the
             /// trigger to be accepted.</param>
@@ -1528,8 +1556,10 @@ namespace Stateless
             /// dynamically by the supplied function.
             /// </summary>
             /// <param name="trigger">The accepted trigger.</param>
-            /// <param name="destinationStateSelector">Function to calculate the state
-            /// that the trigger will cause a transition to.</param>
+            /// <param name="destinationStateSelector">
+            /// Function to calculate the destination state; if the source and destination states are the same, it will be reentered and 
+            /// any exit or entry logic will be invoked.
+            /// </param>
             /// <param name="possibleDestinationStates">Optional list of possible target states.</param>
             /// <returns>The receiver.</returns>
             /// <param name="guards">Functions ant their descriptions that must return true in order for the
@@ -1558,8 +1588,10 @@ namespace Stateless
             /// dynamically by the supplied function.
             /// </summary>
             /// <param name="trigger">The accepted trigger.</param>
-            /// <param name="destinationStateSelector">Function to calculate the state
-            /// that the trigger will cause a transition to.</param>
+            /// <param name="destinationStateSelector">
+            /// Function to calculate the destination state; if the source and destination states are the same, it will be reentered and 
+            /// any exit or entry logic will be invoked.
+            /// </param>
             /// <param name="guard">Parameterized Function that must return true in order for the
             /// trigger to be accepted.</param>
             /// <param name="guardDescription">Guard description</param>
@@ -1585,8 +1617,10 @@ namespace Stateless
             /// dynamically by the supplied function.
             /// </summary>
             /// <param name="trigger">The accepted trigger.</param>
-            /// <param name="destinationStateSelector">Function to calculate the state
-            /// that the trigger will cause a transition to.</param>
+            /// <param name="destinationStateSelector">
+            /// Function to calculate the destination state; if the source and destination states are the same, it will be reentered and 
+            /// any exit or entry logic will be invoked.
+            /// </param>
             /// <param name="possibleDestinationStates">Optional list of possible target states.</param>
             /// <param name="guards">Functions and their descriptions that must return true in order for the
             /// trigger to be accepted.</param>
@@ -1611,8 +1645,10 @@ namespace Stateless
             /// dynamically by the supplied function.
             /// </summary>
             /// <param name="trigger">The accepted trigger.</param>
-            /// <param name="destinationStateSelector">Function to calculate the state
-            /// that the trigger will cause a transition to.</param>
+            /// <param name="destinationStateSelector">
+            /// Function to calculate the destination state; if the source and destination states are the same, it will be reentered and 
+            /// any exit or entry logic will be invoked.
+            /// </param>
             /// <param name="guard">Function that must return true in order for the
             /// trigger to be accepted.</param>
             /// <param name="guardDescription">Guard description</param>
@@ -1640,8 +1676,10 @@ namespace Stateless
             /// dynamically by the supplied function.
             /// </summary>
             /// <param name="trigger">The accepted trigger.</param>
-            /// <param name="destinationStateSelector">Function to calculate the state
-            /// that the trigger will cause a transition to.</param>
+            /// <param name="destinationStateSelector">
+            /// Function to calculate the destination state; if the source and destination states are the same, it will be reentered and 
+            /// any exit or entry logic will be invoked.
+            /// </param>
             /// <param name="guards">Functions that must return true in order for the
             /// trigger to be accepted.</param>
             /// <param name="possibleDestinationStates">Optional list of possible target states.</param>
@@ -1668,8 +1706,10 @@ namespace Stateless
             /// dynamically by the supplied function.
             /// </summary>
             /// <param name="trigger">The accepted trigger.</param>
-            /// <param name="destinationStateSelector">Function to calculate the state
-            /// that the trigger will cause a transition to.</param>
+            /// <param name="destinationStateSelector">
+            /// Function to calculate the destination state; if the source and destination states are the same, it will be reentered and 
+            /// any exit or entry logic will be invoked.
+            /// </param>
             /// <param name="guard">Function that must return true in order for the
             /// trigger to be accepted.</param>
             /// <param name="guardDescription">Guard description</param>
@@ -1677,7 +1717,7 @@ namespace Stateless
             /// <returns>The receiver.</returns>
             /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
             /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
-            /// <typeparam name="TArg2"></typeparam>
+            /// <typeparam name="TArg2">Type of the third trigger argument.</typeparam>
             public StateConfiguration PermitDynamicIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Func<TArg0, TArg1, TArg2, TState> destinationStateSelector, Func<TArg0, TArg1, TArg2, bool> guard, string guardDescription = null, Reflection.DynamicStateInfos possibleDestinationStates = null)
             {
                 if (trigger == null) throw new ArgumentNullException(nameof(trigger));
@@ -1699,15 +1739,17 @@ namespace Stateless
             /// dynamically by the supplied function.
             /// </summary>
             /// <param name="trigger">The accepted trigger.</param>
-            /// <param name="destinationStateSelector">Function to calculate the state
-            /// that the trigger will cause a transition to.</param>
+            /// <param name="destinationStateSelector">
+            /// Function to calculate the destination state; if the source and destination states are the same, it will be reentered and 
+            /// any exit or entry logic will be invoked.
+            /// </param>
             /// <param name="guards">Functions that must return true in order for the
             /// trigger to be accepted.</param>
             /// <param name="possibleDestinationStates">Optional list of possible target states.</param>
             /// <returns>The receiver.</returns>
             /// <typeparam name="TArg0">Type of the first trigger argument.</typeparam>
             /// <typeparam name="TArg1">Type of the second trigger argument.</typeparam>
-            /// <typeparam name="TArg2"></typeparam>
+            /// <typeparam name="TArg2">Type of the third trigger argument.</typeparam>
             public StateConfiguration PermitDynamicIf<TArg0, TArg1, TArg2>(TriggerWithParameters<TArg0, TArg1, TArg2> trigger, Func<TArg0, TArg1, TArg2, TState> destinationStateSelector, Tuple<Func<TArg0, TArg1, TArg2, bool>, string>[] guards, Reflection.DynamicStateInfos possibleDestinationStates = null)
             {
                 if (trigger == null) throw new ArgumentNullException(nameof(trigger));

--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -220,8 +220,19 @@ namespace Stateless
                         break;
                     }
                 case DynamicTriggerBehaviour _ when result.Handler.ResultsInTransitionFrom(source, args, out var destination):
-                case TransitioningTriggerBehaviour _ when result.Handler.ResultsInTransitionFrom(source, args, out destination):
                     {
+                        // Handle transition, and set new state; reentry is permitted from dynamic trigger behaviours.
+                        var transition = new Transition(source, destination, trigger, args);
+                        await HandleTransitioningTriggerAsync(args, representativeState, transition);
+
+                        break;
+                    }
+                case TransitioningTriggerBehaviour _ when result.Handler.ResultsInTransitionFrom(source, args, out var destination):
+                    {
+                        // If a trigger was found on a superstate that would cause unintended reentry, don't trigger.
+                        if (source.Equals(destination))
+                            break;
+
                         // Handle transition, and set new state
                         var transition = new Transition(source, destination, trigger, args);
                         await HandleTransitioningTriggerAsync(args, representativeState, transition);

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -421,9 +421,16 @@ namespace Stateless
                     break;
                 }
                 case DynamicTriggerBehaviour _ when result.Handler.ResultsInTransitionFrom(source, args, out var destination):
-                case TransitioningTriggerBehaviour _ when result.Handler.ResultsInTransitionFrom(source, args, out destination):
                 {
-                    //If a trigger was found on a superstate that would cause unintended reentry, don't trigger.
+                    // Handle transition, and set new state; reentry is permitted from dynamic trigger behaviours.
+                    var transition = new Transition(source, destination, trigger, args);
+                    HandleTransitioningTrigger(args, representativeState, transition);
+
+                    break;
+                }
+                case TransitioningTriggerBehaviour _ when result.Handler.ResultsInTransitionFrom(source, args, out var destination):
+                {
+                    // If a trigger was found on a superstate that would cause unintended reentry, don't trigger.
                     if (source.Equals(destination))
                         break;
 

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -6,13 +6,13 @@ using System.Linq;
 namespace Stateless
 {
     /// <summary>
-    /// Enum for the different modes used when Fire-ing a trigger
+    /// Enum for the different modes used when <c>Fire</c>ing a trigger
     /// </summary>
     public enum FiringMode
     {
         /// <summary> Use immediate mode when the queuing of trigger events are not needed. Care must be taken when using this mode, as there is no run-to-completion guaranteed.</summary>
         Immediate,
-        /// <summary> Use the queued Fire-ing mode when run-to-completion is required. This is the recommended mode.</summary>
+        /// <summary> Use the queued <c>Fire</c>ing mode when run-to-completion is required. This is the recommended mode.</summary>
         Queued
     }
 

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -47,7 +47,7 @@ namespace Stateless
         /// </summary>
         /// <param name="stateAccessor">A function that will be called to read the current state value.</param>
         /// <param name="stateMutator">An action that will be called to write new state values.</param>
-        public StateMachine(Func<TState> stateAccessor, Action<TState> stateMutator) :this(stateAccessor, stateMutator, FiringMode.Queued)
+        public StateMachine(Func<TState> stateAccessor, Action<TState> stateMutator) : this(stateAccessor, stateMutator, FiringMode.Queued)
         {
         }
 
@@ -414,39 +414,39 @@ namespace Stateless
                 // Handle special case, re-entry in superstate
                 // Check if it is an internal transition, or a transition from one state to another.
                 case ReentryTriggerBehaviour handler:
-                {
-                    // Handle transition, and set new state
-                    var transition = new Transition(source, handler.Destination, trigger, args);
-                    HandleReentryTrigger(args, representativeState, transition);
-                    break;
-                }
-                case DynamicTriggerBehaviour _ when result.Handler.ResultsInTransitionFrom(source, args, out var destination):
-                {
-                    // Handle transition, and set new state; reentry is permitted from dynamic trigger behaviours.
-                    var transition = new Transition(source, destination, trigger, args);
-                    HandleTransitioningTrigger(args, representativeState, transition);
-
-                    break;
-                }
-                case TransitioningTriggerBehaviour _ when result.Handler.ResultsInTransitionFrom(source, args, out var destination):
-                {
-                    // If a trigger was found on a superstate that would cause unintended reentry, don't trigger.
-                    if (source.Equals(destination))
+                    {
+                        // Handle transition, and set new state
+                        var transition = new Transition(source, handler.Destination, trigger, args);
+                        HandleReentryTrigger(args, representativeState, transition);
                         break;
+                    }
+                case DynamicTriggerBehaviour _ when result.Handler.ResultsInTransitionFrom(source, args, out var destination):
+                    {
+                        // Handle transition, and set new state; reentry is permitted from dynamic trigger behaviours.
+                        var transition = new Transition(source, destination, trigger, args);
+                        HandleTransitioningTrigger(args, representativeState, transition);
 
-                    // Handle transition, and set new state
-                    var transition = new Transition(source, destination, trigger, args);
-                    HandleTransitioningTrigger(args, representativeState, transition);
+                        break;
+                    }
+                case TransitioningTriggerBehaviour _ when result.Handler.ResultsInTransitionFrom(source, args, out var destination):
+                    {
+                        // If a trigger was found on a superstate that would cause unintended reentry, don't trigger.
+                        if (source.Equals(destination))
+                            break;
 
-                    break;
-                }
+                        // Handle transition, and set new state
+                        var transition = new Transition(source, destination, trigger, args);
+                        HandleTransitioningTrigger(args, representativeState, transition);
+
+                        break;
+                    }
                 case InternalTriggerBehaviour _:
-                {
-                    // Internal transitions does not update the current state, but must execute the associated action.
-                    var transition = new Transition(source, source, trigger, args);
-                    CurrentRepresentation.InternalAction(transition, args);
-                    break;
-                }
+                    {
+                        // Internal transitions does not update the current state, but must execute the associated action.
+                        var transition = new Transition(source, source, trigger, args);
+                        CurrentRepresentation.InternalAction(transition, args);
+                        break;
+                    }
                 default:
                     throw new InvalidOperationException("State machine configuration incorrect, no handler for trigger.");
             }
@@ -478,7 +478,7 @@ namespace Stateless
             State = representation.UnderlyingState;
         }
 
-        private void HandleTransitioningTrigger( object[] args, StateRepresentation representativeState, Transition transition)
+        private void HandleTransitioningTrigger(object[] args, StateRepresentation representativeState, Transition transition)
         {
             transition = representativeState.Exit(transition);
 
@@ -499,7 +499,7 @@ namespace Stateless
             _onTransitionCompletedEvent.Invoke(new Transition(transition.Source, State, transition.Trigger, transition.Parameters));
         }
 
-        private StateRepresentation EnterState(StateRepresentation representation, Transition transition, object [] args)
+        private StateRepresentation EnterState(StateRepresentation representation, Transition transition, object[] args)
         {
             // Enter the new state
             representation.Enter(transition, args);

--- a/test/Stateless.Tests/AsyncActionsFixture.cs
+++ b/test/Stateless.Tests/AsyncActionsFixture.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using System.Globalization;
@@ -562,7 +561,6 @@ namespace Stateless.Tests
                 });
 
             await sm.FireAsync(Trigger.X, 42, "Stateless", true, 123.45, Trigger.Y);
-            Console.WriteLine(Thread.CurrentThread.CurrentCulture);
 
             Assert.Equal(expectedParam, actualParam);
         }

--- a/test/Stateless.Tests/AsyncActionsFixture.cs
+++ b/test/Stateless.Tests/AsyncActionsFixture.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 
 using Xunit;
+using System.Globalization;
 
 namespace Stateless.Tests
 {
@@ -567,7 +568,8 @@ namespace Stateless.Tests
         [Fact]
         public async Task FireAsync_TriggerWithMoreThanThreeParameters()
         {
-            const string expectedParam = "42-Stateless-True-420.69-Y";
+            var decimalSeparator = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
+            string expectedParam = $"42-Stateless-True-420{decimalSeparator}69-Y";
             string actualParam = null;
 
             var sm = new StateMachine<State, Trigger>(State.A);

--- a/test/Stateless.Tests/AsyncActionsFixture.cs
+++ b/test/Stateless.Tests/AsyncActionsFixture.cs
@@ -589,6 +589,28 @@ namespace Stateless.Tests
 
             Assert.Equal(expectedParam, actualParam);
         }
+
+        [Fact]
+        public async Task WhenInSubstate_TriggerSuperStateTwiceToSameSubstate_DoesNotReenterSubstate_Async()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var eCount = 0;
+
+            sm.Configure(State.B)
+                .OnEntry(() => { eCount++; })
+                .SubstateOf(State.C);
+
+            sm.Configure(State.A)
+                .SubstateOf(State.C);
+
+            sm.Configure(State.C)
+                .Permit(Trigger.X, State.B);
+
+            await sm.FireAsync(Trigger.X);
+            await sm.FireAsync(Trigger.X);
+
+            Assert.Equal(1, eCount);
+        }
     }
 }
 

--- a/test/Stateless.Tests/AsyncActionsFixture.cs
+++ b/test/Stateless.Tests/AsyncActionsFixture.cs
@@ -1,15 +1,16 @@
 #if TASKS
 
 using System;
-using System.Threading.Tasks;
 using System.Collections.Generic;
-
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 using System.Globalization;
 
 namespace Stateless.Tests
 {
-
     public class AsyncActionsFixture
     {
         [Fact]
@@ -556,11 +557,12 @@ namespace Stateless.Tests
             sm.Configure(State.B)
                 .OnEntryAsync(t =>
                 {
-                    actualParam = string.Join("-", t.Parameters);
+                    actualParam = string.Join("-", t.Parameters.Select(x => string.Format(CultureInfo.InvariantCulture, "{0}", x)));
                     return Task.CompletedTask;
                 });
 
             await sm.FireAsync(Trigger.X, 42, "Stateless", true, 123.45, Trigger.Y);
+            Console.WriteLine(Thread.CurrentThread.CurrentCulture);
 
             Assert.Equal(expectedParam, actualParam);
         }
@@ -579,7 +581,7 @@ namespace Stateless.Tests
             sm.Configure(State.B)
                 .OnEntryAsync(t =>
                 {
-                    actualParam = string.Join("-", t.Parameters);
+                    actualParam = string.Join("-", t.Parameters.Select(x => string.Format(CultureInfo.InvariantCulture, "{0}", x)));
                     return Task.CompletedTask;
                 });
 

--- a/test/Stateless.Tests/AsyncActionsFixture.cs
+++ b/test/Stateless.Tests/AsyncActionsFixture.cs
@@ -545,7 +545,7 @@ namespace Stateless.Tests
         [Fact]
         public async Task FireAsyncTriggerWithParametersArray()
         {
-            const string expectedParam = "42-Stateless-True-420.69-Y";
+            const string expectedParam = "42-Stateless-True-123.45-Y";
             string actualParam = null;
 
             var sm = new StateMachine<State, Trigger>(State.A);
@@ -560,7 +560,7 @@ namespace Stateless.Tests
                     return Task.CompletedTask;
                 });
 
-            await sm.FireAsync(Trigger.X, 42, "Stateless", true, 420.69, Trigger.Y);
+            await sm.FireAsync(Trigger.X, 42, "Stateless", true, 123.45, Trigger.Y);
 
             Assert.Equal(expectedParam, actualParam);
         }
@@ -568,8 +568,7 @@ namespace Stateless.Tests
         [Fact]
         public async Task FireAsync_TriggerWithMoreThanThreeParameters()
         {
-            var decimalSeparator = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
-            string expectedParam = $"42-Stateless-True-420{decimalSeparator}69-Y";
+            const string expectedParam = "42-Stateless-True-123.45-Y";
             string actualParam = null;
 
             var sm = new StateMachine<State, Trigger>(State.A);
@@ -586,7 +585,7 @@ namespace Stateless.Tests
 
             var parameterizedX = sm.SetTriggerParameters(Trigger.X, typeof(int), typeof(string), typeof(bool), typeof(double), typeof(Trigger));
 
-            await sm.FireAsync(parameterizedX, 42, "Stateless", true, 420.69, Trigger.Y);
+            await sm.FireAsync(parameterizedX, 42, "Stateless", true, 123.45, Trigger.Y);
 
             Assert.Equal(expectedParam, actualParam);
         }

--- a/test/Stateless.Tests/AsyncActionsFixture.cs
+++ b/test/Stateless.Tests/AsyncActionsFixture.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
-using System.Globalization;
 
 namespace Stateless.Tests
 {

--- a/test/Stateless.Tests/DynamicTriggerBehaviourAsyncFixture.cs
+++ b/test/Stateless.Tests/DynamicTriggerBehaviourAsyncFixture.cs
@@ -1,37 +1,38 @@
 ﻿using System;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Stateless.Tests
 {
-    public class DynamicTriggerBehaviourFixture
+    public class DynamicTriggerBehaviourAsyncFixture
     {
         [Fact]
-        public void PermitDynamic_Selects_Expected_State()
+        public async Task PermitDynamic_Selects_Expected_State_Async()
         {
             var sm = new StateMachine<State, Trigger>(State.A);
             sm.Configure(State.A)
                 .PermitDynamic(Trigger.X, () => State.B);
 
-            sm.Fire(Trigger.X);
+            await sm.FireAsync(Trigger.X);
 
             Assert.Equal(State.B, sm.State);
         }
 
         [Fact]
-        public void PermitDynamic_With_TriggerParameter_Selects_Expected_State()
+        public async Task PermitDynamic_With_TriggerParameter_Selects_Expected_State_Async()
         {
             var sm = new StateMachine<State, Trigger>(State.A);
             var trigger = sm.SetTriggerParameters<int>(Trigger.X);
             sm.Configure(State.A)
                 .PermitDynamic(trigger, i => i == 1 ? State.B : State.C);
 
-            sm.Fire(trigger, 1);
+            await sm.FireAsync(trigger, 1);
 
             Assert.Equal(State.B, sm.State);
         }
 
         [Fact]
-        public void PermitDynamic_Permits_Reentry()
+        public async Task PermitDynamic_Permits_Reentry_Async()
         {
             var sm = new StateMachine<State, Trigger>(State.A);
             var onExitInvoked = false;
@@ -43,7 +44,7 @@ namespace Stateless.Tests
                 .OnEntryFrom(Trigger.X, () => onEntryFromInvoked = true)
                 .OnExit(() => onExitInvoked = true);
 
-            sm.Fire(Trigger.X);
+            await sm.FireAsync(Trigger.X);
 
             Assert.True(onExitInvoked, "Expected OnExit to be invoked");
             Assert.True(onEntryInvoked, "Expected OnEntry to be invoked");
@@ -52,33 +53,33 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        public void PermitDynamic_Selects_Expected_State_Based_On_DestinationStateSelector_Function()
+        public async Task PermitDynamic_Selects_Expected_State_Based_On_DestinationStateSelector_Function_Async()
         {
             var sm = new StateMachine<State, Trigger>(State.A);
             var value = 'C';
             sm.Configure(State.A)
                 .PermitDynamic(Trigger.X, () => value == 'B' ? State.B : State.C);
 
-            sm.Fire(Trigger.X);
+            await sm.FireAsync(Trigger.X);
 
             Assert.Equal(State.C, sm.State);
         }
 
         [Fact]
-        public void PermitDynamicIf_With_TriggerParameter_Permits_Transition_When_GuardCondition_Met()
+        public async Task PermitDynamicIf_With_TriggerParameter_Permits_Transition_When_GuardCondition_Met_Async()
         {
             var sm = new StateMachine<State, Trigger>(State.A);
             var trigger = sm.SetTriggerParameters<int>(Trigger.X);
             sm.Configure(State.A)
                 .PermitDynamicIf(trigger, (i) => i == 1 ? State.C : State.B, (i) => i == 1);
 
-            sm.Fire(trigger, 1);
+            await sm.FireAsync(trigger, 1);
 
             Assert.Equal(State.C, sm.State);
         }
 
         [Fact]
-        public void PermitDynamicIf_With_2_TriggerParameters_Permits_Transition_When_GuardCondition_Met()
+        public async Task PermitDynamicIf_With_2_TriggerParameters_Permits_Transition_When_GuardCondition_Met_Async()
         {
             var sm = new StateMachine<State, Trigger>(State.A);
             var trigger = sm.SetTriggerParameters<int, int>(Trigger.X);
@@ -87,13 +88,13 @@ namespace Stateless.Tests
                 (i, j) => i == 1 && j == 2 ? State.C : State.B, 
                 (i, j) => i == 1 && j == 2);
 
-            sm.Fire(trigger, 1, 2);
+            await sm.FireAsync(trigger, 1, 2);
 
             Assert.Equal(State.C, sm.State);
         }
 
         [Fact]
-        public void PermitDynamicIf_With_3_TriggerParameters_Permits_Transition_When_GuardCondition_Met()
+        public async Task PermitDynamicIf_With_3_TriggerParameters_Permits_Transition_When_GuardCondition_Met_Async()
         {
             var sm = new StateMachine<State, Trigger>(State.A);
             var trigger = sm.SetTriggerParameters<int, int, int>(Trigger.X);
@@ -102,24 +103,24 @@ namespace Stateless.Tests
                 (i, j, k) => i == 1 && j == 2 && k == 3 ? State.C : State.B,
                 (i, j, k) => i == 1 && j == 2 && k == 3);
 
-            sm.Fire(trigger, 1, 2, 3);
+            await sm.FireAsync(trigger, 1, 2, 3);
 
             Assert.Equal(State.C, sm.State);
         }
 
         [Fact]
-        public void PermitDynamicIf_With_TriggerParameter_Throws_When_GuardCondition_Not_Met()
+        public async Task PermitDynamicIf_With_TriggerParameter_Throws_When_GuardCondition_Not_Met_Async()
         {
             var sm = new StateMachine<State, Trigger>(State.A);
             var trigger = sm.SetTriggerParameters<int>(Trigger.X);
             sm.Configure(State.A)
                 .PermitDynamicIf(trigger, (i) => i > 0 ? State.C : State.B, (i) => i == 2 ? true : false);
 
-            Assert.Throws<InvalidOperationException>(() => sm.Fire(trigger, 1));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await sm.FireAsync(trigger, 1));
         }
 
         [Fact]
-        public void PermitDynamicIf_With_2_TriggerParameters_Throws_When_GuardCondition_Not_Met()
+        public async Task PermitDynamicIf_With_2_TriggerParameters_Throws_When_GuardCondition_Not_Met_Async()
         {
             var sm = new StateMachine<State, Trigger>(State.A);
             var trigger = sm.SetTriggerParameters<int, int>(Trigger.X);
@@ -128,11 +129,11 @@ namespace Stateless.Tests
                 (i, j) => i > 0 ? State.C : State.B, 
                 (i, j) => i == 2 && j == 3);
 
-            Assert.Throws<InvalidOperationException>(() => sm.Fire(trigger, 1, 2));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await sm.FireAsync(trigger, 1, 2));
         }
 
         [Fact]
-        public void PermitDynamicIf_With_3_TriggerParameters_Throws_When_GuardCondition_Not_Met()
+        public async Task PermitDynamicIf_With_3_TriggerParameters_Throws_When_GuardCondition_Not_Met_Async()
         {
             var sm = new StateMachine<State, Trigger>(State.A);
             var trigger = sm.SetTriggerParameters<int, int, int>(Trigger.X);
@@ -140,11 +141,11 @@ namespace Stateless.Tests
                 (i, j, k) => i > 0 ? State.C : State.B, 
                 (i, j, k) => i == 2 && j == 3 && k == 4);
 
-            Assert.Throws<InvalidOperationException>(() => sm.Fire(trigger, 1, 2, 3));
+            await Assert.ThrowsAsync<InvalidOperationException>(async () => await sm.FireAsync(trigger, 1, 2, 3));
         }
 
         [Fact]
-        public void PermitDynamicIf_Permits_Reentry_When_GuardCondition_Met()
+        public async Task PermitDynamicIf_Permits_Reentry_When_GuardCondition_Met_Async()
         {
             var sm = new StateMachine<State, Trigger>(State.A);
             var onExitInvoked = false;
@@ -156,7 +157,7 @@ namespace Stateless.Tests
                 .OnEntryFrom(Trigger.X, () => onEntryFromInvoked = true)
                 .OnExit(() => onExitInvoked = true);
 
-            sm.Fire(Trigger.X);
+            await sm.FireAsync(Trigger.X);
 
             Assert.True(onExitInvoked, "Expected OnExit to be invoked");
             Assert.True(onEntryInvoked, "Expected OnEntry to be invoked");

--- a/test/Stateless.Tests/DynamicTriggerBehaviourFixture.cs
+++ b/test/Stateless.Tests/DynamicTriggerBehaviourFixture.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+﻿using System;
 using Xunit;
 
 namespace Stateless.Tests
@@ -6,7 +6,7 @@ namespace Stateless.Tests
     public class DynamicTriggerBehaviour
     {
         [Fact]
-        public void DestinationStateIsDynamic()
+        public void PermitDynamic_Selects_Expected_State()
         {
             var sm = new StateMachine<State, Trigger>(State.A);
             sm.Configure(State.A)
@@ -18,7 +18,7 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        public void DestinationStateIsCalculatedBasedOnTriggerParameters()
+        public void PermitDynamic_With_TriggerParameter_Selects_Expected_State()
         {
             var sm = new StateMachine<State, Trigger>(State.A);
             var trigger = sm.SetTriggerParameters<int>(Trigger.X);
@@ -31,17 +31,137 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        public void Sdfsf()
+        public void PermitDynamic_Permits_Reentry()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var onExitInvoked = false;
+            var onEntryInvoked = false;
+            var onEntryFromInvoked = false;
+            sm.Configure(State.A)
+                .PermitDynamic(Trigger.X, () => State.A)
+                .OnEntry(() => onEntryInvoked = true)
+                .OnEntryFrom(Trigger.X, () => onEntryFromInvoked = true)
+                .OnExit(() => onExitInvoked = true);
+
+            sm.Fire(Trigger.X);
+
+            Assert.True(onExitInvoked, "Expected OnExit to be invoked");
+            Assert.True(onEntryInvoked, "Expected OnEntry to be invoked");
+            Assert.True(onEntryFromInvoked, "Expected OnEntryFrom to be invoked");
+            Assert.Equal(State.A, sm.State);
+        }
+
+        [Fact]
+        public void PermitDynamic_Selects_Expected_State_Based_On_DestinationStateSelector_Function()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var value = 'C';
+            sm.Configure(State.A)
+                .PermitDynamic(Trigger.X, () => value == 'B' ? State.B : State.C);
+
+            sm.Fire(Trigger.X);
+
+            Assert.Equal(State.C, sm.State);
+        }
+
+        [Fact]
+        public void PermitDynamicIf_With_TriggerParameter_Permits_Transition_When_GuardCondition_Met()
         {
             var sm = new StateMachine<State, Trigger>(State.A);
             var trigger = sm.SetTriggerParameters<int>(Trigger.X);
             sm.Configure(State.A)
-                .PermitDynamicIf(trigger, (i) => i == 1 ? State.C : State.B, (i) => i == 1 ? true : false);
-
-            // Should not throw
-            sm.GetPermittedTriggers().ToList();
+                .PermitDynamicIf(trigger, (i) => i == 1 ? State.C : State.B, (i) => i == 1);
 
             sm.Fire(trigger, 1);
+
+            Assert.Equal(State.C, sm.State);
+        }
+
+        [Fact]
+        public void PermitDynamicIf_With_2_TriggerParameters_Permits_Transition_When_GuardCondition_Met()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var trigger = sm.SetTriggerParameters<int, int>(Trigger.X);
+            sm.Configure(State.A).PermitDynamicIf(
+                trigger, 
+                (i, j) => i == 1 && j == 2 ? State.C : State.B, 
+                (i, j) => i == 1 && j == 2);
+
+            sm.Fire(trigger, 1, 2);
+
+            Assert.Equal(State.C, sm.State);
+        }
+
+        [Fact]
+        public void PermitDynamicIf_With_3_TriggerParameters_Permits_Transition_When_GuardCondition_Met()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var trigger = sm.SetTriggerParameters<int, int, int>(Trigger.X);
+            sm.Configure(State.A).PermitDynamicIf(
+                trigger,
+                (i, j, k) => i == 1 && j == 2 && k == 3 ? State.C : State.B,
+                (i, j, k) => i == 1 && j == 2 && k == 3);
+
+            sm.Fire(trigger, 1, 2, 3);
+
+            Assert.Equal(State.C, sm.State);
+        }
+
+        [Fact]
+        public void PermitDynamicIf_With_TriggerParameter_Throws_When_GuardCondition_Not_Met()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var trigger = sm.SetTriggerParameters<int>(Trigger.X);
+            sm.Configure(State.A)
+                .PermitDynamicIf(trigger, (i) => i > 0 ? State.C : State.B, (i) => i == 2 ? true : false);
+
+            Assert.Throws<InvalidOperationException>(() => sm.Fire(trigger, 1));
+        }
+
+        [Fact]
+        public void PermitDynamicIf_With_2_TriggerParameters_Throws_When_GuardCondition_Not_Met()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var trigger = sm.SetTriggerParameters<int, int>(Trigger.X);
+            sm.Configure(State.A).PermitDynamicIf(
+                trigger,
+                (i, j) => i > 0 ? State.C : State.B, 
+                (i, j) => i == 2 && j == 3);
+
+            Assert.Throws<InvalidOperationException>(() => sm.Fire(trigger, 1, 2));
+        }
+
+        [Fact]
+        public void PermitDynamicIf_With_3_TriggerParameters_Throws_When_GuardCondition_Not_Met()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var trigger = sm.SetTriggerParameters<int, int, int>(Trigger.X);
+            sm.Configure(State.A).PermitDynamicIf(trigger, 
+                (i, j, k) => i > 0 ? State.C : State.B, 
+                (i, j, k) => i == 2 && j == 3 && k == 4);
+
+            Assert.Throws<InvalidOperationException>(() => sm.Fire(trigger, 1, 2, 3));
+        }
+
+        [Fact]
+        public void PermitDynamicIf_Permits_Reentry_When_GuardCondition_Met()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            var onExitInvoked = false;
+            var onEntryInvoked = false;
+            var onEntryFromInvoked = false;
+            sm.Configure(State.A)
+                .PermitDynamicIf(Trigger.X, () => State.A, () => true)
+                .OnEntry(() => onEntryInvoked = true)
+                .OnEntryFrom(Trigger.X, () => onEntryFromInvoked = true)
+                .OnExit(() => onExitInvoked = true);
+
+            sm.Fire(Trigger.X);
+
+            Assert.True(onExitInvoked, "Expected OnExit to be invoked");
+            Assert.True(onEntryInvoked, "Expected OnEntry to be invoked");
+            Assert.True(onEntryFromInvoked, "Expected OnEntryFrom to be invoked");
+            Assert.Equal(State.A, sm.State);
         }
     }
 }

--- a/test/Stateless.Tests/ReflectionFixture.cs
+++ b/test/Stateless.Tests/ReflectionFixture.cs
@@ -892,6 +892,14 @@ namespace Stateless.Tests
             StateConfiguration InternalPermitDynamic(TTrigger trigger, Func<object[], TState> destinationStateSelector, string guardDescription)
              */
         }
+
+        [Fact]
+        public void InvocationInfo_Description_Property_When_Method_Name_Is_Null_Returns_String_Literal_Null()
+        {
+            var invocationInfo = new InvocationInfo(null, null, InvocationInfo.Timing.Synchronous);
+
+            Assert.Equal("<null>", invocationInfo.Description);
+        }
     }
 }
 


### PR DESCRIPTION
To address issue #565, this PR restores the pre-v5.15 behavior so that state re-entry is possible when dynamic transitions are used.

Example:

```csharp
var sm = new StateMachine<State, Trigger>(State.A);
sm.Configure(State.A).PermitDynamic(Trigger.X, () => State.A);
Console.WriteLine($"Initial state: {sm.State}");

// Firing Trigger.X does not cause InvalidOperation to be thrown.
sm.Fire(Trigger.X);
Console.WriteLine($"Final state: {sm.State}");

// Output:
// Initial state: A
// Final state: A
```