### PR TITLE
Remove getDestination, and use Destination property instead.

### DIFF
--- a/src/Stateless/DynamicTriggerBehaviour.cs
+++ b/src/Stateless/DynamicTriggerBehaviour.cs
@@ -17,10 +17,9 @@ namespace Stateless
                 TransitionInfo = info ?? throw new ArgumentNullException(nameof(info));
             }
 
-            public override bool ResultsInTransitionFrom(TState source, object[] args, out TState destination)
+            public void GetDestinationState(TState source, object[] args, out TState destination)
             {
                 destination = _destination(args);
-                return true;
             }
         }
     }

--- a/src/Stateless/IgnoredTriggerBehaviour.cs
+++ b/src/Stateless/IgnoredTriggerBehaviour.cs
@@ -8,12 +8,6 @@
                 : base(trigger, transitionGuard)
             {
             }
-
-            public override bool ResultsInTransitionFrom(TState source, object[] args, out TState destination)
-            {
-                destination = default(TState);
-                return false;
-            }
         }
     }
 }

--- a/src/Stateless/InternalTriggerBehaviour.cs
+++ b/src/Stateless/InternalTriggerBehaviour.cs
@@ -14,12 +14,6 @@ namespace Stateless
             public abstract void Execute(Transition transition, object[] args);
             public abstract Task ExecuteAsync(Transition transition, object[] args);
 
-            public override bool ResultsInTransitionFrom(TState source, object[] args, out TState destination)
-            {
-                destination = source;
-                return false;
-            }
-
             public class Sync : InternalTriggerBehaviour
             {
                 public Action<Transition, object[]> InternalAction { get; }

--- a/src/Stateless/ReentryTriggerBehaviour.cs
+++ b/src/Stateless/ReentryTriggerBehaviour.cs
@@ -14,13 +14,6 @@
             {
                 _destination = destination;
             }
-
-            public override bool ResultsInTransitionFrom(TState source, object[] args, out TState destination)
-            {
-                destination = _destination;
-                return true;
-            }
         }
-        
     }
 }

--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -219,22 +219,23 @@ namespace Stateless
                         await HandleReentryTriggerAsync(args, representativeState, transition);
                         break;
                     }
-                case DynamicTriggerBehaviour _ when result.Handler.ResultsInTransitionFrom(source, args, out var destination):
+                case DynamicTriggerBehaviour handler:
                     {
+                        handler.GetDestinationState(source, args, out var destination);
                         // Handle transition, and set new state; reentry is permitted from dynamic trigger behaviours.
                         var transition = new Transition(source, destination, trigger, args);
                         await HandleTransitioningTriggerAsync(args, representativeState, transition);
 
                         break;
                     }
-                case TransitioningTriggerBehaviour _ when result.Handler.ResultsInTransitionFrom(source, args, out var destination):
+                case TransitioningTriggerBehaviour handler:
                     {
                         // If a trigger was found on a superstate that would cause unintended reentry, don't trigger.
-                        if (source.Equals(destination))
+                        if (source.Equals(handler.Destination))
                             break;
 
                         // Handle transition, and set new state
-                        var transition = new Transition(source, destination, trigger, args);
+                        var transition = new Transition(source, handler.Destination, trigger, args);
                         await HandleTransitioningTriggerAsync(args, representativeState, transition);
 
                         break;

--- a/src/Stateless/TransitioningTriggerBehaviour.cs
+++ b/src/Stateless/TransitioningTriggerBehaviour.cs
@@ -12,12 +12,6 @@
             {
                 Destination = destination;
             }
-
-            public override bool ResultsInTransitionFrom(TState source, object[] args, out TState destination)
-            {
-                destination = Destination;
-                return true;
-            }
         }
     }
 }

--- a/src/Stateless/TriggerBehaviour.cs
+++ b/src/Stateless/TriggerBehaviour.cs
@@ -37,7 +37,7 @@ namespace Stateless
             internal ICollection<Func<object[], bool>> Guards =>_guard.Guards;
 
             /// <summary>
-            /// GuardConditionsMet is true if all of the guard functions return true
+            /// GuardConditionsMet is true if all the guard functions return true
             /// or if there are no guard functions
             /// </summary>
             public bool GuardConditionsMet(params object[] args) => _guard.GuardConditionsMet(args);
@@ -47,8 +47,6 @@ namespace Stateless
             /// whose guard function returns false
             /// </summary>
             public ICollection<string> UnmetGuardConditions(object[] args) => _guard.UnmetGuardConditions(args);
-
-            public abstract bool ResultsInTransitionFrom(TState source, object[] args, out TState destination);
         }
     }
 }

--- a/test/Stateless.Tests/IgnoredTriggerBehaviourFixture.cs
+++ b/test/Stateless.Tests/IgnoredTriggerBehaviourFixture.cs
@@ -8,8 +8,12 @@ namespace Stateless.Tests
         [Fact]
         public void StateRemainsUnchanged()
         {
-            var ignored = new StateMachine<State, Trigger>.IgnoredTriggerBehaviour(Trigger.X, null);
-            Assert.False(ignored.ResultsInTransitionFrom(State.B, new object[0], out _));
+            var sm = new StateMachine<State, Trigger>(State.A);
+            sm.Configure(State.A).Ignore(Trigger.X);
+            
+            sm.Fire(Trigger.X);
+            
+            Assert.Equal(State.A, sm.State);
         }
 
         [Fact]
@@ -21,7 +25,7 @@ namespace Stateless.Tests
             Assert.Equal(Trigger.X, ignored.Trigger);
         }
 
-        protected bool False(params object[] args)
+        private bool False(params object[] args)
         {
             return false;
         }
@@ -35,7 +39,7 @@ namespace Stateless.Tests
             Assert.False(ignored.GuardConditionsMet());
         }
 
-        protected bool True(params object[] args)
+        private bool True(params object[] args)
         {
             return true;
         }
@@ -48,6 +52,7 @@ namespace Stateless.Tests
 
             Assert.True(ignored.GuardConditionsMet());
         }
+        
         [Fact]
         public void IgnoredTriggerMustBeIgnoredSync()
         {

--- a/test/Stateless.Tests/SynchronizationContextFixture.cs
+++ b/test/Stateless.Tests/SynchronizationContextFixture.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -90,7 +89,7 @@ public class SynchronizationContextFixture
         sm.Configure(State.A)
             .OnActivateAsync(CaptureThenLoseSyncContext)
             .SubstateOf(State.B);
-            ;
+            
         sm.Configure(State.B)
             .OnActivateAsync(CaptureThenLoseSyncContext);
         
@@ -110,7 +109,7 @@ public class SynchronizationContextFixture
         sm.Configure(State.A)
             .OnDeactivateAsync(CaptureThenLoseSyncContext)
             .SubstateOf(State.B);
-            ;
+            
         sm.Configure(State.B)
             .OnDeactivateAsync(CaptureThenLoseSyncContext);
         

--- a/test/Stateless.Tests/TransitioningTriggerBehaviourFixture.cs
+++ b/test/Stateless.Tests/TransitioningTriggerBehaviourFixture.cs
@@ -8,8 +8,7 @@ namespace Stateless.Tests
         public void TransitionsToDestinationState()
         {
             var transitioning = new StateMachine<State, Trigger>.TransitioningTriggerBehaviour(Trigger.X, State.C, null);
-            Assert.True(transitioning.ResultsInTransitionFrom(State.B, new object[0], out State destination));
-            Assert.Equal(State.C, destination);
+            Assert.Equal(State.C, transitioning.Destination);
         }
     }
 }


### PR DESCRIPTION
Remove getDestination, and use Destination property instead.
Only dynamic transition needs a GetDestination, so it still has it. Updated tests according to changes.