### PR TITLE
Prepare release 5.16.0

### DIFF
--- a/.github/workflows/BuildAndTestOnPullRequests.yml
+++ b/.github/workflows/BuildAndTestOnPullRequests.yml
@@ -10,7 +10,7 @@ jobs:
   Build_Stateless_solution:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Install dependencies
       run: dotnet restore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 5.16.0 - 2024.05.21
+### Changed
+ - Permit state reentry from dynamic transitions [#565]
+   - This is a change in behavior from v5.15.0 (see [#544]); this version restores the previous behavior for `PermitDynamic` that allows reentry;
+     if reentry is not the desired behavior, consider using a guard condition with `PermitDynamicIf`.
+ - Remove getDestination, and use Destination property instead (internal refactor) [#575]
+### Added
+ - Add overloads to `FireAsync` to support parameterized trigger arguments [#570]
+ - Add overloads to `CanFire` to support parameterized trigger arguments [#574]
+### Fixed
+ - Prevent `NullReferenceException` in the `InvocationInfo` class [#566]
+
 ## 5.15.0 - 2023.12.29
 ### Changed
  - Updated net6.0 build target to net8.0 [#551]
@@ -210,6 +222,11 @@ Version 5.10.0 is now listed as the newest, since it has the highest version num
 ### Removed
 ### Fixed
 
+[#575]: https://github.com/dotnet-state-machine/stateless/pull/575
+[#574]: https://github.com/dotnet-state-machine/stateless/pull/574
+[#570]: https://github.com/dotnet-state-machine/stateless/pull/570
+[#566]: https://github.com/dotnet-state-machine/stateless/pull/566
+[#565]: https://github.com/dotnet-state-machine/stateless/issues/565
 [#551]: https://github.com/dotnet-state-machine/stateless/pull/551
 [#557]: https://github.com/dotnet-state-machine/stateless/issues/557
 [#553]: https://github.com/dotnet-state-machine/stateless/issues/553

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## 5.16.0 - 2024.05.21
+## 5.16.0 - 2024.05.24
 ### Changed
  - Permit state reentry from dynamic transitions [#565]
    - This is a change in behavior from v5.15.0 (see [#544]); this version restores the previous behavior for `PermitDynamic` that allows reentry;

--- a/src/Stateless/Stateless.csproj
+++ b/src/Stateless/Stateless.csproj
@@ -8,7 +8,7 @@
     <Description>Create state machines and lightweight state machine-based workflows directly in .NET code</Description>
     <Copyright>Copyright © Stateless Contributors 2009-$([System.DateTime]::Now.ToString(yyyy))</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>5.15.0</VersionPrefix>
+    <VersionPrefix>5.16.0</VersionPrefix>
     <Authors>Stateless Contributors</Authors>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Release 5.16.0:

 - Permit state reentry from dynamic transitions #565
 - Remove getDestination, and use Destination property instead (internal refactor) #575
 - Add overloads to `FireAsync` to support parameterized trigger arguments #570
 - Add overloads to `CanFire` to support parameterized trigger arguments #574
 - Prevent `NullReferenceException` in the `InvocationInfo` class #566
