### PR TITLE
Expose unmet guard conditions

### DIFF
--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -147,6 +147,17 @@ namespace Stateless
                 .Select(trigger => new TriggerDetails<TState, TTrigger>(trigger, _triggerConfiguration));
         }
 
+        /// <summary>
+        /// Gets any triggers for the current state that are not permissible, and the descriptions
+        /// of the unmet trigger conditions associated with them.
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
+        public IEnumerable<Tuple<TTrigger, string[]>> GetTriggersWithUnmetConditions(params object[] args)
+        {
+            return CurrentRepresentation.GetTriggersWithUnmetGuardConditions(args);
+        }
+
         StateRepresentation CurrentRepresentation
         {
             get

--- a/src/Stateless/StateRepresentation.cs
+++ b/src/Stateless/StateRepresentation.cs
@@ -330,6 +330,26 @@ namespace Stateless
                 return result;
             }
 
+            public IEnumerable<Tuple<TTrigger, string[]>> GetTriggersWithUnmetGuardConditions(params object[] args)
+            {
+                List<Tuple<TTrigger, string[]>> unmetConditions = new List<Tuple<TTrigger, string[]>>();
+
+                var behaviours = TriggerBehaviours.Values.SelectMany(x => x);
+                foreach (var triggerBehaviour in behaviours)
+                {
+                    if (triggerBehaviour.GuardConditionsMet(args))
+                        continue;
+                    
+                    var conditions = triggerBehaviour.UnmetGuardConditions(args);
+                    unmetConditions.Add(new Tuple<TTrigger, string[]>(triggerBehaviour.Trigger, conditions.ToArray()));
+                }
+                
+                if (Superstate != null)
+                    unmetConditions.AddRange(Superstate.GetTriggersWithUnmetGuardConditions(args));
+
+                return unmetConditions;
+            }
+
             internal void SetInitialTransition(TState state)
             {
                 InitialTransitionTarget = state;


### PR DESCRIPTION
This change adds a method to expose the unmet guard conditions.

I'm using this to show validation messages to users as to WHY they are unable to take a certain action within the workflow.

While it is possible to get the entire set of guard condition descriptions through the `StateMachine.GetInfo()` method, the info object exposes all guard conditions for a Trigger, without reporting back which ones are unmet. 

Please let me know if this needs additional changes, and what kind of tests would be appropriate.

I'm also happy to change the return value `IEnumerable<Tuple<TTrigger, string[]>>` with `Dictionary<TTrigger, ICollection<string[]>` if that more closely aligns with other types in use - please let me know.