### PR TITLE
Fix entry function being shown on internal transitions in dot graph

### DIFF
--- a/src/Stateless/Graph/StateGraph.cs
+++ b/src/Stateless/Graph/StateGraph.cs
@@ -137,7 +137,7 @@ namespace Stateless.Graph
                     State toState = States[fix.DestinationState.UnderlyingState.ToString()];
                     if (fromState == toState)
                     {
-                        StayTransition stay = new StayTransition(fromState, fix.Trigger, fix.GuardConditionsMethodDescriptions, true);
+                        StayTransition stay = new StayTransition(fromState, fix.Trigger, fix.GuardConditionsMethodDescriptions, !fix.IsInternalTransition);
                         Transitions.Add(stay);
                         fromState.Leaving.Add(stay);
                         fromState.Arriving.Add(stay);

--- a/src/Stateless/Reflection/FixedTransitionInfo.cs
+++ b/src/Stateless/Reflection/FixedTransitionInfo.cs
@@ -15,7 +15,8 @@ namespace Stateless.Reflection
                 Trigger = new TriggerInfo(behaviour.Trigger),
                 DestinationState = destinationStateInfo,
                 GuardConditionsMethodDescriptions = behaviour.Guard == null
-                    ? new List<InvocationInfo>() : behaviour.Guard.Conditions.Select(c => c.MethodDescription)
+                    ? new List<InvocationInfo>() : behaviour.Guard.Conditions.Select(c => c.MethodDescription),
+                IsInternalTransition = behaviour is StateMachine<TState, TTrigger>.InternalTriggerBehaviour
             };
 
             return transition;

--- a/src/Stateless/Reflection/TransitionInfo.cs
+++ b/src/Stateless/Reflection/TransitionInfo.cs
@@ -17,5 +17,10 @@ namespace Stateless.Reflection
         /// Returns a non-null but empty list if there are no guard conditions
         /// </summary>
         public IEnumerable<InvocationInfo> GuardConditionsMethodDescriptions;
+
+        /// <summary>
+        /// When true, the transition is internal and does not invoke the entry/exit actions of the state.
+        /// </summary>
+        public bool IsInternalTransition { get; protected set; }
     }
 }

--- a/test/Stateless.Tests/DotGraphFixture.cs
+++ b/test/Stateless.Tests/DotGraphFixture.cs
@@ -538,6 +538,30 @@ namespace Stateless.Tests
         }
 
         [Fact]
+        public void Internal_Transition_Does_Not_Show_Entry_Exit_Functions()
+        {
+            var expected = Prefix(Style.UML)
+                + Box(Style.UML, "A", new List<string> { "DoEntry" }, new List<string> { "DoExit" })
+                + Line("A", "A", "X [Function]")
+                + suffix;
+
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+                .OnEntry(x => { }, "DoEntry")
+                .OnExit(x => { }, "DoExit")
+                .InternalTransition(Trigger.X, x => { });
+
+            string dotGraph = UmlDotGraph.Format(sm.GetInfo());
+
+#if WRITE_DOTS_TO_FOLDER
+            System.IO.File.WriteAllText(DestinationFolder + "Internal_Transition_Does_Not_Show_Entry_Exit_Functions.dot", dotGraph);
+#endif
+
+            Assert.Equal(expected, dotGraph);
+        }
+
+        [Fact]
         public void Initial_State_Not_Changed_After_Trigger_Fired()
         {
             var expected = Prefix(Style.UML) + Box(Style.UML, "A") + Box(Style.UML, "B") + Line("A", "B", "X") + suffix;


### PR DESCRIPTION
To address issue #587.

This PR is to address an issue in `StateGraph` where re-entrant transitions cannot be marked as internal since the `TransitionInfo` class does not distinguish between internal and non-internal transitions. By adding a flag, `IsInternalTransition`, `StateGraph` is able to correctly set the `executeEntryExitActions` argument on the `StayTransition` constructor.