### PR TITLE
Add net9.0 to build targets; include build targets in tests.

### DIFF
--- a/src/Stateless/Stateless.csproj
+++ b/src/Stateless/Stateless.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>Stateless</AssemblyName>
     <AssemblyTitle>Stateless</AssemblyTitle>
     <Product>Stateless</Product>
-    <TargetFrameworks>netstandard2.0;net462;net8.0;</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net8.0;net9.0</TargetFrameworks>
     <Description>Create state machines and lightweight state machine-based workflows directly in .NET code</Description>
     <Copyright>Copyright © Stateless Contributors 2009-$([System.DateTime]::Now.ToString(yyyy))</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/test/Stateless.Tests/GetInfoFixture.cs
+++ b/test/Stateless.Tests/GetInfoFixture.cs
@@ -1,41 +1,42 @@
 ﻿using System.Threading.Tasks;
 using Xunit;
 
-namespace Stateless.Tests;
-
-public class GetInfoFixture
+namespace Stateless.Tests
 {
-    [Fact]
-    public void GetInfo_should_return_Entry_action_with_trigger_name()
+    public class GetInfoFixture
     {
-        // ARRANGE
-        var sm = new StateMachine<State, Trigger>(State.A);
-        sm.Configure(State.B)
-            .OnEntryFrom(Trigger.X, () => { });
+        [Fact]
+        public void GetInfo_should_return_Entry_action_with_trigger_name()
+        {
+            // ARRANGE
+            var sm = new StateMachine<State, Trigger>(State.A);
+            sm.Configure(State.B)
+                .OnEntryFrom(Trigger.X, () => { });
         
-        // ACT
-        var stateMachineInfo = sm.GetInfo();
+            // ACT
+            var stateMachineInfo = sm.GetInfo();
         
-        // ASSERT
-        var stateInfo = Assert.Single(stateMachineInfo.States);
-        var entryActionInfo = Assert.Single(stateInfo.EntryActions);
-        Assert.Equal(Trigger.X.ToString(), entryActionInfo.FromTrigger);
-    }
+            // ASSERT
+            var stateInfo = Assert.Single(stateMachineInfo.States);
+            var entryActionInfo = Assert.Single(stateInfo.EntryActions);
+            Assert.Equal(Trigger.X.ToString(), entryActionInfo.FromTrigger);
+        }
     
-    [Fact]
-    public void GetInfo_should_return_async_Entry_action_with_trigger_name()
-    {
-        // ARRANGE
-        var sm = new StateMachine<State, Trigger>(State.A);
-        sm.Configure(State.B)
-            .OnEntryFromAsync(Trigger.X, () => Task.CompletedTask);
+        [Fact]
+        public void GetInfo_should_return_async_Entry_action_with_trigger_name()
+        {
+            // ARRANGE
+            var sm = new StateMachine<State, Trigger>(State.A);
+            sm.Configure(State.B)
+                .OnEntryFromAsync(Trigger.X, () => Task.CompletedTask);
         
-        // ACT
-        var stateMachineInfo = sm.GetInfo();
+            // ACT
+            var stateMachineInfo = sm.GetInfo();
         
-        // ASSERT
-        var stateInfo = Assert.Single(stateMachineInfo.States);
-        var entryActionInfo = Assert.Single(stateInfo.EntryActions);
-        Assert.Equal(Trigger.X.ToString(), entryActionInfo.FromTrigger);
+            // ASSERT
+            var stateInfo = Assert.Single(stateMachineInfo.States);
+            var entryActionInfo = Assert.Single(stateInfo.EntryActions);
+            Assert.Equal(Trigger.X.ToString(), entryActionInfo.FromTrigger);
+        }
     }
 }

--- a/test/Stateless.Tests/StateInfoTests.cs
+++ b/test/Stateless.Tests/StateInfoTests.cs
@@ -1,25 +1,26 @@
 ﻿using Stateless.Reflection;
 using Xunit;
 
-namespace Stateless.Tests;
-
-public class StateInfoTests
+namespace Stateless.Tests
 {
-    /// <summary>
-    /// For StateInfo, Substates, FixedTransitions and DynamicTransitions are only initialised by a call to AddRelationships.
-    /// However, for StateMachineInfo.InitialState, this never happens. Therefore StateMachineInfo.InitialState.Transitions
-    /// throws a System.ArgumentNullException. 
-    /// </summary>
-    [Fact]
-    public void StateInfo_transitions_should_default_to_empty()
+    public class StateInfoTests
     {
-        // ARRANGE
-        var stateInfo = StateInfo.CreateStateInfo(new StateMachine<State, Trigger>.StateRepresentation(State.A));
+        /// <summary>
+        /// For StateInfo, Substates, FixedTransitions and DynamicTransitions are only initialised by a call to AddRelationships.
+        /// However, for StateMachineInfo.InitialState, this never happens. Therefore StateMachineInfo.InitialState.Transitions
+        /// throws a System.ArgumentNullException. 
+        /// </summary>
+        [Fact]
+        public void StateInfo_transitions_should_default_to_empty()
+        {
+            // ARRANGE
+            var stateInfo = StateInfo.CreateStateInfo(new StateMachine<State, Trigger>.StateRepresentation(State.A));
         
-        // ACT
-        var stateInfoTransitions = stateInfo.Transitions;
+            // ACT
+            var stateInfoTransitions = stateInfo.Transitions;
         
-        // ASSERT
-        Assert.Null(stateInfoTransitions);
-    } 
+            // ASSERT
+            Assert.Null(stateInfoTransitions);
+        } 
+    }
 }

--- a/test/Stateless.Tests/Stateless.Tests.csproj
+++ b/test/Stateless.Tests/Stateless.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);TASKS</DefineConstants>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AssemblyName>Stateless.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../asset/Stateless.snk</AssemblyOriginatorKeyFile>

--- a/test/Stateless.Tests/SynchronizationContextFixture.cs
+++ b/test/Stateless.Tests/SynchronizationContextFixture.cs
@@ -6,355 +6,356 @@ using System.Threading.Tasks;
 using Xunit;
 using Xunit.Sdk;
 
-namespace Stateless.Tests;
-
-public class SynchronizationContextFixture
+namespace Stateless.Tests
 {
-    // Define a custom SynchronizationContext. All calls made to delegates should be with this context.
-    private readonly MaxConcurrencySyncContext _customSynchronizationContext = new(3);
-    private readonly List<SynchronizationContext> _capturedSyncContext = new();
-    
-    private StateMachine<State, Trigger> GetSut(State initialState = State.A)
+    public class SynchronizationContextFixture
     {
-        return new StateMachine<State, Trigger>(initialState, FiringMode.Queued)
+        // Define a custom SynchronizationContext. All calls made to delegates should be with this context.
+        private readonly MaxConcurrencySyncContext _customSynchronizationContext = new MaxConcurrencySyncContext(3);
+        private readonly List<SynchronizationContext> _capturedSyncContext = new List<SynchronizationContext>();
+    
+        private StateMachine<State, Trigger> GetSut(State initialState = State.A)
         {
-            RetainSynchronizationContext = true
-        };
-    }
-    
-    private void SetSyncContext()
-    {
-        SynchronizationContext.SetSynchronizationContext(_customSynchronizationContext);
-    }
-
-    /// <summary>
-    /// Simulate a call that loses the synchronization context
-    /// </summary>
-    private async Task CaptureThenLoseSyncContext()
-    {
-        CaptureSyncContext();
-        await LoseSyncContext().ConfigureAwait(false); // ConfigureAwait false here to ensure we continue using the sync context returned by LoseSyncContext 
-    }
-    
-    private void CaptureSyncContext()
-    {
-        _capturedSyncContext.Add(SynchronizationContext.Current);
-    }
-
-    private async Task LoseSyncContext()
-    {
-        await new CompletesOnDifferentThreadAwaitable(); // Switch synchronization context and continue
-        Assert.NotEqual(_customSynchronizationContext, SynchronizationContext.Current);
-    }
-
-    /// <summary>
-    /// Tests capture the SynchronizationContext at various points throughout their execution.
-    /// This asserts that every capture is the expected SynchronizationContext instance and that it hasn't been lost. 
-    /// </summary>
-    /// <param name="numberOfExpectedCalls">Ensure that we have the expected number of captures</param>
-    // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
-    private void AssertSyncContextAlwaysRetained(int numberOfExpectedCalls)
-    {
-        Assert.Equal(numberOfExpectedCalls, _capturedSyncContext.Count);
-        Assert.All(_capturedSyncContext, actual => Assert.Equal(_customSynchronizationContext, actual));
-    }
-
-    /// <summary>
-    /// XUnit uses its own SynchronizationContext to execute each test. Therefore, placing SetSyncContext() in the constructor instead of
-    /// at the start of every test does not work as desired. This test ensures XUnit's behaviour has not changed.
-    /// </summary>
-    [Fact]
-    public void Ensure_XUnit_is_using_SyncContext()
-    {
-        SetSyncContext();
-        CaptureSyncContext();
-        AssertSyncContextAlwaysRetained(1);
-    }
-    
-    /// <summary>
-    /// SynchronizationContext are funny things. The way that they are lost varies depending on their implementation.
-    /// This test ensures that our mechanism for losing the SynchronizationContext works.
-    /// </summary>
-    [Fact]
-    public async Task Ensure_XUnit_can_lose_sync_context()
-    {
-        SetSyncContext();
-        await LoseSyncContext().ConfigureAwait(false);
-        Assert.NotEqual(_customSynchronizationContext, SynchronizationContext.Current);
-    }
-
-    [Fact]
-    public async Task Activation_of_state_with_superstate_should_retain_SyncContext()
-    {
-        // ARRANGE
-        SetSyncContext();
-        var sm = GetSut();
-        sm.Configure(State.A)
-            .OnActivateAsync(CaptureThenLoseSyncContext)
-            .SubstateOf(State.B);
-            
-        sm.Configure(State.B)
-            .OnActivateAsync(CaptureThenLoseSyncContext);
-        
-        // ACT
-        await sm.ActivateAsync();
-        
-        // ASSERT
-        AssertSyncContextAlwaysRetained(2);
-    }
-    
-    [Fact]
-    public async Task Deactivation_of_state_with_superstate_should_retain_SyncContext()
-    {
-        // ARRANGE
-        SetSyncContext();
-        var sm = GetSut();
-        sm.Configure(State.A)
-            .OnDeactivateAsync(CaptureThenLoseSyncContext)
-            .SubstateOf(State.B);
-            
-        sm.Configure(State.B)
-            .OnDeactivateAsync(CaptureThenLoseSyncContext);
-        
-        // ACT
-        await sm.DeactivateAsync();
-        
-        // ASSERT
-        AssertSyncContextAlwaysRetained(2);
-    }
-    
-    [Fact]
-    public async Task Multiple_activations_should_retain_SyncContext()
-    {
-        // ARRANGE
-        SetSyncContext();
-        var sm = GetSut();
-        sm.Configure(State.A)
-            .OnActivateAsync(CaptureThenLoseSyncContext)
-            .OnActivateAsync(CaptureThenLoseSyncContext)
-            .OnActivateAsync(CaptureThenLoseSyncContext);
-        
-        // ACT
-        await sm.ActivateAsync();
-        
-        // ASSERT
-        AssertSyncContextAlwaysRetained(3);
-    }
-    
-    [Fact]
-    public async Task Multiple_Deactivations_should_retain_SyncContext()
-    {
-        // ARRANGE
-        SetSyncContext();
-        var sm = GetSut();
-        sm.Configure(State.A)
-            .OnDeactivateAsync(CaptureThenLoseSyncContext)
-            .OnDeactivateAsync(CaptureThenLoseSyncContext)
-            .OnDeactivateAsync(CaptureThenLoseSyncContext);
-        
-        // ACT
-        await sm.DeactivateAsync();
-        
-        // ASSERT
-        AssertSyncContextAlwaysRetained(3);
-     }
-    
-    [Fact]
-    public async Task Multiple_OnEntry_should_retain_SyncContext()
-    {
-        // ARRANGE
-        SetSyncContext();
-        var sm = GetSut();
-        sm.Configure(State.A).Permit(Trigger.X, State.B);
-        sm.Configure(State.B)
-            .OnEntryAsync(CaptureThenLoseSyncContext)
-            .OnEntryAsync(CaptureThenLoseSyncContext)
-            .OnEntryAsync(CaptureThenLoseSyncContext);
-        
-        // ACT
-        await sm.FireAsync(Trigger.X);
-        
-        // ASSERT
-        AssertSyncContextAlwaysRetained(3);
-    } 
-    
-    [Fact]
-    public async Task Multiple_OnExit_should_retain_SyncContext()
-    {
-        // ARRANGE
-        SetSyncContext();
-        var sm = GetSut();
-        sm.Configure(State.A)
-            .Permit(Trigger.X, State.B)
-            .OnExitAsync(CaptureThenLoseSyncContext)
-            .OnExitAsync(CaptureThenLoseSyncContext)
-            .OnExitAsync(CaptureThenLoseSyncContext);
-        sm.Configure(State.B);
-        
-        // ACT
-        await sm.FireAsync(Trigger.X);
-        
-        // ASSERT
-        AssertSyncContextAlwaysRetained(3);
-    }
-    
-    [Fact]
-    public async Task OnExit_state_with_superstate_should_retain_SyncContext()
-    {
-        // ARRANGE
-        SetSyncContext();
-        var sm = GetSut(State.B);
-        sm.Configure(State.A)
-            .OnExitAsync(CaptureThenLoseSyncContext)
-            ;
-        
-        sm.Configure(State.B)
-            .SubstateOf(State.A)
-            .Permit(Trigger.X, State.C)
-            .OnExitAsync(CaptureThenLoseSyncContext)
-            ;
-        sm.Configure(State.C);
-        
-        // ACT
-        await sm.FireAsync(Trigger.X);
-        
-        // ASSERT
-        AssertSyncContextAlwaysRetained(2);
-    }
-    
-    [Fact]
-    public async Task OnExit_state_and_superstate_should_retain_SyncContext()
-    {
-        // ARRANGE
-        SetSyncContext();
-        var sm = GetSut(State.C);
-        sm.Configure(State.A);
-
-        sm.Configure(State.B)
-            .SubstateOf(State.A)
-            .OnExitAsync(CaptureThenLoseSyncContext);
-        
-        sm.Configure(State.C)
-            .SubstateOf(State.B)
-            .Permit(Trigger.X, State.A)
-            .OnExitAsync(CaptureThenLoseSyncContext);
-        
-        // ACT
-        await sm.FireAsync(Trigger.X);
-        
-        // ASSERT
-        AssertSyncContextAlwaysRetained(2);
-    }
-    
-    [Fact]
-    public async Task Multiple_OnEntry_on_Reentry_should_retain_SyncContext()
-    {
-        // ARRANGE
-        SetSyncContext();
-        var sm = GetSut();
-        sm.Configure(State.A).PermitReentry(Trigger.X)
-            .OnEntryAsync(CaptureThenLoseSyncContext)
-            .OnEntryAsync(CaptureThenLoseSyncContext);
-        
-        // ACT
-        await sm.FireAsync(Trigger.X);
-        
-        // ASSERT
-        AssertSyncContextAlwaysRetained(2);
-    }
-    
-    [Fact]
-    public async Task Multiple_OnExit_on_Reentry_should_retain_SyncContext()
-    {
-        // ARRANGE
-        SetSyncContext();
-        var sm = GetSut();
-        sm.Configure(State.A).PermitReentry(Trigger.X)
-            .OnExitAsync(CaptureThenLoseSyncContext)
-            .OnExitAsync(CaptureThenLoseSyncContext);
-        
-        // ACT
-        await sm.FireAsync(Trigger.X);
-        
-        // ASSERT
-        AssertSyncContextAlwaysRetained(2);
-    }
-
-    [Fact]
-    public async Task Trigger_firing_another_Trigger_should_retain_SyncContext()
-    {
-        // ARRANGE
-        SetSyncContext();
-        var sm = GetSut();
-        sm.Configure(State.A)
-            .InternalTransitionAsync(Trigger.X, async () =>
+            return new StateMachine<State, Trigger>(initialState, FiringMode.Queued)
             {
-                await CaptureThenLoseSyncContext();
-                await sm.FireAsync(Trigger.Y);
-            })
-            .Permit(Trigger.Y, State.B)
-            ;
-        sm.Configure(State.B)
-            .OnEntryAsync(CaptureThenLoseSyncContext);
-        
-        // ACT
-        await sm.FireAsync(Trigger.X);
-        
-        // ASSERT
-        AssertSyncContextAlwaysRetained(2);
-    }
+                RetainSynchronizationContext = true
+            };
+        }
     
-    [Fact]
-    public async Task OnTransition_should_retain_SyncContext()
-    {
-        // ARRANGE
-        SetSyncContext();
-        var sm = GetSut();
-        sm.Configure(State.A)
-            .Permit(Trigger.X, State.B);
-
-        sm.Configure(State.B);
-
-        sm.OnTransitionedAsync(_ => CaptureThenLoseSyncContext());
-        sm.OnTransitionedAsync(_ => CaptureThenLoseSyncContext());
-        sm.OnTransitionedAsync(_ => CaptureThenLoseSyncContext());
-        
-        // ACT
-        await sm.FireAsync(Trigger.X);
-        
-        // ASSERT
-        AssertSyncContextAlwaysRetained(3);
-    }
-    
-    [Fact]
-    public async Task InternalTransition_firing_a_sync_action_should_retain_SyncContext()
-    {
-        // ARRANGE
-        SetSyncContext();
-        var sm = GetSut();
-        sm.Configure(State.A)
-            .InternalTransition(Trigger.X, CaptureSyncContext);
-        
-        // ACT
-        await sm.FireAsync(Trigger.X);
-        
-        // ASSERT
-        AssertSyncContextAlwaysRetained(1);
-    }
-    
-    private class CompletesOnDifferentThreadAwaitable
-    {
-        public CompletesOnDifferentThreadAwaiter GetAwaiter() => new();
-
-        internal class CompletesOnDifferentThreadAwaiter : INotifyCompletion
+        private void SetSyncContext()
         {
-            public void GetResult() { }
+            SynchronizationContext.SetSynchronizationContext(_customSynchronizationContext);
+        }
 
-            public bool IsCompleted => false;
+        /// <summary>
+        /// Simulate a call that loses the synchronization context
+        /// </summary>
+        private async Task CaptureThenLoseSyncContext()
+        {
+            CaptureSyncContext();
+            await LoseSyncContext().ConfigureAwait(false); // ConfigureAwait false here to ensure we continue using the sync context returned by LoseSyncContext 
+        }
+    
+        private void CaptureSyncContext()
+        {
+            _capturedSyncContext.Add(SynchronizationContext.Current);
+        }
 
-            public void OnCompleted(Action continuation)
+        private async Task LoseSyncContext()
+        {
+            await new CompletesOnDifferentThreadAwaitable(); // Switch synchronization context and continue
+            Assert.NotEqual(_customSynchronizationContext, SynchronizationContext.Current);
+        }
+
+        /// <summary>
+        /// Tests capture the SynchronizationContext at various points throughout their execution.
+        /// This asserts that every capture is the expected SynchronizationContext instance and that it hasn't been lost. 
+        /// </summary>
+        /// <param name="numberOfExpectedCalls">Ensure that we have the expected number of captures</param>
+        // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
+        private void AssertSyncContextAlwaysRetained(int numberOfExpectedCalls)
+        {
+            Assert.Equal(numberOfExpectedCalls, _capturedSyncContext.Count);
+            Assert.All(_capturedSyncContext, actual => Assert.Equal(_customSynchronizationContext, actual));
+        }
+
+        /// <summary>
+        /// XUnit uses its own SynchronizationContext to execute each test. Therefore, placing SetSyncContext() in the constructor instead of
+        /// at the start of every test does not work as desired. This test ensures XUnit's behaviour has not changed.
+        /// </summary>
+        [Fact]
+        public void Ensure_XUnit_is_using_SyncContext()
+        {
+            SetSyncContext();
+            CaptureSyncContext();
+            AssertSyncContextAlwaysRetained(1);
+        }
+    
+        /// <summary>
+        /// SynchronizationContext are funny things. The way that they are lost varies depending on their implementation.
+        /// This test ensures that our mechanism for losing the SynchronizationContext works.
+        /// </summary>
+        [Fact]
+        public async Task Ensure_XUnit_can_lose_sync_context()
+        {
+            SetSyncContext();
+            await LoseSyncContext().ConfigureAwait(false);
+            Assert.NotEqual(_customSynchronizationContext, SynchronizationContext.Current);
+        }
+
+        [Fact]
+        public async Task Activation_of_state_with_superstate_should_retain_SyncContext()
+        {
+            // ARRANGE
+            SetSyncContext();
+            var sm = GetSut();
+            sm.Configure(State.A)
+                .OnActivateAsync(CaptureThenLoseSyncContext)
+                .SubstateOf(State.B);
+            
+            sm.Configure(State.B)
+                .OnActivateAsync(CaptureThenLoseSyncContext);
+        
+            // ACT
+            await sm.ActivateAsync();
+        
+            // ASSERT
+            AssertSyncContextAlwaysRetained(2);
+        }
+    
+        [Fact]
+        public async Task Deactivation_of_state_with_superstate_should_retain_SyncContext()
+        {
+            // ARRANGE
+            SetSyncContext();
+            var sm = GetSut();
+            sm.Configure(State.A)
+                .OnDeactivateAsync(CaptureThenLoseSyncContext)
+                .SubstateOf(State.B);
+            
+            sm.Configure(State.B)
+                .OnDeactivateAsync(CaptureThenLoseSyncContext);
+        
+            // ACT
+            await sm.DeactivateAsync();
+        
+            // ASSERT
+            AssertSyncContextAlwaysRetained(2);
+        }
+    
+        [Fact]
+        public async Task Multiple_activations_should_retain_SyncContext()
+        {
+            // ARRANGE
+            SetSyncContext();
+            var sm = GetSut();
+            sm.Configure(State.A)
+                .OnActivateAsync(CaptureThenLoseSyncContext)
+                .OnActivateAsync(CaptureThenLoseSyncContext)
+                .OnActivateAsync(CaptureThenLoseSyncContext);
+        
+            // ACT
+            await sm.ActivateAsync();
+        
+            // ASSERT
+            AssertSyncContextAlwaysRetained(3);
+        }
+    
+        [Fact]
+        public async Task Multiple_Deactivations_should_retain_SyncContext()
+        {
+            // ARRANGE
+            SetSyncContext();
+            var sm = GetSut();
+            sm.Configure(State.A)
+                .OnDeactivateAsync(CaptureThenLoseSyncContext)
+                .OnDeactivateAsync(CaptureThenLoseSyncContext)
+                .OnDeactivateAsync(CaptureThenLoseSyncContext);
+        
+            // ACT
+            await sm.DeactivateAsync();
+        
+            // ASSERT
+            AssertSyncContextAlwaysRetained(3);
+         }
+    
+        [Fact]
+        public async Task Multiple_OnEntry_should_retain_SyncContext()
+        {
+            // ARRANGE
+            SetSyncContext();
+            var sm = GetSut();
+            sm.Configure(State.A).Permit(Trigger.X, State.B);
+            sm.Configure(State.B)
+                .OnEntryAsync(CaptureThenLoseSyncContext)
+                .OnEntryAsync(CaptureThenLoseSyncContext)
+                .OnEntryAsync(CaptureThenLoseSyncContext);
+        
+            // ACT
+            await sm.FireAsync(Trigger.X);
+        
+            // ASSERT
+            AssertSyncContextAlwaysRetained(3);
+        } 
+    
+        [Fact]
+        public async Task Multiple_OnExit_should_retain_SyncContext()
+        {
+            // ARRANGE
+            SetSyncContext();
+            var sm = GetSut();
+            sm.Configure(State.A)
+                .Permit(Trigger.X, State.B)
+                .OnExitAsync(CaptureThenLoseSyncContext)
+                .OnExitAsync(CaptureThenLoseSyncContext)
+                .OnExitAsync(CaptureThenLoseSyncContext);
+            sm.Configure(State.B);
+        
+            // ACT
+            await sm.FireAsync(Trigger.X);
+        
+            // ASSERT
+            AssertSyncContextAlwaysRetained(3);
+        }
+    
+        [Fact]
+        public async Task OnExit_state_with_superstate_should_retain_SyncContext()
+        {
+            // ARRANGE
+            SetSyncContext();
+            var sm = GetSut(State.B);
+            sm.Configure(State.A)
+                .OnExitAsync(CaptureThenLoseSyncContext)
+                ;
+        
+            sm.Configure(State.B)
+                .SubstateOf(State.A)
+                .Permit(Trigger.X, State.C)
+                .OnExitAsync(CaptureThenLoseSyncContext)
+                ;
+            sm.Configure(State.C);
+        
+            // ACT
+            await sm.FireAsync(Trigger.X);
+        
+            // ASSERT
+            AssertSyncContextAlwaysRetained(2);
+        }
+    
+        [Fact]
+        public async Task OnExit_state_and_superstate_should_retain_SyncContext()
+        {
+            // ARRANGE
+            SetSyncContext();
+            var sm = GetSut(State.C);
+            sm.Configure(State.A);
+
+            sm.Configure(State.B)
+                .SubstateOf(State.A)
+                .OnExitAsync(CaptureThenLoseSyncContext);
+        
+            sm.Configure(State.C)
+                .SubstateOf(State.B)
+                .Permit(Trigger.X, State.A)
+                .OnExitAsync(CaptureThenLoseSyncContext);
+        
+            // ACT
+            await sm.FireAsync(Trigger.X);
+        
+            // ASSERT
+            AssertSyncContextAlwaysRetained(2);
+        }
+    
+        [Fact]
+        public async Task Multiple_OnEntry_on_Reentry_should_retain_SyncContext()
+        {
+            // ARRANGE
+            SetSyncContext();
+            var sm = GetSut();
+            sm.Configure(State.A).PermitReentry(Trigger.X)
+                .OnEntryAsync(CaptureThenLoseSyncContext)
+                .OnEntryAsync(CaptureThenLoseSyncContext);
+        
+            // ACT
+            await sm.FireAsync(Trigger.X);
+        
+            // ASSERT
+            AssertSyncContextAlwaysRetained(2);
+        }
+    
+        [Fact]
+        public async Task Multiple_OnExit_on_Reentry_should_retain_SyncContext()
+        {
+            // ARRANGE
+            SetSyncContext();
+            var sm = GetSut();
+            sm.Configure(State.A).PermitReentry(Trigger.X)
+                .OnExitAsync(CaptureThenLoseSyncContext)
+                .OnExitAsync(CaptureThenLoseSyncContext);
+        
+            // ACT
+            await sm.FireAsync(Trigger.X);
+        
+            // ASSERT
+            AssertSyncContextAlwaysRetained(2);
+        }
+
+        [Fact]
+        public async Task Trigger_firing_another_Trigger_should_retain_SyncContext()
+        {
+            // ARRANGE
+            SetSyncContext();
+            var sm = GetSut();
+            sm.Configure(State.A)
+                .InternalTransitionAsync(Trigger.X, async () =>
+                {
+                    await CaptureThenLoseSyncContext();
+                    await sm.FireAsync(Trigger.Y);
+                })
+                .Permit(Trigger.Y, State.B)
+                ;
+            sm.Configure(State.B)
+                .OnEntryAsync(CaptureThenLoseSyncContext);
+        
+            // ACT
+            await sm.FireAsync(Trigger.X);
+        
+            // ASSERT
+            AssertSyncContextAlwaysRetained(2);
+        }
+    
+        [Fact]
+        public async Task OnTransition_should_retain_SyncContext()
+        {
+            // ARRANGE
+            SetSyncContext();
+            var sm = GetSut();
+            sm.Configure(State.A)
+                .Permit(Trigger.X, State.B);
+
+            sm.Configure(State.B);
+
+            sm.OnTransitionedAsync(_ => CaptureThenLoseSyncContext());
+            sm.OnTransitionedAsync(_ => CaptureThenLoseSyncContext());
+            sm.OnTransitionedAsync(_ => CaptureThenLoseSyncContext());
+        
+            // ACT
+            await sm.FireAsync(Trigger.X);
+        
+            // ASSERT
+            AssertSyncContextAlwaysRetained(3);
+        }
+    
+        [Fact]
+        public async Task InternalTransition_firing_a_sync_action_should_retain_SyncContext()
+        {
+            // ARRANGE
+            SetSyncContext();
+            var sm = GetSut();
+            sm.Configure(State.A)
+                .InternalTransition(Trigger.X, CaptureSyncContext);
+        
+            // ACT
+            await sm.FireAsync(Trigger.X);
+        
+            // ASSERT
+            AssertSyncContextAlwaysRetained(1);
+        }
+    
+        private class CompletesOnDifferentThreadAwaitable
+        {
+            public CompletesOnDifferentThreadAwaiter GetAwaiter() => new CompletesOnDifferentThreadAwaiter();
+
+            internal class CompletesOnDifferentThreadAwaiter : INotifyCompletion
             {
-                ThreadPool.QueueUserWorkItem(_ => continuation());
+                public void GetResult() { }
+
+                public bool IsCompleted => false;
+
+                public void OnCompleted(Action continuation)
+                {
+                    ThreadPool.QueueUserWorkItem(_ => continuation());
+                }
             }
         }
     }


### PR DESCRIPTION
As discussed in #609, adds a .NET 9.0 build target. Also runs tests against .NET Framework 4.6.2 and .NET 9.0 in addition to .NET 8.0.