### PR TITLE
Quality of life changes

### DIFF
--- a/src/Stateless/Graph/MermaidGraphStyle.cs
+++ b/src/Stateless/Graph/MermaidGraphStyle.cs
@@ -66,18 +66,21 @@ namespace Stateless.Graph
         public override string GetPrefix()
         {
             BuildSanitizedNamedStateMap();
-            string prefix = "stateDiagram-v2";
+
+            StringBuilder sb = new StringBuilder("stateDiagram-v2");
             if (_direction.HasValue)
             {
-                prefix += $"{Environment.NewLine}\tdirection {GetDirectionCode(_direction.Value)}";
+                sb.AppendLine();
+                sb.Append($"\tdirection {GetDirectionCode(_direction.Value)}");
             }
 
             foreach (var state in _stateMap.Where(x => !x.Key.Equals(x.Value.StateName, StringComparison.Ordinal)))
             {
-                prefix += $"{Environment.NewLine}\t{state.Key} : {state.Value.StateName}";
+                sb.AppendLine();
+                sb.Append($"\t{state.Key} : {state.Value.StateName}");
             }
 
-            return prefix;
+            return sb.ToString();
         }
 
         /// <inheritdoc/>
@@ -91,25 +94,29 @@ namespace Stateless.Graph
         /// <inheritdoc/>
         public override string FormatOneTransition(string sourceNodeName, string trigger, IEnumerable<string> actions, string destinationNodeName, IEnumerable<string> guards)
         {
-            string label = trigger ?? "";
+            StringBuilder sb = new StringBuilder(trigger ?? string.Empty);
 
             if (actions?.Count() > 0)
-                label += " / " + string.Join(", ", actions);
+            {
+                sb.Append(" / ");
+                sb.Append(string.Join(", ", actions));
+            }
 
             if (guards.Any())
             {
                 foreach (var info in guards)
                 {
-                    if (label.Length > 0)
-                        label += " ";
-                    label += "[" + info + "]";
+                    if (sb.Length > 0)
+                        sb.Append(" ");
+
+                    sb.Append("[" + info + "]");
                 }
             }
 
             var sanitizedSourceNodeName = GetSanitizedStateName(sourceNodeName);
             var sanitizedDestinationNodeName = GetSanitizedStateName(destinationNodeName);
 
-            return FormatOneLine(sanitizedSourceNodeName, sanitizedDestinationNodeName, label);
+            return FormatOneLine(sanitizedSourceNodeName, sanitizedDestinationNodeName, sb.ToString());
         }
 
         internal string FormatOneLine(string fromNodeName, string toNodeName, string label)

--- a/src/Stateless/Graph/StateGraph.cs
+++ b/src/Stateless/Graph/StateGraph.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Text;
 using Stateless.Reflection;
 
 namespace Stateless.Graph
@@ -58,12 +61,12 @@ namespace Stateless.Graph
         /// <returns></returns>
         public string ToGraph(GraphStyleBase style)
         {
-            string dirgraphText = style.GetPrefix();
+            StringBuilder sb = new StringBuilder(style.GetPrefix());
 
             // Start with the clusters
             foreach (var state in States.Values.Where(x => x is SuperState))
             {
-                dirgraphText += style.FormatOneCluster((SuperState)state);
+                sb.Append(style.FormatOneCluster((SuperState)state));
             }
 
             // Next process all non-cluster states
@@ -71,24 +74,28 @@ namespace Stateless.Graph
             {
                 if (state is SuperState || state is Decision || state.SuperState != null)
                     continue;
-                dirgraphText += style.FormatOneState(state);
+
+                sb.Append(style.FormatOneState(state));
             }
 
             // Finally, add decision nodes
             foreach (var dec in Decisions)
             {
-                dirgraphText += style.FormatOneDecisionNode(dec.NodeName, dec.Method.Description);
+                sb.Append(style.FormatOneDecisionNode(dec.NodeName, dec.Method.Description));
             }
 
             // now build behaviours
             List<string> transits = style.FormatAllTransitions(Transitions);
             foreach (var transit in transits)
-                dirgraphText += System.Environment.NewLine + transit;
+            {
+                sb.Append(Environment.NewLine);
+                sb.Append(transit);
+            }
 
             // Add initial transition if present
-            dirgraphText += style.GetInitialTransition(initialState);
+            sb.Append(style.GetInitialTransition(initialState));
 
-            return dirgraphText;
+            return sb.ToString();
         }
 
         /// <summary>
@@ -202,8 +209,9 @@ namespace Stateless.Graph
         {
             foreach (var stateInfo in machineInfo.States)
             {
-                if (!States.ContainsKey(stateInfo.UnderlyingState.ToString()))
-                    States[stateInfo.UnderlyingState.ToString()] = new State(stateInfo);
+                string underlyingState = stateInfo.UnderlyingState.ToString();
+                if (!States.ContainsKey(underlyingState))
+                    States[underlyingState] = new State(stateInfo);
             }
         }
 
@@ -225,14 +233,15 @@ namespace Stateless.Graph
         {
             foreach (var subState in substates)
             {
-                if (States.ContainsKey(subState.UnderlyingState.ToString()))
+                string underlyingState = subState.UnderlyingState.ToString();
+                if (States.ContainsKey(underlyingState))
                 {
                     // This shouldn't happen
                 }
                 else if (subState.Substates.Any())
                 {
                     SuperState sub = new SuperState(subState);
-                    States[subState.UnderlyingState.ToString()] = sub;
+                    States[underlyingState] = sub;
                     superState.SubStates.Add(sub);
                     sub.SuperState = superState;
                     AddSubstates(sub, subState.Substates);
@@ -240,7 +249,7 @@ namespace Stateless.Graph
                 else
                 {
                     State sub = new State(subState);
-                    States[subState.UnderlyingState.ToString()] = sub;
+                    States[underlyingState] = sub;
                     superState.SubStates.Add(sub);
                     sub.SuperState = superState;
                 }

--- a/src/Stateless/Graph/UmlDotGraphStyle.cs
+++ b/src/Stateless/Graph/UmlDotGraphStyle.cs
@@ -70,17 +70,16 @@ namespace Stateless.Graph
             if (state.EntryActions.Count == 0 && state.ExitActions.Count == 0)
                 return $"\"{escapedStateName}\" [label=\"{escapedStateName}\"];{Environment.NewLine}";
 
-            string f = $"\"{escapedStateName}\" [label=\"{escapedStateName}|";
+            StringBuilder sb = new StringBuilder($"\"{escapedStateName}\" [label=\"{escapedStateName}|");
 
             List<string> es = new List<string>();
             es.AddRange(state.EntryActions.Select(act => "entry / " + EscapeLabel(act)));
             es.AddRange(state.ExitActions.Select(act => "exit / " + EscapeLabel(act)));
 
-            f += string.Join("\\n", es);
+            sb.Append(string.Join("\\", es));
+            sb.Append($"\"];{Environment.NewLine}");
 
-            f += $"\"];{Environment.NewLine}";
-
-            return f;
+            return sb.ToString();
         }
 
         /// <summary>
@@ -90,22 +89,26 @@ namespace Stateless.Graph
         /// <inheritdoc/>
         public override string FormatOneTransition(string sourceNodeName, string trigger, IEnumerable<string> actions, string destinationNodeName, IEnumerable<string> guards)
         {
-            string label = trigger ?? "";
+            StringBuilder sb = new StringBuilder(trigger ?? "");
 
             if (actions?.Count() > 0)
-                label += " / " + string.Join(", ", actions);
+            {
+                sb.Append(" / ");
+                sb.Append(string.Join(", ", actions));
+            }
 
             if (guards.Any())
             {
                 foreach (var info in guards)
                 {
-                    if (label.Length > 0)
-                        label += " ";
-                    label += "[" + info + "]";
+                    if (sb.Length > 0)
+                        sb.Append(" ");
+
+                    sb.Append("[" + info + "]");
                 }
             }
 
-            return FormatOneLine(sourceNodeName, destinationNodeName, label);
+            return FormatOneLine(sourceNodeName, destinationNodeName, sb.ToString());
         }
 
         /// <summary>
@@ -126,15 +129,19 @@ namespace Stateless.Graph
         public override string GetInitialTransition(StateInfo initialState)
         {
             var initialStateName = initialState.UnderlyingState.ToString();
-            string dirgraphText = Environment.NewLine + $" init [label=\"\", shape=point];";
-            dirgraphText += Environment.NewLine + $" init -> \"{EscapeLabel(initialStateName)}\"[style = \"solid\"]";
 
-            dirgraphText += Environment.NewLine + "}";
+            StringBuilder sb = new StringBuilder();
+            sb.Append(Environment.NewLine);
+            sb.Append($" init [label=\"\", shape=point];");
+            sb.Append(Environment.NewLine);
+            sb.Append($" init -> \"{EscapeLabel(initialStateName)}\"[style = \"solid\"]");
+            sb.Append(Environment.NewLine);
+            sb.Append("}");
 
-            return dirgraphText;
+            return sb.ToString();
         }
 
-        internal string FormatOneLine(string fromNodeName, string toNodeName, string label)
+        internal static string FormatOneLine(string fromNodeName, string toNodeName, string label)
         {
             return $"\"{EscapeLabel(fromNodeName)}\" -> \"{EscapeLabel(toNodeName)}\" [style=\"solid\", label=\"{EscapeLabel(label)}\"];";
         }

--- a/src/Stateless/Graph/UmlDotGraphStyle.cs
+++ b/src/Stateless/Graph/UmlDotGraphStyle.cs
@@ -76,7 +76,7 @@ namespace Stateless.Graph
             es.AddRange(state.EntryActions.Select(act => "entry / " + EscapeLabel(act)));
             es.AddRange(state.ExitActions.Select(act => "exit / " + EscapeLabel(act)));
 
-            sb.Append(string.Join("\\", es));
+            sb.Append(string.Join("\\n", es));
             sb.Append($"\"];{Environment.NewLine}");
 
             return sb.ToString();
@@ -89,7 +89,7 @@ namespace Stateless.Graph
         /// <inheritdoc/>
         public override string FormatOneTransition(string sourceNodeName, string trigger, IEnumerable<string> actions, string destinationNodeName, IEnumerable<string> guards)
         {
-            StringBuilder sb = new StringBuilder(trigger ?? "");
+            StringBuilder sb = new StringBuilder(trigger ?? string.Empty);
 
             if (actions?.Count() > 0)
             {
@@ -131,11 +131,11 @@ namespace Stateless.Graph
             var initialStateName = initialState.UnderlyingState.ToString();
 
             StringBuilder sb = new StringBuilder();
-            sb.Append(Environment.NewLine);
+            sb.AppendLine();
             sb.Append($" init [label=\"\", shape=point];");
-            sb.Append(Environment.NewLine);
+            sb.AppendLine();
             sb.Append($" init -> \"{EscapeLabel(initialStateName)}\"[style = \"solid\"]");
-            sb.Append(Environment.NewLine);
+            sb.AppendLine();
             sb.Append("}");
 
             return sb.ToString();

--- a/src/Stateless/Reflection/InvocationInfo.cs
+++ b/src/Stateless/Reflection/InvocationInfo.cs
@@ -64,7 +64,7 @@ namespace Stateless.Reflection
                 if (_description != null)
                     return _description;
                 if (MethodName == null)
-                    return "<null>";
+                    return SpecialConstants.NullString;
                 if (MethodName.IndexOfAny(new char[] { '<', '>', '`' }) >= 0)
                     return DefaultFunctionDescription;
                 return MethodName;

--- a/src/Stateless/Reflection/StateInfo.cs
+++ b/src/Stateless/Reflection/StateInfo.cs
@@ -176,7 +176,7 @@ namespace Stateless.Reflection
         /// </summary>
         public override string ToString()
         {
-            return UnderlyingState?.ToString() ?? "<null>";
+            return UnderlyingState?.ToString() ?? SpecialConstants.NullString;
         }
     }
 }

--- a/src/Stateless/Reflection/TriggerInfo.cs
+++ b/src/Stateless/Reflection/TriggerInfo.cs
@@ -20,7 +20,7 @@
         /// </summary>
         public override string ToString()
         {
-            return UnderlyingTrigger?.ToString() ?? "<null>";
+            return UnderlyingTrigger?.ToString() ?? SpecialConstants.NullString;
         }
     }
 }

--- a/src/Stateless/SpecialConstants.cs
+++ b/src/Stateless/SpecialConstants.cs
@@ -1,0 +1,10 @@
+﻿namespace Stateless
+{
+    internal static class SpecialConstants
+    {
+        /// <summary>
+        /// Represents a null string identifier.
+        /// </summary>
+        internal const string NullString = "<null>";
+    }
+}

--- a/test/Stateless.Tests/ReflectionFixture.cs
+++ b/test/Stateless.Tests/ReflectionFixture.cs
@@ -1033,7 +1033,7 @@ namespace Stateless.Tests
         {
             var invocationInfo = new InvocationInfo(null, null, InvocationInfo.Timing.Synchronous);
 
-            Assert.Equal("<null>", invocationInfo.Description);
+            Assert.Equal(SpecialConstants.NullString, invocationInfo.Description);
         }
     }
 }


### PR DESCRIPTION
This PR adds a few quality of life changes that help improve code clarity and also reduces unnecessary waste.

* **StringBuilder** is utilized in lieu of wasteful immutable string concatenation.

* The ```<null>``` string has been utilized in a number of places. To reduce the chance of a typo I've merely added it to a ```SpecialConstants``` file to ensure its usage remains consistent.