### PR TITLE
Fix for transition precedence no longer given to substates

### DIFF
--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -202,7 +202,7 @@ namespace Stateless
             }
         }
 
-        async Task InternalFireOneAsync(TTrigger trigger, params object[] args)
+        private async Task InternalFireOneAsync(TTrigger trigger, params object[] args)
         {
             // If this is a trigger with parameters, we must validate the parameter(s)
             if (_triggerConfiguration.TryGetValue(trigger, out TriggerWithParameters configuration))

--- a/src/Stateless/StateRepresentation.Async.cs
+++ b/src/Stateless/StateRepresentation.Async.cs
@@ -189,13 +189,17 @@ namespace Stateless
 
             public async Task<TriggerBehaviourResult> TryFindHandlerAsync(TTrigger trigger, object[] args)
             {
-                var localHandlerFound = await TryFindLocalHandlerAsync(trigger, args);
+                TriggerBehaviourResult superstateHandler = null;
 
-                var superstateHandlerFound = Superstate != null
-                    ? await Superstate.TryFindHandlerAsync(trigger, args)
-                    : null;
+                var localHandler = await TryFindLocalHandlerAsync(trigger, args);
+                if (localHandler == null)
+                {
+                    superstateHandler = Superstate != null
+                        ? await Superstate.TryFindHandlerAsync(trigger, args)
+                        : null;
+                }
 
-                return superstateHandlerFound ?? localHandlerFound;
+                return superstateHandler ?? localHandler;
             }
 
             private async Task<TriggerBehaviourResult> TryFindLocalHandlerAsync(TTrigger trigger, object[] args)

--- a/test/Stateless.Tests/TransitionFixture.cs
+++ b/test/Stateless.Tests/TransitionFixture.cs
@@ -1,25 +1,26 @@
-﻿using Xunit;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace Stateless.Tests
 {
     public class TransitionFixture
     {
         [Fact]
-        public void IdentityTransitionIsNotChange()
+        public void IsReentry_ShouldBeTrue_WhenSourceAndDestinationAreEqual()
         {
             StateMachine<int, int>.Transition t = new StateMachine<int, int>.Transition(1, 1, 0);
             Assert.True(t.IsReentry);
         }
 
         [Fact]
-        public void TransitioningTransitionIsChange()
+        public void IsReentry_ShouldBeFalse_WhenSourceAndDestinationDiffer()
         {
             StateMachine<int, int>.Transition t = new StateMachine<int, int>.Transition(1, 2, 0);
             Assert.False(t.IsReentry);
         }
 
         [Fact]
-        public void TestInternalIf()
+        public void InternalTransitionIf_ShouldExecuteOnlyFirstMatchingAction()
         {
             // Verifies that only one internal action is executed
             var machine = new StateMachine<int, int>(1);
@@ -41,6 +42,47 @@ namespace Stateless.Tests
                     });
 
             machine.Fire(1);
+        }
+
+        [Fact]
+        public void GivenTriggerHandledOnSuperStateAndSubState_WhenTriggerFiredSync_ThenShouldUseSubstateTransition()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            sm
+                .Configure(State.A)
+                .Permit(Trigger.X, State.B);
+
+            // Overrides the superstate transition
+            sm
+                .Configure(State.B)
+                .SubstateOf(State.A)
+                .Permit(Trigger.X, State.C);
+
+            sm.Fire(Trigger.X);
+            Assert.Equal(State.B, sm.State);
+
+            sm.Fire(Trigger.X);
+            Assert.Equal(State.C, sm.State); // WORKS!
+        }
+
+        [Fact]
+        public async Task GivenTriggerHandledOnSuperStateAndSubState_WhenTriggerFiredAsync_ThenShouldUseSubstateTransitionAsync()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            sm
+                .Configure(State.A)
+                .Permit(Trigger.X, State.B);
+
+            sm
+                .Configure(State.B)
+                .SubstateOf(State.A)
+                .Permit(Trigger.X, State.C);
+
+            await sm.FireAsync(Trigger.X);
+            Assert.Equal(State.B, sm.State);
+
+            await sm.FireAsync(Trigger.X);
+            Assert.Equal(State.C, sm.State);
         }
     }
 }

--- a/test/Stateless.Tests/TransitionTests.cs
+++ b/test/Stateless.Tests/TransitionTests.cs
@@ -3,7 +3,7 @@ using Xunit;
 
 namespace Stateless.Tests
 {
-    public class TransitionFixture
+    public class TransitionTests
     {
         [Fact]
         public void IsReentry_ShouldBeTrue_WhenSourceAndDestinationAreEqual()


### PR DESCRIPTION
This PR addresses issue #624, in which a breaking change in v5.18.0 caused asynchronous substate transitions to be ignored when a viable parent state transition is configured. These changes are intended to restore the transition precedence from prior releases.

* Fixed the trigger handler selection logic in `StateRepresentation.Async.cs` so that substate (local) transitions are preferred over superstate transitions in async scenarios. This ensures correct transition precedence when both substate and superstate can handle the same trigger.

* Added new tests in `TransitionFixture.cs` to verify that substate transitions correctly override superstate transitions for both synchronous and asynchronous trigger firing.

* Improved test naming and clarity in `TransitionFixture.cs` for reentry and transition tests, making the intent of each test clearer.