### PR TITLE
Fix for ignored async superstate transitions when child state has unmet guard

### DIFF
--- a/src/Stateless/OnTransitionedEvent.cs
+++ b/src/Stateless/OnTransitionedEvent.cs
@@ -21,7 +21,6 @@ namespace Stateless
                 _onTransitioned?.Invoke(transition);
             }
 
-#if TASKS
             public async Task InvokeAsync(Transition transition, bool retainSynchronizationContext)
             {
                 _onTransitioned?.Invoke(transition);
@@ -29,7 +28,6 @@ namespace Stateless
                 foreach (var callback in _onTransitionedAsync)
                     await callback(transition).ConfigureAwait(retainSynchronizationContext);
             }
-#endif
 
             public void Register(Action<Transition> action)
             {

--- a/src/Stateless/StateConfiguration.Async.cs
+++ b/src/Stateless/StateConfiguration.Async.cs
@@ -1,6 +1,4 @@
-﻿#if TASKS
-
-using System;
+﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -1437,4 +1435,3 @@ namespace Stateless
         }
     }
 }
-#endif

--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -1,5 +1,3 @@
-#if TASKS
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -477,5 +475,3 @@ namespace Stateless
         }
     }
 }
-
-#endif

--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -206,7 +206,9 @@ namespace Stateless
         {
             // If this is a trigger with parameters, we must validate the parameter(s)
             if (_triggerConfiguration.TryGetValue(trigger, out TriggerWithParameters configuration))
+            {
                 configuration.ValidateParameters(args);
+            }
 
             var source = State;
             var representativeState = GetRepresentation(source);

--- a/src/Stateless/StateRepresentation.Async.cs
+++ b/src/Stateless/StateRepresentation.Async.cs
@@ -163,7 +163,6 @@ namespace Stateless
                 return syncResult;
             }
 
-
             public async Task<List<TTrigger>> GetPermittedTriggersAsync(params object[] args)
             {
                 var resultList = new List<TTrigger>();
@@ -192,7 +191,9 @@ namespace Stateless
                 TriggerBehaviourResult superstateHandler = null;
 
                 var localHandler = await TryFindLocalHandlerAsync(trigger, args);
-                if (localHandler == null)
+                bool localHandlerFound = localHandler != null && !localHandler.UnmetGuardConditions.Any();
+                
+                if (!localHandlerFound)
                 {
                     superstateHandler = Superstate != null
                         ? await Superstate.TryFindHandlerAsync(trigger, args)
@@ -231,7 +232,6 @@ namespace Stateless
 
                     handleResultAsync = TryFindLocalHandlerResult(trigger, asyncTriggerBehaviourResult) ?? TryFindLocalHandlerResultWithUnmetGuardConditions(asyncTriggerBehaviourResult);
                 }
-               
 
                 return handleResultSync ?? handleResultAsync;
             }

--- a/src/Stateless/StateRepresentation.Async.cs
+++ b/src/Stateless/StateRepresentation.Async.cs
@@ -1,5 +1,3 @@
-#if TASKS
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -238,5 +236,3 @@ namespace Stateless
         }
     }
 }
-
-#endif

--- a/test/Stateless.Tests/AsyncActionsFixture.cs
+++ b/test/Stateless.Tests/AsyncActionsFixture.cs
@@ -1,5 +1,3 @@
-#if TASKS
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -656,5 +654,3 @@ namespace Stateless.Tests
         }
     }
 }
-
-#endif

--- a/test/Stateless.Tests/AsyncFiringModesFixture.cs
+++ b/test/Stateless.Tests/AsyncFiringModesFixture.cs
@@ -1,5 +1,4 @@
-﻿#if TASKS
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -204,4 +203,3 @@ namespace Stateless.Tests
         }
     }
 }
-#endif

--- a/test/Stateless.Tests/AsyncFiringModesFixture.cs
+++ b/test/Stateless.Tests/AsyncFiringModesFixture.cs
@@ -15,7 +15,7 @@ namespace Stateless.Tests
         /// Check that the immediate Firing modes executes entry/exit out of order.
         /// </summary>
         [Fact]
-        public void ImmediateEntryAProcessedBeforeEnterB()
+        public async Task ImmediateEntryAProcessedBeforeEnterB()
         {
             var record = new List<string>();
             var sm = new StateMachine<State, Trigger>(State.A, FiringMode.Immediate);
@@ -35,7 +35,7 @@ namespace Stateless.Tests
                 .Permit(Trigger.Y, State.A)
                 .OnExit(() => record.Add("ExitB"));
 
-            sm.FireAsync(Trigger.X);
+            await sm.FireAsync(Trigger.X);
 
             // Expected sequence of events: Exit A -> Exit B -> Enter A -> Enter B
             Assert.Equal("ExitA", record[0]);
@@ -49,7 +49,7 @@ namespace Stateless.Tests
         /// Checks that queued Firing mode executes triggers in order
         /// </summary>
         [Fact]
-        public void ImmediateEntryAProcessedBeforeEterB()
+        public async Task QueuedEntryAProcessedAfterEnterB()
         {
             var record = new List<string>();
             var sm = new StateMachine<State, Trigger>(State.A, FiringMode.Queued);
@@ -69,7 +69,7 @@ namespace Stateless.Tests
                 .Permit(Trigger.Y, State.A)
                 .OnExit(() => record.Add("ExitB"));
 
-            sm.FireAsync(Trigger.X);
+            await sm.FireAsync(Trigger.X);
 
             // Expected sequence of events: Exit A -> Enter B -> Exit B -> Enter A
             Assert.Equal("ExitA", record[0]);
@@ -82,7 +82,7 @@ namespace Stateless.Tests
         /// Check that the immediate Firing modes executes entry/exit out of order.
         /// </summary>
         [Fact]
-        public void ImmediateFiringOnEntryEndsUpInCorrectState()
+        public async Task ImmediateFiringOnEntryEndsUpInCorrectState()
         {
             var record = new List<string>();
             var sm = new StateMachine<State, Trigger>(State.A, FiringMode.Immediate);
@@ -107,7 +107,7 @@ namespace Stateless.Tests
                 .Permit(Trigger.X, State.A)
                 .OnExit(() => record.Add("ExitC"));
 
-            sm.FireAsync(Trigger.X);
+            await sm.FireAsync(Trigger.X);
 
             // Expected sequence of events: Exit A -> Exit B -> Enter A -> Enter B
             Assert.Equal("ExitA", record[0]);

--- a/test/Stateless.Tests/AsyncTransitionTests.cs
+++ b/test/Stateless.Tests/AsyncTransitionTests.cs
@@ -65,13 +65,13 @@ namespace Stateless.Tests
 
 
         [Theory]
-        [InlineData(false, false, true, "D")]
-        [InlineData(false, true, false, "E")]
-        [InlineData(false, true, true, "D")]
-        [InlineData(true, false, false, "F")]
-        [InlineData(true, false, true, "D")]
-        [InlineData(true, true, false, "E")]
-        [InlineData(true, true, true, "D")]
+        [InlineData(false, false, true, "GrandchildStateTarget")]
+        [InlineData(false, true, false, "ChildStateTarget")]
+        [InlineData(false, true, true, "GrandchildStateTarget")]
+        [InlineData(true, false, false, "ParentStateTarget")]
+        [InlineData(true, false, true, "GrandchildStateTarget")]
+        [InlineData(true, true, false, "ChildStateTarget")]
+        [InlineData(true, true, true, "GrandchildStateTarget")]
         public async Task GivenMultiLayerSubstates_AndGuardConditionIsClosed_OpenTransitionOnClosestAncestorIsUsedAsync(
             bool parentGuardConditionValue,
             bool childGuardConditionValue,
@@ -79,21 +79,21 @@ namespace Stateless.Tests
             string expectedState
         )
         {
-            var sm = new StateMachine<string, Trigger>("C");
+            var sm = new StateMachine<string, Trigger>("GrandchildState");
 
             sm
-                .Configure("A")
-                .PermitIf(Trigger.X, "F", () => parentGuardConditionValue);
+                .Configure("ParentState")
+                .PermitIf(Trigger.X, "ParentStateTarget", () => parentGuardConditionValue);
 
             sm
-                .Configure("B")
-                .SubstateOf("A")
-                .PermitIf(Trigger.X, "E", () => childGuardConditionValue);
+                .Configure("ChildState")
+                .SubstateOf("ParentState")
+                .PermitIf(Trigger.X, "ChildStateTarget", () => childGuardConditionValue);
 
             sm
-                .Configure("C")
-                .SubstateOf("B")
-                .PermitIf(Trigger.X, "D", () => grandchildGuardConditionValue);
+                .Configure("GrandchildState")
+                .SubstateOf("ChildState")
+                .PermitIf(Trigger.X, "GrandchildStateTarget", () => grandchildGuardConditionValue);
 
             await sm.FireAsync(Trigger.X);
             Assert.Equal(expectedState, sm.State);

--- a/test/Stateless.Tests/AsyncTransitionTests.cs
+++ b/test/Stateless.Tests/AsyncTransitionTests.cs
@@ -62,5 +62,41 @@ namespace Stateless.Tests
             await sm.FireAsync(Trigger.X);
             Assert.Equal(State.C, sm.State);
         }
+
+
+        [Theory]
+        [InlineData(false, false, true, "D")]
+        [InlineData(false, true, false, "E")]
+        [InlineData(false, true, true, "D")]
+        [InlineData(true, false, false, "F")]
+        [InlineData(true, false, true, "D")]
+        [InlineData(true, true, false, "E")]
+        [InlineData(true, true, true, "D")]
+        public async Task GivenMultiLayerSubstates_AndGuardConditionIsClosed_OpenTransitionOnClosestAncestorIsUsedAsync(
+            bool parentGuardConditionValue,
+            bool childGuardConditionValue,
+            bool grandchildGuardConditionValue,
+            string expectedState
+        )
+        {
+            var sm = new StateMachine<string, Trigger>("C");
+
+            sm
+                .Configure("A")
+                .PermitIf(Trigger.X, "F", () => parentGuardConditionValue);
+
+            sm
+                .Configure("B")
+                .SubstateOf("A")
+                .PermitIf(Trigger.X, "E", () => childGuardConditionValue);
+
+            sm
+                .Configure("C")
+                .SubstateOf("B")
+                .PermitIf(Trigger.X, "D", () => grandchildGuardConditionValue);
+
+            await sm.FireAsync(Trigger.X);
+            Assert.Equal(expectedState, sm.State);
+        }
     }
 }

--- a/test/Stateless.Tests/AsyncTransitionTests.cs
+++ b/test/Stateless.Tests/AsyncTransitionTests.cs
@@ -1,0 +1,66 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Stateless.Tests
+{
+    public class AsyncTransitionTests
+    {
+        [Fact]
+        public async Task GivenTriggerHandledOnSuperStateAndSubState_WhenTriggerFiredAsync_ThenShouldUseSubstateTransitionAsync()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+            sm
+                .Configure(State.A)
+                .Permit(Trigger.X, State.B);
+
+            sm
+                .Configure(State.B)
+                .SubstateOf(State.A)
+                .Permit(Trigger.X, State.C);
+
+            await sm.FireAsync(Trigger.X);
+            Assert.Equal(State.B, sm.State);
+
+            await sm.FireAsync(Trigger.X);
+            Assert.Equal(State.C, sm.State);
+        }
+
+        [Fact]
+        public async Task GivenTriggerHandledOnSuperStateAndSubState_WhenSubstateTransitionGuardBlocked_ThenShouldUseSuperstateTransitionAsync()
+        {
+            var guardConditionValue = false;
+            var sm = new StateMachine<State, Trigger>(State.B);
+
+            sm
+                .Configure(State.A)
+                .PermitIf(Trigger.X, State.D);
+
+            sm
+                .Configure(State.B)
+                .SubstateOf(State.A)
+                .PermitIf(Trigger.X, State.C, () => guardConditionValue);
+
+            await sm.FireAsync(Trigger.X);
+            Assert.Equal(State.D, sm.State);
+        }
+
+        [Fact]
+        public async Task GivenTriggerHandledOnSuperStateAndSubState_WhenSubstateTransitionGuardIsOpen_ThenShouldUseSubstateTransitionAsync()
+        {
+            var guardConditionValue = true;
+            var sm = new StateMachine<State, Trigger>(State.B);
+
+            sm
+                .Configure(State.A)
+                .PermitIf(Trigger.X, State.D);
+
+            sm
+                .Configure(State.B)
+                .SubstateOf(State.A)
+                .PermitIf(Trigger.X, State.C, () => guardConditionValue);
+
+            await sm.FireAsync(Trigger.X);
+            Assert.Equal(State.C, sm.State);
+        }
+    }
+}

--- a/test/Stateless.Tests/TransitionTests.cs
+++ b/test/Stateless.Tests/TransitionTests.cs
@@ -103,13 +103,13 @@ namespace Stateless.Tests
         }
 
         [Theory]
-        [InlineData(false, false, true, "D")]
-        [InlineData(false, true, false, "E")]
-        [InlineData(false, true, true, "D")]
-        [InlineData(true, false, false, "F")]
-        [InlineData(true, false, true, "D")]
-        [InlineData(true, true, false, "E")]
-        [InlineData(true, true, true, "D")]
+        [InlineData(false, false, true, "GrandchildStateTarget")]
+        [InlineData(false, true, false, "ChildStateTarget")]
+        [InlineData(false, true, true, "GrandchildStateTarget")]
+        [InlineData(true, false, false, "ParentStateTarget")]
+        [InlineData(true, false, true, "GrandchildStateTarget")]
+        [InlineData(true, true, false, "ChildStateTarget")]
+        [InlineData(true, true, true, "GrandchildStateTarget")]
         public void GivenMultiLayerSubstates_AndGuardConditionIsClosed_OpenTransitionOnClosestAncestorIsUsed(
             bool parentGuardConditionValue,
             bool childGuardConditionValue,
@@ -117,21 +117,21 @@ namespace Stateless.Tests
             string expectedState
         )
         {
-            var sm = new StateMachine<string, Trigger>("C");
+            var sm = new StateMachine<string, Trigger>("GrandchildState");
 
             sm
-                .Configure("A")
-                .PermitIf(Trigger.X, "F", () => parentGuardConditionValue);
+                .Configure("ParentState")
+                .PermitIf(Trigger.X, "ParentStateTarget", () => parentGuardConditionValue);
 
             sm
-                .Configure("B")
-                .SubstateOf("A")
-                .PermitIf(Trigger.X, "E", () => childGuardConditionValue);
+                .Configure("ChildState")
+                .SubstateOf("ParentState")
+                .PermitIf(Trigger.X, "ChildStateTarget", () => childGuardConditionValue);
 
             sm
-                .Configure("C")
-                .SubstateOf("B")
-                .PermitIf(Trigger.X, "D", () => grandchildGuardConditionValue);
+                .Configure("GrandchildState")
+                .SubstateOf("ChildState")
+                .PermitIf(Trigger.X, "GrandchildStateTarget", () => grandchildGuardConditionValue);
 
             sm.Fire(Trigger.X);
             Assert.Equal(expectedState, sm.State);

--- a/test/Stateless.Tests/TransitionTests.cs
+++ b/test/Stateless.Tests/TransitionTests.cs
@@ -1,4 +1,3 @@
-﻿using System.Threading.Tasks;
 using Xunit;
 
 namespace Stateless.Tests
@@ -66,22 +65,40 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        public async Task GivenTriggerHandledOnSuperStateAndSubState_WhenTriggerFiredAsync_ThenShouldUseSubstateTransitionAsync()
+        public void GivenTriggerHandledOnSuperStateAndSubState_WhenSubstateTransitionGuardBlocked_ThenShouldUseSuperstateTransition()
         {
-            var sm = new StateMachine<State, Trigger>(State.A);
+            var guardConditionValue = false;
+            var sm = new StateMachine<State, Trigger>(State.B);
+
             sm
                 .Configure(State.A)
-                .Permit(Trigger.X, State.B);
+                .PermitIf(Trigger.X, State.D);
 
             sm
                 .Configure(State.B)
                 .SubstateOf(State.A)
-                .Permit(Trigger.X, State.C);
+                .PermitIf(Trigger.X, State.C, () => guardConditionValue);
 
-            await sm.FireAsync(Trigger.X);
-            Assert.Equal(State.B, sm.State);
+            sm.Fire(Trigger.X);
+            Assert.Equal(State.D, sm.State);
+        }
 
-            await sm.FireAsync(Trigger.X);
+        [Fact]
+        public void GivenTriggerHandledOnSuperStateAndSubState_WhenSubstateTransitionGuardOpen_ThenShouldUseSubstateTransition()
+        {
+            var guardConditionValue = true;
+            var sm = new StateMachine<State, Trigger>(State.B);
+
+            sm
+                .Configure(State.A)
+                .PermitIf(Trigger.X, State.D);
+
+            sm
+                .Configure(State.B)
+                .SubstateOf(State.A)
+                .PermitIf(Trigger.X, State.C, () => guardConditionValue);
+
+            sm.Fire(Trigger.X);
             Assert.Equal(State.C, sm.State);
         }
     }

--- a/test/Stateless.Tests/TransitionTests.cs
+++ b/test/Stateless.Tests/TransitionTests.cs
@@ -101,5 +101,40 @@ namespace Stateless.Tests
             sm.Fire(Trigger.X);
             Assert.Equal(State.C, sm.State);
         }
+
+        [Theory]
+        [InlineData(false, false, true, "D")]
+        [InlineData(false, true, false, "E")]
+        [InlineData(false, true, true, "D")]
+        [InlineData(true, false, false, "F")]
+        [InlineData(true, false, true, "D")]
+        [InlineData(true, true, false, "E")]
+        [InlineData(true, true, true, "D")]
+        public void GivenMultiLayerSubstates_AndGuardConditionIsClosed_OpenTransitionOnClosestAncestorIsUsed(
+            bool parentGuardConditionValue,
+            bool childGuardConditionValue,
+            bool grandchildGuardConditionValue,
+            string expectedState
+        )
+        {
+            var sm = new StateMachine<string, Trigger>("C");
+
+            sm
+                .Configure("A")
+                .PermitIf(Trigger.X, "F", () => parentGuardConditionValue);
+
+            sm
+                .Configure("B")
+                .SubstateOf("A")
+                .PermitIf(Trigger.X, "E", () => childGuardConditionValue);
+
+            sm
+                .Configure("C")
+                .SubstateOf("B")
+                .PermitIf(Trigger.X, "D", () => grandchildGuardConditionValue);
+
+            sm.Fire(Trigger.X);
+            Assert.Equal(expectedState, sm.State);
+        }
     }
 }


### PR DESCRIPTION
This PR is for issue #629 in which a parent state transition is ignored when:

 - the child state has a transition configured with the same trigger;
 - the child state's transition has an unmet guard condition;
 - the parent state's transition does not have unmet guard conditions;
 - the child state is the current state;
 - the trigger is fired using `FireAsync`.

When the synchronous call to `Fire` is used instead, it selects the nearest ancestor that has a transition with no unmet guard conditions.

This PR also includes some housekeeping changes:

 - Removed unused `#if TASKS` directives.
 - Changed test method signatures in `AsyncFiringModesFixture` from `void` to `async Task`.
 - Split `TransitionTests` into sync and async test classes.