### PR TITLE
Implemented FiringMode.Serial as a separate worker task

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,15 +358,19 @@ var stateMachine = new StateMachine<State, Trigger>(initialState)
 
 Setting this is vital within a Microsoft Orleans Grain for example, which requires the `SynchronizationContext` in order to make calls to other Grains.
 
-### Thread safety
+### FiringMode.Serial
 By default, Stateless is **NOT** thread-safe.
-`FiringMode.Serial` ensures thread-safety for Fire(), however reading the State Machine's state from multiple threads may still be unsafe and require aditional locks.
+`FiringMode.Serial` ensures thread-safety for Fire()/FireAsync(), however reading the State Machine's state from multiple threads may still be unsafe and require aditional locks.
 
-Stateless processes triggers sequentially, and as a result there can only be one thread "driving" the processing at a time.
+In `FiringMode.Serial` triggers are sequentially ran on a separate worker task. So all calls to Fire / FireAsync return as soon as the trigger is enqueued. 
 
-In `FiringMode.Serial`, if the main processing thread throws an error, unprocessed triggers should be removed from the queue in order to ensure consistency. Otherwise the event queue may still hold unprocessed triggers which would require another Fire() call to resume processing.  
-Set `DropUnprocessedEventsOnErrorInSerialMode` to true if you need consistent behaviour.  
-Set `DropUnprocessedEventsOnErrorInSerialMode` to false if you don't want triggers to be dropped (default).
+If you need to wait for the trigger to be ran or catch its specific exceptions, use `await FireAndWaitAsync(trigger)`. Warning, if you call and await `FireAndWaitAsync` inside a state transition event, you risk deadlocking (because the current transition now waits for a future transition to be completed).
+
+If you need to await the triggers processing task or catch exceptions, you can use `await GetSerialEventsWorkerTask()`.
+
+**Important**: If an unexpected exception is thrown durring the processing of triggers, the faulting trigger is dequeued and the worker task halts (possibly locking tasks waiting via `await FireAndWaitAsync(trigger)`).  
+If you need to resume execution, you can call the parameterless Fire method.  
+If you need to cancel all the unexecuted triggers still pending, you can call `CancelPendingTriggers()`.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -360,11 +360,11 @@ Setting this is vital within a Microsoft Orleans Grain for example, which requir
 
 ### Thread safety
 By default, Stateless is **NOT** thread-safe.
-`FiringMode.Sequential` ensures thread-safety for Fire(), however reading the State Machine's state from multiple threads may still be unsafe and require aditional locks.
+`FiringMode.Serial` ensures thread-safety for Fire(), however reading the State Machine's state from multiple threads may still be unsafe and require aditional locks.
 
 Stateless processes triggers sequentially, and as a result there can only be one thread "driving" the processing at a time.
 
-In `FiringMode.Sequential`, if the main processing thread throws an error, unprocessed triggers should be removed from the queue in order to ensure consistency. Otherwise the event queue may still hold unprocessed triggers which would require another Fire() call to resume processing.  
+In `FiringMode.Serial`, if the main processing thread throws an error, unprocessed triggers should be removed from the queue in order to ensure consistency. Otherwise the event queue may still hold unprocessed triggers which would require another Fire() call to resume processing.  
 Set `DropUnprocessedEventsOnErrorInSerialMode` to true if you need consistent behaviour.  
 Set `DropUnprocessedEventsOnErrorInSerialMode` to false if you don't want triggers to be dropped (default).
 

--- a/README.md
+++ b/README.md
@@ -358,6 +358,16 @@ var stateMachine = new StateMachine<State, Trigger>(initialState)
 
 Setting this is vital within a Microsoft Orleans Grain for example, which requires the `SynchronizationContext` in order to make calls to other Grains.
 
+### Thread safety
+By default, Stateless is **NOT** thread-safe.
+`FiringMode.Sequential` ensures thread-safety for Fire(), however reading the State Machine's state from multiple threads may still be unsafe and require aditional locks.
+
+Stateless processes triggers sequentially, and as a result there can only be one thread "driving" the processing at a time.
+
+In `FiringMode.Sequential`, if the main processing thread throws an error, unprocessed triggers should be removed from the queue in order to ensure consistency. Otherwise the event queue may still hold unprocessed triggers which would require another Fire() call to resume processing.  
+Set `DropUnprocessedEventsOnErrorInSerialMode` to true if you need consistent behaviour.  
+Set `DropUnprocessedEventsOnErrorInSerialMode` to false if you don't want triggers to be dropped (default).
+
 ## Building
 
 Stateless runs on .NET runtime version 4+ and practically all modern .NET platforms by targeting .NET Framework 4.6.2, .NET Standard 2.0, and .NET 8.0, 9.0 and 10.0. Visual Studio 2017 or later is required to build the solution.

--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -162,9 +162,71 @@ namespace Stateless
                 case FiringMode.Queued:
                     await InternalFireQueuedAsync(trigger, args);
                     break;
+                case FiringMode.Serial:
+                    await InternalFireSerialAsync(trigger, args);
+                    break;
                 default:
                     // If something is completely messed up we let the user know ;-)
                     throw new InvalidOperationException("The firing mode has not been configured!");
+            }
+        }
+
+        /// <summary>
+        /// Queue events and then fire in order.
+        /// If only one event is queued, this behaves identically to the non-queued version.
+        /// </summary>
+        /// <param name="trigger">  The trigger. </param>
+        /// <param name="args">     A variable-length parameters list containing arguments. </param>
+        async Task InternalFireSerialAsync(TTrigger trigger, params object[] args) {
+
+            lock (_serialModeLock) 
+            {
+                // Add trigger to queue
+                _eventQueue.Enqueue(new QueuedTrigger { Trigger = trigger, Args = args });
+
+                // If a trigger is already being handled then the trigger will be queued (FIFO) and processed later.
+                if (_firing)
+                    return;
+
+                _firing = true;
+            }
+
+            try 
+            {
+
+                // Empty queue for triggers
+                while (true)
+                {
+
+                    QueuedTrigger queuedEvent;
+
+                    lock (_serialModeLock)
+                    {
+
+                        if (_eventQueue.Count == 0) 
+                        {
+                            _firing = false;
+                            break;
+                        }
+
+                        queuedEvent = _eventQueue.Dequeue();
+                    }
+
+                    await InternalFireOneAsync(queuedEvent.Trigger, queuedEvent.Args).ConfigureAwait(RetainSynchronizationContext);
+                }
+            } 
+            catch
+            {
+
+                lock (_serialModeLock)
+                {
+                    if (DropUnprocessedEventsOnErrorInSerialMode)
+                        _eventQueue.Clear();
+
+                    _firing = false;
+                }
+
+                throw;
             }
         }
 

--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -6,8 +6,20 @@ using System.Threading.Tasks;
 
 namespace Stateless
 {
-    public partial class StateMachine<TState, TTrigger>
+    public partial class StateMachine<TState, TTrigger> : IDisposable
     {
+
+        private bool _disposing;
+
+        private class QueuedSerialTrigger : QueuedTrigger {
+            public TaskCompletionSource<bool> TaskCompletionSource { get; set; }
+        }
+
+        private readonly Queue<QueuedSerialTrigger> _serialEventQueue = new Queue<QueuedSerialTrigger>();
+
+        private Task _serialEventQueueProcessingTask;
+        private CancellationTokenSource _serialEventQueueCancellationToken;
+
         /// <summary>
         /// Activates current state in asynchronous fashion. Actions associated with activating the current state
         /// will be invoked. The activation is idempotent and subsequent activation of the same current state 
@@ -41,6 +53,16 @@ namespace Stateless
         public async Task<IEnumerable<TTrigger>> GetPermittedTriggersAsync(params object[] args)
         {
             return await CurrentRepresentation.GetPermittedTriggersAsync(args);
+        }
+
+        /// <summary> Obtains the curent serial events worker task. </summary>
+        public Task GetSerialEventsWorkerTask() {
+            return _serialEventQueueProcessingTask ?? Task.CompletedTask;
+        }
+
+        /// <summary> Resumes the execution of the event processing queue if not empty. </summary>
+        public Task FireAsync() {
+            return InternalFireAsync();
         }
 
         /// <summary>
@@ -147,24 +169,21 @@ namespace Stateless
             return InternalFireAsync(trigger.Trigger, arg0, arg1, arg2);
         }
 
+
         /// <summary>
-        /// Determine how to Fire the trigger
+        /// Fires the trigger and waits for the trigger to be processed.
+        /// Relevant for FiringMode.Serial.
         /// </summary>
-        /// <param name="trigger">The trigger. </param>
+        /// <param name="trigger">The trigger to fire.</param>
         /// <param name="args">A variable-length parameters list containing arguments. </param>
-        async Task InternalFireAsync(TTrigger trigger, params object[] args)
-        {
-            switch (_firingMode)
-            {
+        public Task FireAndWaitAsync(TTrigger trigger, params object[] args) {
+            switch (_firingMode) {
                 case FiringMode.Immediate:
-                    await InternalFireOneAsync(trigger, args);
-                    break;
+                    return InternalFireOneAsync(trigger, args);
                 case FiringMode.Queued:
-                    await InternalFireQueuedAsync(trigger, args);
-                    break;
+                    return InternalFireQueuedAsync(trigger, args);
                 case FiringMode.Serial:
-                    await InternalFireSerialAsync(trigger, args);
-                    break;
+                    return InternalFireSerialAsync(trigger, getTriggerCompletionTask: true, args);
                 default:
                     // If something is completely messed up we let the user know ;-)
                     throw new InvalidOperationException("The firing mode has not been configured!");
@@ -172,62 +191,155 @@ namespace Stateless
         }
 
         /// <summary>
-        /// Queue events and then fire in order.
-        /// If only one event is queued, this behaves identically to the non-queued version.
+        /// Determine how to Fire the trigger
+        /// </summary>
+        /// <param name="trigger">The trigger. </param>
+        /// <param name="args">A variable-length parameters list containing arguments. </param>
+        Task InternalFireAsync(TTrigger trigger, params object[] args)
+        {
+            switch (_firingMode)
+            {
+                case FiringMode.Immediate:
+                    return InternalFireOneAsync(trigger, args);
+                case FiringMode.Queued:
+                    return InternalFireQueuedAsync(trigger, args);
+                case FiringMode.Serial:
+                    return InternalFireSerialAsync(trigger, getTriggerCompletionTask: false, args);
+                default:
+                    // If something is completely messed up we let the user know ;-)
+                    throw new InvalidOperationException("The firing mode has not been configured!");
+            }
+        }
+
+
+        /// <summary> Resumes the execution of the event processing queue if not empty. </summary>
+        Task InternalFireAsync() {
+            switch (_firingMode) {
+                case FiringMode.Immediate:
+                    return Task.CompletedTask;
+                case FiringMode.Queued:
+                    return InternalFireQueuedAsync();
+                case FiringMode.Serial:
+                    return InternalFireSerialAsync();
+                default:
+                    // If something is completely messed up we let the user know ;-)
+                    throw new InvalidOperationException("The firing mode has not been configured!");
+            }
+        }
+
+        /// <summary>
+        /// Queue events and then fire in order on a separate worker thread.
+        /// This returns immediately after queueing the trigger.
+        /// This method is thread-safe.
         /// </summary>
         /// <param name="trigger">  The trigger. </param>
+        /// <param name="getTriggerCompletionTask">  If true, returns the task associated with the processing of the trigger. </param>
         /// <param name="args">     A variable-length parameters list containing arguments. </param>
-        async Task InternalFireSerialAsync(TTrigger trigger, params object[] args) {
+        Task InternalFireSerialAsync(TTrigger trigger, bool getTriggerCompletionTask, params object[] args)
+        {
+
+            if (_disposing)
+                throw new ObjectDisposedException("State machine");
+
+            var taskCompletionSource = new TaskCompletionSource<bool>();
 
             lock (_serialModeLock) 
             {
-                // Add trigger to queue
-                _eventQueue.Enqueue(new QueuedTrigger { Trigger = trigger, Args = args });
+                _serialEventQueue.Enqueue(new QueuedSerialTrigger { Trigger = trigger, Args = args, TaskCompletionSource = taskCompletionSource });
 
-                // If a trigger is already being handled then the trigger will be queued (FIFO) and processed later.
-                if (_firing)
-                    return;
+                if (_firing) 
+                    return getTriggerCompletionTask ? taskCompletionSource.Task : Task.CompletedTask;
 
                 _firing = true;
             }
 
-            try 
-            {
+            _serialEventQueueProcessingTask = InternalFireSerialAsync_RunProcessingQueue();
 
-                // Empty queue for triggers
-                while (true)
+            return getTriggerCompletionTask ? taskCompletionSource.Task : Task.CompletedTask;
+        }
+
+        /// <summary> Resumes the execution if the event queue is not empty </summary>
+        Task InternalFireSerialAsync()
+        {
+            lock (_serialModeLock)
+            {
+                if (_firing || _serialEventQueue.Count == 0)
+                    return Task.CompletedTask;
+
+                _firing = true;
+            }
+
+            _serialEventQueueProcessingTask = InternalFireSerialAsync_RunProcessingQueue();
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Starts a serial event processing thread.
+        /// Only call if you aquired "_firing = true" inside a lock.
+        /// </summary>
+        Task InternalFireSerialAsync_RunProcessingQueue()
+        {
+
+            _serialEventQueueCancellationToken = new CancellationTokenSource();
+
+            return Task.Run(
+                async () => 
                 {
 
-                    QueuedTrigger queuedEvent;
+                    QueuedSerialTrigger queuedEvent = null;
+                    Task currentTask = null;
 
-                    lock (_serialModeLock)
+                    try 
+                    {
+                        if (_disposing)
+                            throw new ObjectDisposedException("State machine");
+
+                        while (true) 
+                        {
+
+                            lock (_serialModeLock)
+                            {
+
+                                if (_serialEventQueue.Count == 0)
+                                {
+                                    _firing = false;
+                                    break;
+                                }
+
+                                queuedEvent = _serialEventQueue.Dequeue();
+                            }
+
+                            currentTask = InternalFireOneAsync(queuedEvent.Trigger, queuedEvent.Args);
+
+                            await currentTask;
+
+                            queuedEvent.TaskCompletionSource.SetResult(true);
+
+                            _serialEventQueueCancellationToken.Token.ThrowIfCancellationRequested();
+                        }
+                    } 
+                    catch
                     {
 
-                        if (_eventQueue.Count == 0) 
+                        lock (_serialModeLock)
                         {
                             _firing = false;
-                            break;
                         }
 
-                        queuedEvent = _eventQueue.Dequeue();
+                        if (currentTask?.IsCanceled == true)
+                        {
+                            queuedEvent?.TaskCompletionSource.SetCanceled();
+                        } 
+                        else if (currentTask?.IsFaulted == true) 
+                        {
+                            queuedEvent?.TaskCompletionSource.SetException(currentTask.Exception);
+                        }
+
+                        throw;
                     }
-
-                    await InternalFireOneAsync(queuedEvent.Trigger, queuedEvent.Args).ConfigureAwait(RetainSynchronizationContext);
                 }
-            } 
-            catch
-            {
-
-                lock (_serialModeLock)
-                {
-                    if (DropUnprocessedEventsOnErrorInSerialMode)
-                        _eventQueue.Clear();
-
-                    _firing = false;
-                }
-
-                throw;
-            }
+            );
         }
 
         /// <summary>
@@ -236,28 +348,29 @@ namespace Stateless
         /// </summary>
         /// <param name="trigger">  The trigger. </param>
         /// <param name="args">     A variable-length parameters list containing arguments. </param>
-        async Task InternalFireQueuedAsync(TTrigger trigger, params object[] args)
+        Task InternalFireQueuedAsync(TTrigger trigger, params object[] args)
         {
-            if (_firing)
-            {
-                _eventQueue.Enqueue(new QueuedTrigger { Trigger = trigger, Args = args });
+
+            _eventQueue.Enqueue(new QueuedTrigger { Trigger = trigger, Args = args });
+
+            return InternalFireQueuedAsync();
+        }
+
+        /// <summary> Processes the event queue </summary>
+        async Task InternalFireQueuedAsync() {
+
+            if (_firing) {
                 return;
             }
 
-            try
-            {
+            try {
                 _firing = true;
 
-                await InternalFireOneAsync(trigger, args).ConfigureAwait(RetainSynchronizationContext);
-
-                while (_eventQueue.Count != 0)
-                {
+                while (_eventQueue.Count != 0) {
                     var queuedEvent = _eventQueue.Dequeue();
                     await InternalFireOneAsync(queuedEvent.Trigger, queuedEvent.Args).ConfigureAwait(RetainSynchronizationContext);
                 }
-            }
-            finally
-            {
+            } finally {
                 _firing = false;
             }
         }
@@ -534,6 +647,28 @@ namespace Stateless
         {
             if (onTransitionAction == null) throw new ArgumentNullException(nameof(onTransitionAction));
             _onTransitionCompletedEvent.Unregister(onTransitionAction);
+        }
+
+        /// <summary>
+        /// Dispose the state machine
+        /// </summary>
+        public void Dispose()
+        {
+            _disposing = true;
+
+            if (_firingMode == FiringMode.Serial)
+            {
+                _serialEventQueueCancellationToken?.Cancel();
+
+                if (!_serialEventQueueProcessingTask?.IsCompleted == true)
+                {
+                    try {
+                        _serialEventQueueProcessingTask.Wait();
+                    } catch {
+                        //Since we are disposing, ignore any errors
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -47,16 +47,6 @@ namespace Stateless
         private bool _firing;
 
         /// <summary>
-        /// If the main processing thread throws an error, unprocessed triggers should be removed from
-        /// the queue in order to ensure consistency. Otherwise the event queue
-        /// may still hold unprocessed triggers which would require another
-        /// Fire() call to resume processing.
-        /// Set this to true if you need consistent behaviour.
-        /// Set this to false if you don't want triggers to be dropped.
-        /// </summary>
-        public bool DropUnprocessedEventsOnErrorInSerialMode { get; set; } = false;
-
-        /// <summary>
         /// Construct a state machine with external state storage.
         /// </summary>
         /// <param name="stateAccessor">A function that will be called to read the current state value.</param>
@@ -216,6 +206,11 @@ namespace Stateless
             return new StateConfiguration(this, GetRepresentation(state), GetRepresentation);
         }
 
+        /// <summary> Resumes the execution of the event processing queue if not empty. </summary>
+        public void Fire() {
+            InternalFire();
+        }
+
         /// <summary>
         /// Transition from the current state via the specified trigger.
         /// The target state is determined by the configuration of the current state.
@@ -363,67 +358,39 @@ namespace Stateless
             }
         }
 
+        /// <summary> Resumes the execution of the event processing queue if not empty. </summary>
+        void InternalFire() {
+            switch (_firingMode) {
+                case FiringMode.Immediate:
+                    break;
+                case FiringMode.Queued:
+                    InternalFireQueued();
+                    break;
+                case FiringMode.Serial:
+                    InternalFireSerial();
+                    break;
+                default:
+                    // If something is completely messed up we let the user know ;-)
+                    throw new InvalidOperationException("The firing mode has not been configured!");
+            }
+        }
+
         /// <summary>
-        /// Queue events and then fire in order.
-        /// If only one event is queued, this behaves identically to the non-queued version.
-        /// This method is almost equivalent to InternalFireQueued, but it employs simple locks 
-        /// in order to ensure thread-safety.
-        /// Warning! If processing a trigger throws an unexpected error, unprocessed events will be dropped
-        /// if DropUnprocessedEventsOnErrorInSerialMode is set to true.
+        /// Queue events and then fire in order on a separate worker thread.
+        /// This returns immediately after queueing the trigger.
+        /// This method is thread-safe.
         /// </summary>
         /// <param name="trigger">  The trigger. </param>
         /// <param name="args">     A variable-length parameters list containing arguments. </param>
         private void InternalFireSerial(TTrigger trigger, params object[] args) {
+            // Since the processing happens on a separate task, we re-use the async method
+            _ = InternalFireSerialAsync(trigger, getTriggerCompletionTask: false, args);
+        }
 
-            lock (_serialModeLock) 
-            {
-                // Add trigger to queue
-                _eventQueue.Enqueue(new QueuedTrigger { Trigger = trigger, Args = args });
-
-                // If a trigger is already being handled then the trigger will be queued (FIFO) and processed later.
-                if (_firing)
-                    return;
-
-                _firing = true;
-            }
-
-            try 
-            {
-
-                // Empty queue for triggers
-                while (true)
-                {
-
-                    QueuedTrigger queuedEvent;
-
-                    lock (_serialModeLock)
-                    {
-
-                        if (_eventQueue.Count == 0) 
-                        {
-                            _firing = false;
-                            break;
-                        }
-
-                        queuedEvent = _eventQueue.Dequeue();
-                    }
-
-                    InternalFireOne(queuedEvent.Trigger, queuedEvent.Args);
-                }
-            } 
-            catch
-            {
-
-                lock (_serialModeLock)
-                {
-                    if (DropUnprocessedEventsOnErrorInSerialMode)
-                        _eventQueue.Clear();
-
-                    _firing = false;
-                }
-
-                throw;
-            }
+        /// <summary> Resumes the execution if the event queue is not empty </summary>
+        private void InternalFireSerial() {
+            // Since the processing happens on a separate task, we re-use the async method
+            _ = InternalFireSerialAsync();
         }
 
         /// <summary>
@@ -437,26 +404,48 @@ namespace Stateless
             // Add trigger to queue
             _eventQueue.Enqueue(new QueuedTrigger { Trigger = trigger, Args = args });
 
+            InternalFireQueued();
+        }
+
+        /// <summary> Processes the event queue </summary>
+        private void InternalFireQueued() {
+
             // If a trigger is already being handled then the trigger will be queued (FIFO) and processed later.
-            if (_firing)
-            {
+            if (_firing) {
                 return;
             }
 
-            try
-            {
+            try {
                 _firing = true;
 
                 // Empty queue for triggers
-                while (_eventQueue.Any())
-                {
+                while (_eventQueue.Any()) {
                     var queuedEvent = _eventQueue.Dequeue();
                     InternalFireOne(queuedEvent.Trigger, queuedEvent.Args);
                 }
-            }
-            finally
-            {
+            } finally {
                 _firing = false;
+            }
+        }
+
+        /// <summary>
+        /// Cancel unprocessed triggers that are still waiting in the queue.
+        /// Applies only to FiringMode.Queued and FiringMode.Serial.
+        /// </summary>
+        public void CancelPendingTriggers() {
+            if (_firingMode == FiringMode.Queued)
+            {
+                _eventQueue.Clear();
+            }
+            else if (_firingMode == FiringMode.Serial) 
+            {
+                lock (_serialModeLock)
+                {
+                    while (_serialEventQueue.Count > 0) {
+                        var queuedEvent = _serialEventQueue.Dequeue();
+                        queuedEvent.TaskCompletionSource.SetCanceled();
+                    }
+                }
             }
         }
 

--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -14,7 +14,9 @@ namespace Stateless
         /// <summary> Use immediate mode when the queuing of trigger events are not needed. Care must be taken when using this mode, as there is no run-to-completion guaranteed.</summary>
         Immediate,
         /// <summary> Use the queued <c>Fire</c>ing mode when run-to-completion is required. This is the recommended mode.</summary>
-        Queued
+        Queued,
+        /// <summary> Equivalent to Queued mode, but thread-safe for Fire.</summary>
+        Serial
     }
 
     /// <summary>
@@ -40,8 +42,19 @@ namespace Stateless
             public object[] Args { get; set; }
         }
 
+        private object _serialModeLock = new object();
         private readonly Queue<QueuedTrigger> _eventQueue = new Queue<QueuedTrigger>();
         private bool _firing;
+
+        /// <summary>
+        /// If the main processing thread throws an error, unprocessed triggers should be removed from
+        /// the queue in order to ensure consistency. Otherwise the event queue
+        /// may still hold unprocessed triggers which would require another
+        /// Fire() call to resume processing.
+        /// Set this to true if you need consistent behaviour.
+        /// Set this to false if you don't want triggers to be dropped.
+        /// </summary>
+        public bool DropUnprocessedEventsOnErrorInSerialMode { get; set; } = false;
 
         /// <summary>
         /// Construct a state machine with external state storage.
@@ -341,9 +354,75 @@ namespace Stateless
                 case FiringMode.Queued:
                     InternalFireQueued(trigger, args);
                     break;
+                case FiringMode.Serial:
+                    InternalFireSerial(trigger, args);
+                    break;
                 default:
                     // If something is completely messed up we let the user know ;-)
                     throw new InvalidOperationException("The firing mode has not been configured!");
+            }
+        }
+
+        /// <summary>
+        /// Queue events and then fire in order.
+        /// If only one event is queued, this behaves identically to the non-queued version.
+        /// This method is almost equivalent to InternalFireQueued, but it employs simple locks 
+        /// in order to ensure thread-safety.
+        /// Warning! If processing a trigger throws an unexpected error, unprocessed events will be dropped
+        /// if DropUnprocessedEventsOnErrorInSerialMode is set to true.
+        /// </summary>
+        /// <param name="trigger">  The trigger. </param>
+        /// <param name="args">     A variable-length parameters list containing arguments. </param>
+        private void InternalFireSerial(TTrigger trigger, params object[] args) {
+
+            lock (_serialModeLock) 
+            {
+                // Add trigger to queue
+                _eventQueue.Enqueue(new QueuedTrigger { Trigger = trigger, Args = args });
+
+                // If a trigger is already being handled then the trigger will be queued (FIFO) and processed later.
+                if (_firing)
+                    return;
+
+                _firing = true;
+            }
+
+            try 
+            {
+
+                // Empty queue for triggers
+                while (true)
+                {
+
+                    QueuedTrigger queuedEvent;
+
+                    lock (_serialModeLock)
+                    {
+
+                        if (_eventQueue.Count == 0) 
+                        {
+                            _firing = false;
+                            break;
+                        }
+
+                        queuedEvent = _eventQueue.Dequeue();
+                    }
+
+                    InternalFireOne(queuedEvent.Trigger, queuedEvent.Args);
+                }
+            } 
+            catch
+            {
+
+                lock (_serialModeLock)
+                {
+                    if (DropUnprocessedEventsOnErrorInSerialMode)
+                        _eventQueue.Clear();
+
+                    _firing = false;
+                }
+
+                throw;
             }
         }
 

--- a/test/Stateless.Tests/SerialModeThreadSafetyFixture.cs
+++ b/test/Stateless.Tests/SerialModeThreadSafetyFixture.cs
@@ -11,7 +11,7 @@ namespace Stateless.Tests {
     [CollectionDefinition("SerialModeThreadSafetyFixture", DisableParallelization = true)]
     public class SerialModeThreadSafetyFixture {
 
-        [Fact]
+        [Fact(Timeout = 60 * 1000)]
         public async Task IncrementIsThreadSafeUnderContentionSync() {
 
             var stateMachine = new StateMachine<State, Trigger>(State.A, FiringMode.Serial);
@@ -37,10 +37,13 @@ namespace Stateless.Tests {
             startGate.Set();
             await Task.WhenAll(tasks);
 
+            // Wait for the tasks to be done processing
+            await stateMachine.GetSerialEventsWorkerTask();
+
             Assert.Equal(160_000, counter);
         }
 
-        [Fact]
+        [Fact(Timeout = 60 * 1000)]
         public async Task IncrementIsThreadSafeUnderContentionAsync() {
 
             var stateMachine = new StateMachine<State, Trigger>(State.A, FiringMode.Serial);
@@ -50,7 +53,6 @@ namespace Stateless.Tests {
 
             stateMachine.Configure(State.A)
                 .OnEntryAsync(async () => {
-                    await Task.Yield();
                     counter = counter + 1;
                 })
                 .PermitReentry(Trigger.X);
@@ -59,7 +61,7 @@ namespace Stateless.Tests {
                 Task.Run(async () => {
                     startGate.Wait();
                     for (int i = 0; i < 1_000; i++) {
-                        await stateMachine.FireAsync(Trigger.X);
+                        var forget = stateMachine.FireAsync(Trigger.X);
                     }
                 })
             ).ToArray();
@@ -67,10 +69,13 @@ namespace Stateless.Tests {
             startGate.Set();
             await Task.WhenAll(tasks);
 
+            // Wait for the tasks to be done processing
+            await stateMachine.GetSerialEventsWorkerTask();
+
             Assert.Equal(16_000, counter);
         }
 
-        [Fact]
+        [Fact(Timeout = 60 * 1000)]
         public async Task RecursiveFireDoesNotDeadlockSync() {
 
             var stateMachine = new StateMachine<State, Trigger>(State.A, FiringMode.Serial);
@@ -93,10 +98,13 @@ namespace Stateless.Tests {
 
             stateMachine.Fire(Trigger.X);
 
+            // Wait for the tasks to be done processing
+            await stateMachine.GetSerialEventsWorkerTask();
+
             Assert.Equal(State.C, stateMachine.State);
         }
 
-        [Fact]
+        [Fact(Timeout = 60*1000)]
         public async Task RecursiveFireDoesNotDeadlockAsync() {
 
             var stateMachine = new StateMachine<State, Trigger>(State.A, FiringMode.Serial);
@@ -118,6 +126,9 @@ namespace Stateless.Tests {
             stateMachine.Configure(State.C);
 
             await stateMachine.FireAsync(Trigger.X);
+
+            // Wait for the tasks to be done processing
+            await stateMachine.GetSerialEventsWorkerTask();
 
             Assert.Equal(State.C, stateMachine.State);
         }

--- a/test/Stateless.Tests/SerialModeThreadSafetyFixture.cs
+++ b/test/Stateless.Tests/SerialModeThreadSafetyFixture.cs
@@ -55,6 +55,7 @@ namespace Stateless.Tests {
 
             stateMachine.Configure(State.A)
                 .OnEntryAsync(async () => {
+                    await Task.Yield();
                     counter = counter + 1;
                 })
                 .PermitReentry(Trigger.X);

--- a/test/Stateless.Tests/SerialModeThreadSafetyFixture.cs
+++ b/test/Stateless.Tests/SerialModeThreadSafetyFixture.cs
@@ -41,6 +41,8 @@ namespace Stateless.Tests {
             await stateMachine.GetSerialEventsWorkerTask();
 
             Assert.Equal(160_000, counter);
+
+            stateMachine.Dispose();
         }
 
         [Fact(Timeout = 60 * 1000)]
@@ -61,7 +63,7 @@ namespace Stateless.Tests {
                 Task.Run(async () => {
                     startGate.Wait();
                     for (int i = 0; i < 1_000; i++) {
-                        var forget = stateMachine.FireAsync(Trigger.X);
+                        await stateMachine.FireAsync(Trigger.X);
                     }
                 })
             ).ToArray();
@@ -73,6 +75,8 @@ namespace Stateless.Tests {
             await stateMachine.GetSerialEventsWorkerTask();
 
             Assert.Equal(16_000, counter);
+
+            stateMachine.Dispose();
         }
 
         [Fact(Timeout = 60 * 1000)]
@@ -102,6 +106,8 @@ namespace Stateless.Tests {
             await stateMachine.GetSerialEventsWorkerTask();
 
             Assert.Equal(State.C, stateMachine.State);
+
+            stateMachine.Dispose();
         }
 
         [Fact(Timeout = 60*1000)]
@@ -131,6 +137,8 @@ namespace Stateless.Tests {
             await stateMachine.GetSerialEventsWorkerTask();
 
             Assert.Equal(State.C, stateMachine.State);
+
+            stateMachine.Dispose();
         }
 
     }

--- a/test/Stateless.Tests/SerialModeThreadSafetyFixture.cs
+++ b/test/Stateless.Tests/SerialModeThreadSafetyFixture.cs
@@ -1,0 +1,126 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Stateless.Tests {
+    /// <summary>
+    /// We disable parallelization to ensure other threads are not occupied by other tests.
+    /// Some tests regarding DropUnprocessedEventsOnErrorInSerialMode need to be added.
+    /// </summary>
+    [CollectionDefinition("SerialModeThreadSafetyFixture", DisableParallelization = true)]
+    public class SerialModeThreadSafetyFixture {
+
+        [Fact]
+        public async Task IncrementIsThreadSafeUnderContentionSync() {
+
+            var stateMachine = new StateMachine<State, Trigger>(State.A, FiringMode.Serial);
+
+            int counter = 0;
+            var startGate = new ManualResetEventSlim(false);
+
+            stateMachine.Configure(State.A)
+                .OnEntry(() => {
+                    counter = counter + 1;
+                })
+                .PermitReentry(Trigger.X);
+
+            var tasks = Enumerable.Range(0, 16).Select(_ =>
+                Task.Run(() => {
+                    startGate.Wait();
+                    for (int i = 0; i < 10_000; i++) {
+                        stateMachine.Fire(Trigger.X);
+                    }
+                })
+            ).ToArray();
+
+            startGate.Set();
+            await Task.WhenAll(tasks);
+
+            Assert.Equal(160_000, counter);
+        }
+
+        [Fact]
+        public async Task IncrementIsThreadSafeUnderContentionAsync() {
+
+            var stateMachine = new StateMachine<State, Trigger>(State.A, FiringMode.Serial);
+
+            int counter = 0;
+            var startGate = new ManualResetEventSlim(false);
+
+            stateMachine.Configure(State.A)
+                .OnEntryAsync(async () => {
+                    await Task.Yield();
+                    counter = counter + 1;
+                })
+                .PermitReentry(Trigger.X);
+
+            var tasks = Enumerable.Range(0, 16).Select(_ =>
+                Task.Run(async () => {
+                    startGate.Wait();
+                    for (int i = 0; i < 1_000; i++) {
+                        await stateMachine.FireAsync(Trigger.X);
+                    }
+                })
+            ).ToArray();
+
+            startGate.Set();
+            await Task.WhenAll(tasks);
+
+            Assert.Equal(16_000, counter);
+        }
+
+        [Fact]
+        public async Task RecursiveFireDoesNotDeadlockSync() {
+
+            var stateMachine = new StateMachine<State, Trigger>(State.A, FiringMode.Serial);
+
+            stateMachine.Configure(State.A)
+                .OnEntry(() => {
+                    stateMachine.Fire(Trigger.Y);
+                })
+                .Permit(Trigger.Y, State.B)
+                .PermitReentry(Trigger.X);
+
+            stateMachine.Configure(State.B)
+                .OnEntry(() => {
+                    stateMachine.Fire(Trigger.Y);
+                })
+                .Permit(Trigger.Y, State.C)
+                .PermitReentry(Trigger.X);
+
+            stateMachine.Configure(State.C);
+
+            stateMachine.Fire(Trigger.X);
+
+            Assert.Equal(State.C, stateMachine.State);
+        }
+
+        [Fact]
+        public async Task RecursiveFireDoesNotDeadlockAsync() {
+
+            var stateMachine = new StateMachine<State, Trigger>(State.A, FiringMode.Serial);
+
+            stateMachine.Configure(State.A)
+                .OnEntryAsync(async () => {
+                    await stateMachine.FireAsync(Trigger.Y);
+                })
+                .Permit(Trigger.Y, State.B)
+                .PermitReentry(Trigger.X);
+
+            stateMachine.Configure(State.B)
+                .OnEntryAsync(async () => {
+                    await stateMachine.FireAsync(Trigger.Y);
+                })
+                .Permit(Trigger.Y, State.C)
+                .PermitReentry(Trigger.X);
+
+            stateMachine.Configure(State.C);
+
+            await stateMachine.FireAsync(Trigger.X);
+
+            Assert.Equal(State.C, stateMachine.State);
+        }
+
+    }
+}


### PR DESCRIPTION
- This PR proposes an implementation for FiringMode.Serial as discussed in #527
- This is an alternate implementation of PR #639. This implementation runs triggers on a separate task in order not to block any callers to Fire/FireAsync.
- This implementation still employs a standard short-lived lock to ensure thread safety.
- This implementation no longer needs the `DropUnprocessedEventsOnErrorInSerialMode` from the previous PR.
- All calls to Fire/FireAsync return immediately after the trigger is enqueued.
- If you need to wait for the trigger to be ran or catch its specific exceptions, you can use `await FireAndWaitAsync(trigger)`. Warning, if you call and await `FireAndWaitAsync` inside a state transition event, you risk deadlocking (because the current transition now waits for a future transition to be completed).
- If you need to await the triggers processing task or catch exceptions, you can use `await GetSerialEventsWorkerTask()`.
- **Important**: If an unexpected exception is thrown durring the processing of triggers, the faulting trigger is dequeued and the worker task halts (possibly locking tasks waiting via `await FireAndWaitAsync(trigger)`).  
- If you need to resume execution, you can call the new parameterless Fire method (works for the FiringMode.Queued mode too).
- If you need to cancel all the unexecuted triggers still pending, you can call `CancelPendingTriggers()`.

Resolves #527