### PR TITLE
Fix ignored async guard conditions

### DIFF
--- a/src/Stateless/StateMachine.Async.cs
+++ b/src/Stateless/StateMachine.Async.cs
@@ -216,7 +216,7 @@ namespace Stateless
 
             if (foundHandler == null || foundHandler.UnmetGuardConditions.Any())
             {
-                await _unhandledTriggerAction.ExecuteAsync(representativeState.UnderlyingState, trigger, null);
+                await _unhandledTriggerAction.ExecuteAsync(representativeState.UnderlyingState, trigger, foundHandler?.UnmetGuardConditions);
                 return;
             }
 

--- a/test/Stateless.Tests/AsyncActionsFixture.cs
+++ b/test/Stateless.Tests/AsyncActionsFixture.cs
@@ -314,6 +314,46 @@ namespace Stateless.Tests
 
             Assert.Equal("foo", test); // Should await action
         }
+
+        [Fact]
+        public async Task CanInvokeOnUnhandledTriggerAsyncActionWithUnmetGuardDescriptions()
+        {
+            const string guardDescription = "Guard failed";
+            ICollection<string> guardDescriptions = null;
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+                .PermitIfAsync(Trigger.X, State.B, async () => await Task.FromResult(false), guardDescription);
+
+            sm.OnUnhandledTriggerAsync((s, t, u) =>
+            {
+                guardDescriptions = u;
+                return TaskResult.Done;
+            });
+
+            await sm.FireAsync(Trigger.X).ConfigureAwait(false);
+
+            Assert.Equal(State.A, sm.State);
+            Assert.NotNull(guardDescriptions);
+            Assert.Single(guardDescriptions);
+            Assert.Contains(guardDescription, guardDescriptions);
+        }
+
+        [Fact]
+        public async Task FireAsyncThrowsGuardDescriptionsWhenGuardFails()
+        {
+            const string guardDescription = "Guard failed";
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+                .PermitIfAsync(Trigger.X, State.B, async () => await Task.FromResult(false), guardDescription);
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => sm.FireAsync(Trigger.X)).ConfigureAwait(false);
+
+            Assert.Contains(guardDescription, exception.Message);
+        }
+
         [Fact]
         public void WhenSyncFireOnUnhandledTriggerAsyncTask()
         {

--- a/test/Stateless.Tests/Stateless.Tests.csproj
+++ b/test/Stateless.Tests/Stateless.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <DefineConstants>$(DefineConstants);TASKS</DefineConstants>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <TargetFrameworks>net462;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0;net9.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AssemblyName>Stateless.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../asset/Stateless.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
This PR addresses issue #645 by fixing the async unhandled-trigger path so unmet guard descriptions are preserved when `FireAsync()` cannot take a transition.

Changes:
- pass unmet guard descriptions into the async unhandled-trigger action
- add regression tests for `OnUnhandledTriggerAsync`
- verify `FireAsync()` exception messages include the guard description
- add `net10.0` to the test project target frameworks