### PR TITLE
Restore synchronous PermittedTriggers for sync-only state machines

### DIFF
--- a/src/Stateless/StateMachine.cs
+++ b/src/Stateless/StateMachine.cs
@@ -123,16 +123,14 @@ namespace Stateless
         /// <summary>
         /// The currently-permissible trigger values.
         /// </summary>
-        [Obsolete("Kept for compatibility purposes. Recommended to use PermittedTriggersAsync instead")]
         public IEnumerable<TTrigger> PermittedTriggers => GetPermittedTriggers();
 
         /// <summary>
         /// The currently-permissible trigger values.
         /// </summary>
-        [Obsolete("Kept for compatibility purposes. Recommended to use GetPermittedTriggersAsync instead")]
         public IEnumerable<TTrigger> GetPermittedTriggers(params object[] args)
         {
-            return Task.Run(() => CurrentRepresentation.GetPermittedTriggersAsync(args)).GetAwaiter().GetResult();
+            return CurrentRepresentation.GetPermittedTriggers(args);
         }
 
         /// <summary>
@@ -723,10 +721,14 @@ namespace Stateless
         /// <returns>A description of the current state and permitted triggers.</returns>
         public override string ToString()
         {
+            var permittedTriggers = CurrentRepresentation.RequiresAsyncPermittedTriggersEvaluation
+                ? string.Join(", ", Task.Run(() => GetPermittedTriggersAsync()).GetAwaiter().GetResult().Select(t => t.ToString()).ToArray())
+                : string.Join(", ", GetPermittedTriggers().Select(t => t.ToString()).ToArray());
+
             return string.Format(
                 "StateMachine {{ State = {0}, PermittedTriggers = {{ {1} }}}}",
                 State,
-                string.Join(", ", Task.Run(() => GetPermittedTriggersAsync()).GetAwaiter().GetResult().Select(t => t.ToString()).ToArray()));
+                permittedTriggers);
         }
 
         /// <summary>

--- a/src/Stateless/StateMachineResources.Designer.cs
+++ b/src/Stateless/StateMachineResources.Designer.cs
@@ -67,6 +67,15 @@ namespace Stateless {
                 return ResourceManager.GetString("CannotReconfigureParameters", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///    Looks up a localized string similar to Cannot synchronously enumerate permitted triggers from state &apos;{0}&apos; because the current state or one of its superstates has asynchronous guard conditions. Use GetPermittedTriggersAsync instead..
+        /// </summary>
+        public static string CannotGetPermittedTriggersSynchronously {
+            get {
+                return ResourceManager.GetString("CannotGetPermittedTriggersSynchronously", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///    Looks up a localized string similar to No valid leaving transitions are permitted from state &apos;{1}&apos; for trigger &apos;{0}&apos;. Consider ignoring the trigger..

--- a/src/Stateless/StateMachineResources.resx
+++ b/src/Stateless/StateMachineResources.resx
@@ -120,6 +120,9 @@
   <data name="CannotReconfigureParameters" xml:space="preserve">
     <value>Parameters for the trigger '{0}' have already been configured.</value>
   </data>
+  <data name="CannotGetPermittedTriggersSynchronously" xml:space="preserve">
+    <value>Cannot synchronously enumerate permitted triggers from state '{0}' because the current state or one of its superstates has asynchronous guard conditions. Use GetPermittedTriggersAsync instead.</value>
+  </data>
   <data name="NoTransitionsPermitted" xml:space="preserve">
     <value>No valid leaving transitions are permitted from state '{1}' for trigger '{0}'. Consider ignoring the trigger.</value>
   </data>

--- a/src/Stateless/StateRepresentation.Async.cs
+++ b/src/Stateless/StateRepresentation.Async.cs
@@ -10,6 +10,9 @@ namespace Stateless
         internal partial class StateRepresentation
         {
             internal IDictionary<TTrigger, ICollection<TriggerBehaviourAsync>> TriggerBehavioursAsync { get; } = new Dictionary<TTrigger, ICollection<TriggerBehaviourAsync>>();
+            internal bool RequiresAsyncPermittedTriggersEvaluation =>
+                TriggerBehavioursAsync.Count != 0 || (Superstate?.RequiresAsyncPermittedTriggersEvaluation ?? false);
+
             public void AddActivateAction(Func<Task> action, Reflection.InvocationInfo activateActionDescription)
             {
                 ActivateActions.Add(new ActivateActionBehaviour.Async(_state, action, activateActionDescription));
@@ -165,11 +168,7 @@ namespace Stateless
             {
                 var resultList = new List<TTrigger>();
 
-                var syncResult = TriggerBehaviours
-                    .Where(t => t.Value.Any(a => !a.UnmetGuardConditions(args).Any()))
-                    .Select(t => t.Key);
-
-                resultList.AddRange(syncResult);
+                resultList.AddRange(GetPermittedTriggersForCurrentState(args));
 
                 var asyncTriggers = await GetAsyncTriggers(args);
                 resultList.AddRange(asyncTriggers);

--- a/src/Stateless/StateRepresentation.cs
+++ b/src/Stateless/StateRepresentation.cs
@@ -38,6 +38,34 @@ namespace Stateless
                 return TryFindHandler(trigger, args, out TriggerBehaviourResult _);
             }
 
+            IEnumerable<TTrigger> GetPermittedTriggersForCurrentState(object[] args)
+            {
+                return TriggerBehaviours
+                    .Where(t => t.Value.Any(a => !a.UnmetGuardConditions(args).Any()))
+                    .Select(t => t.Key);
+            }
+
+            public List<TTrigger> GetPermittedTriggers(params object[] args)
+            {
+                if (RequiresAsyncPermittedTriggersEvaluation)
+                {
+                    throw new InvalidOperationException(
+                        string.Format(
+                            StateMachineResources.CannotGetPermittedTriggersSynchronously,
+                            _state));
+                }
+
+                var resultList = GetPermittedTriggersForCurrentState(args).ToList();
+
+                if (Superstate != null)
+                {
+                    var superStatePermittedTriggers = Superstate.GetPermittedTriggers(args);
+                    resultList = resultList.Union(superStatePermittedTriggers).ToList();
+                }
+
+                return resultList;
+            }
+
             public bool CanHandle(TTrigger trigger, object[] args, out ICollection<string> unmetGuards)
             {
                 bool handlerFound = TryFindHandler(trigger, args, out TriggerBehaviourResult result);

--- a/test/Stateless.Tests/InternalTransitionFixture.cs
+++ b/test/Stateless.Tests/InternalTransitionFixture.cs
@@ -205,7 +205,6 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        [Obsolete]
         public void ConditionalInternalTransition_ShouldBeReflectedInPermittedTriggersLegacy()
         {
             var isPermitted = true;

--- a/test/Stateless.Tests/StateMachineFixture.cs
+++ b/test/Stateless.Tests/StateMachineFixture.cs
@@ -155,7 +155,6 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        [Obsolete]
         public void PermittedTriggersIncludeSuperstatePermittedTriggersLegacy()
         {
             var sm = new StateMachine<State, Trigger>(State.B);
@@ -195,7 +194,6 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        [Obsolete]
         public void PermittedTriggersAreDistinctValuesLegacy()
         {
             var sm = new StateMachine<State, Trigger>(State.B);
@@ -224,7 +222,6 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        [Obsolete]
         public void AcceptedTriggersRespectGuardsLegacy()
         {
             var sm = new StateMachine<State, Trigger>(State.B);
@@ -247,7 +244,6 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        [Obsolete]
         public void AcceptedAsyncTriggersRespectGuardsLegacy()
         {
             var sm = new StateMachine<State, Trigger>(State.B);
@@ -255,7 +251,8 @@ namespace Stateless.Tests
             sm.Configure(State.B)
                 .PermitIfAsync(Trigger.X, State.A, async () => await Task.FromResult(false));
 
-            Assert.Equal(0, sm.GetPermittedTriggers().Count());
+            var exception = Assert.Throws<InvalidOperationException>(() => sm.GetPermittedTriggers().Count());
+            Assert.Contains("GetPermittedTriggersAsync", exception.Message);
         }
 
         [Fact]
@@ -270,7 +267,6 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        [Obsolete]
         public void AcceptedValidAsyncTriggersRespectGuardsLegacy()
         {
             var sm = new StateMachine<State, Trigger>(State.B);
@@ -278,7 +274,8 @@ namespace Stateless.Tests
             sm.Configure(State.B)
                 .PermitIfAsync(Trigger.X, State.A, async () => await Task.FromResult(true));
 
-            Assert.Equal(1, sm.GetPermittedTriggers().Count());
+            var exception = Assert.Throws<InvalidOperationException>(() => sm.GetPermittedTriggers().Count());
+            Assert.Contains("GetPermittedTriggersAsync", exception.Message);
         }
 
         [Fact]
@@ -294,7 +291,6 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        [Obsolete]
         public void AcceptedOneValidAsyncAndSyncTriggersRespectGuardsLegacy()
         {
             var sm = new StateMachine<State, Trigger>(State.B);
@@ -303,7 +299,8 @@ namespace Stateless.Tests
                 .PermitIfAsync(Trigger.X, State.A, async () => await Task.FromResult(true))
                 .PermitIf(Trigger.Y, State.C, () => false);
 
-            Assert.Equal(1, sm.GetPermittedTriggers().Count());
+            var exception = Assert.Throws<InvalidOperationException>(() => sm.GetPermittedTriggers().Count());
+            Assert.Contains("GetPermittedTriggersAsync", exception.Message);
         }
 
         [Fact]
@@ -320,7 +317,6 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        [Obsolete]
         public void AcceptedTriggersRespectMultipleGuardsLegacy()
         {
             var sm = new StateMachine<State, Trigger>(State.B);
@@ -1260,7 +1256,6 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        [Obsolete]
         public void WhenConfigurePermittedTransitionOnTriggerWithoutParameters_ThenStateMachineCanEnumeratePermittedTriggersLegacy()
         {
             var trigger = Trigger.X;
@@ -1290,7 +1285,6 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        [Obsolete]
         public void WhenConfigurePermittedTransitionOnTriggerWithParameters_ThenStateMachineCanEnumeratePermittedTriggersLegacy()
         {
             var trigger = Trigger.X;
@@ -1319,7 +1313,6 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        [Obsolete]
         public void WhenConfigureInternalTransitionOnTriggerWithoutParameters_ThenStateMachineCanEnumeratePermittedTriggersLegacy()
         {
             var trigger = Trigger.X;
@@ -1347,7 +1340,6 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        [Obsolete]
         public void WhenConfigureInternalTransitionOnTriggerWithParameters_ThenStateMachineCanEnumeratePermittedTriggersLegacy()
         {
             var trigger = Trigger.X;
@@ -1375,7 +1367,6 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        [Obsolete]
         public void WhenConfigureConditionallyPermittedTransitionOnTriggerWithParameters_ThenStateMachineCanEnumeratePermittedTriggersLegacy()
         {
             var trigger = Trigger.X;
@@ -1398,7 +1389,6 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        [Obsolete]
         public void PermittedTriggersIncludeAllDefinedTriggersLegacy()
         {
             var sm = new StateMachine<State, Trigger>(State.A);
@@ -1422,7 +1412,6 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        [Obsolete]
         public void PermittedTriggersExcludeAllUndefinedTriggersLegacy()
         {
             var sm = new StateMachine<State, Trigger>(State.A);
@@ -1464,7 +1453,6 @@ namespace Stateless.Tests
         }
 
         [Fact]
-        [Obsolete]
         public void PermittedTriggersIncludeAllInheritedTriggersLegacy()
         {
             State superState = State.A,
@@ -1493,6 +1481,61 @@ namespace Stateless.Tests
             Assert.Contains(superStateTrigger, superPermittedTriggers);
             Assert.Contains(subStateTrigger, subPermittedTriggers);
             Assert.DoesNotContain(subStateTrigger, superPermittedTriggers);
+        }
+
+        [Fact]
+        public void PermittedTriggersWithAsyncGuardsInSuperstateThrowSynchronously()
+        {
+            var sm = new StateMachine<State, Trigger>(State.B);
+
+            sm.Configure(State.B)
+                .SubstateOf(State.C)
+                .Permit(Trigger.Y, State.A);
+
+            sm.Configure(State.C)
+                .PermitIfAsync(Trigger.X, State.A, async () => await Task.FromResult(true));
+
+            var exception = Assert.Throws<InvalidOperationException>(() => sm.GetPermittedTriggers().Count());
+            Assert.Contains("state 'B'", exception.Message);
+            Assert.Contains("GetPermittedTriggersAsync", exception.Message);
+        }
+
+        [Fact]
+        public void PermittedTriggersIgnoreAsyncGuardsOutsideCurrentStateHierarchy()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+                .Permit(Trigger.X, State.B);
+
+            sm.Configure(State.B)
+                .PermitIfAsync(Trigger.Y, State.C, async () => await Task.FromResult(true));
+
+            Assert.Single(sm.GetPermittedTriggers(), Trigger.X);
+        }
+
+        [Fact]
+        public void PermittedTriggersSupportAsyncDynamicDestinationsWithSynchronousGuards()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+                .PermitDynamicAsync(Trigger.X, () => Task.FromResult(State.B));
+
+            Assert.Single(sm.GetPermittedTriggers(), Trigger.X);
+        }
+
+        [Fact]
+        public void ToString_WhenAsyncGuardsArePresent_DoesNotThrow()
+        {
+            var sm = new StateMachine<State, Trigger>(State.A);
+
+            sm.Configure(State.A)
+                .PermitIfAsync(Trigger.X, State.B, async () => await Task.FromResult(true));
+
+            var description = sm.ToString();
+
+            Assert.Equal("StateMachine { State = A, PermittedTriggers = { X }}", description);
         }
 
         [Fact]


### PR DESCRIPTION
This PR revisits the deprecation of synchronous `PermittedTriggers`/`GetPermittedTriggers` discussed in #634. After concerns were raised about marking these members for deprecation, the goal is to keep synchronous introspection available for fully synchronous workflows, while making the async boundary explicit when async guard evaluation is actually required.

Note that this change introduces a new exception condition: `InvalidOperationException` is thrown when `PermittedTriggers`/`GetPermittedTriggers` is used on a state that has `async` triggers.

- Restored a native synchronous implementation of `PermittedTriggers` and `GetPermittedTriggers`
- Removed the blocking wrapper that routed sync calls through `GetPermittedTriggersAsync`
- Added detection for whether permitted-trigger evaluation requires async guard evaluation in the current state hierarchy
- Changed synchronous permitted-trigger enumeration to throw a clear `InvalidOperationException` when async guards are present in the current state or one of its superstates
- Kept `GetPermittedTriggersAsync` as the full-fidelity API for all configurations
- Updated `ToString()` to use the synchronous path when async guard evaluation is not needed and fall back to async permitted-trigger enumeration only when required
